### PR TITLE
Adds java.util Collection Views

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install: true
 script: .travis/run-tests.sh
 after_success:
   - codecov
-  - python <(curl -s https://raw.githubusercontent.com/TouK/sputnik-ci/master/sputnik-ci.py)
+#  - python <(curl -s https://raw.githubusercontent.com/TouK/sputnik-ci/master/sputnik-ci.py)
   - mvn clean deploy -DskipTests --settings .travis/maven-settings.xml
   - .travis/trigger-build.sh javaslang-gwt
   - .travis/trigger-build.sh javaslang-jackson

--- a/javaslang/src/main/java/javaslang/collection/Array.java
+++ b/javaslang/src/main/java/javaslang/collection/Array.java
@@ -16,6 +16,8 @@ import java.util.stream.Collector;
 
 import static java.util.Arrays.copyOf;
 import static java.util.Arrays.sort;
+import static javaslang.collection.JavaConverters.ChangePolicy.IMMUTABLE;
+import static javaslang.collection.JavaConverters.ChangePolicy.MUTABLE;
 
 /**
  * Array is a Traversable wrapper for {@code Object[]} containing elements of type {@code T}.
@@ -600,6 +602,26 @@ public final class Array<T> implements Kind1<Array<?>, T>, IndexedSeq<T>, Serial
         return ofAll(iterator().<R> collect(partialFunction));
     }
     
+    @Override
+    public java.util.List<T> asJavaImmutable() {
+        return JavaConverters.asJava(this, IMMUTABLE);
+    }
+
+    @Override
+    public Array<T> asJavaImmutable(Consumer<? super java.util.List<T>> action) {
+        return Collections.asJava(this, action, IMMUTABLE);
+    }
+
+    @Override
+    public java.util.List<T> asJavaMutable() {
+        return JavaConverters.asJava(this, MUTABLE);
+    }
+
+    @Override
+    public Array<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
+        return Collections.asJava(this, action, MUTABLE);
+    }
+
     @Override
     public boolean hasDefiniteSize() {
         return true;

--- a/javaslang/src/main/java/javaslang/collection/CharSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/CharSeq.java
@@ -18,6 +18,9 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collector;
 
+import static javaslang.collection.JavaConverters.ChangePolicy.IMMUTABLE;
+import static javaslang.collection.JavaConverters.ChangePolicy.MUTABLE;
+
 /**
  * The CharSeq (read: character sequence) collection essentially is a rich String wrapper having all operations
  * we know from the functional Javaslang collections.
@@ -373,6 +376,26 @@ public final class CharSeq implements Kind1<CharSeq, Character>, CharSequence, I
             sb.append(element);
         }
         return of(sb);
+    }
+
+    @Override
+    public java.util.List<Character> asJavaImmutable() {
+        return JavaConverters.asJava(this, IMMUTABLE);
+    }
+
+    @Override
+    public CharSeq asJavaImmutable(Consumer<? super java.util.List<Character>> action) {
+        return Collections.asJava(this, action, IMMUTABLE);
+    }
+
+    @Override
+    public java.util.List<Character> asJavaMutable() {
+        return JavaConverters.asJava(this, MUTABLE);
+    }
+
+    @Override
+    public CharSeq asJavaMutable(Consumer<? super java.util.List<Character>> action) {
+        return Collections.asJava(this, action, MUTABLE);
     }
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/Collections.java
+++ b/javaslang/src/main/java/javaslang/collection/Collections.java
@@ -5,6 +5,8 @@
  */
 package javaslang.collection;
 
+import javaslang.collection.JavaConverters.ChangePolicy;
+import javaslang.collection.JavaConverters.ListView;
 import javaslang.control.Option;
 
 import java.util.ArrayList;
@@ -13,6 +15,7 @@ import java.util.Objects;
 import java.util.function.*;
 
 import static javaslang.collection.ArrayType.asArray;
+import static javaslang.collection.JavaConverters.ChangePolicy.MUTABLE;
 
 /**
  * Internal class, containing helpers.
@@ -32,6 +35,13 @@ final class Collections {
             }
         }
         return iter1.hasNext() == iter2.hasNext();
+    }
+
+    static <T, C extends Seq<T>> C asJava(C source, Consumer<? super java.util.List<T>> action, ChangePolicy changePolicy) {
+        Objects.requireNonNull(action, "action is null");
+        final ListView<T, C> view = JavaConverters.asJava(source, changePolicy);
+        action.accept(view);
+        return view.getDelegate();
     }
 
     @SuppressWarnings("unchecked")

--- a/javaslang/src/main/java/javaslang/collection/IndexedSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/IndexedSeq.java
@@ -51,6 +51,12 @@ public interface IndexedSeq<T> extends Seq<T> {
     IndexedSeq<T> appendAll(Iterable<? extends T> elements);
 
     @Override
+    IndexedSeq<T> asJavaImmutable(Consumer<? super java.util.List<T>> action);
+
+    @Override
+    IndexedSeq<T> asJavaMutable(Consumer<? super java.util.List<T>> action);
+
+    @Override
     <R> IndexedSeq<R> collect(PartialFunction<? super T, ? extends R> partialFunction);
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/JavaConverters.java
+++ b/javaslang/src/main/java/javaslang/collection/JavaConverters.java
@@ -1,0 +1,449 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2017 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import java.io.Serializable;
+import java.util.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static javaslang.API.TODO;
+
+/**
+ * THIS CLASS IS INTENDED TO BE USED INTERNALLY ONLY!
+ * <p>
+ * This helper class provides methods that return views on Java collections.
+ * The view creation and back conversion take O(1).
+ *
+ * @author Daniel Dietrich
+ * @since 2.1.0
+ */
+class JavaConverters {
+
+    private JavaConverters() {
+    }
+
+    static <T, C extends Seq<T>> ListView<T, C> asJava(C seq, ChangePolicy changePolicy) {
+        return new ListView<>(seq, changePolicy.isMutable());
+    }
+
+    static <T, C extends Set<T>> SetView<T> asJava(C set, ChangePolicy changePolicy) {
+        return TODO("new SetView<>(set, changePolicy.isMutable());");
+    }
+
+    static <T, C extends SortedSet<T>> NavigableSetView<T> asJava(C sortedSet, ChangePolicy changePolicy) {
+        return TODO("new NavigableSetView<>(set, changePolicy.isMutable());");
+    }
+
+    static <K, V, C extends Map<K, V>> MapView<K, V> asJava(C map, ChangePolicy changePolicy) {
+        return TODO("new MapView<>(map, changePolicy.isMutable());");
+    }
+
+    static <K, V, C extends SortedMap<K, V>> NavigableMapView<K, V> asJava(C sortedMap, ChangePolicy changePolicy) {
+        return TODO("new NavigableMapView<>(map, changePolicy.isMutable());");
+    }
+
+    /*
+    static <K, V, C extends Multimap<K, V>> MapView<K, java.util.Collection<V>> asJava(C multimap, ChangePolicy changePolicy) {
+        return TODO("new MapView<>(map, changePolicy.isMutable());");
+    }
+
+    TODO: create interface javaslang.collection.SortedMultimap
+    static <K, V, C extends SortedMultimap<K, V>> NavigableMapView<K, java.util.Collection<V>> asJava(C sortedMultimap, ChangePolicy changePolicy) {
+        return TODO("new NavigableMapView<>(map, changePolicy.isMutable());");
+    }
+    */
+
+    enum ChangePolicy {
+
+        IMMUTABLE, MUTABLE;
+
+        boolean isMutable() {
+            return this == MUTABLE;
+        }
+    }
+
+    // -- private view implementations
+
+    /**
+     * Encapsulates the access to delegate and performs mutability checks.
+     *
+     * @param <C> The Javaslang collection type
+     */
+    private static abstract class HasDelegate<C extends Traversable<?>> implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private C delegate;
+        private final boolean mutable;
+
+        HasDelegate(C delegate, boolean mutable) {
+            this.delegate = delegate;
+            this.mutable = mutable;
+        }
+
+        protected boolean isMutable() {
+            return mutable;
+        }
+
+        C getDelegate() {
+            return delegate;
+        }
+
+        protected boolean setDelegateAndCheckChanged(Supplier<C> delegate) {
+            ensureMutable();
+            final C previousDelegate = this.delegate;
+            final C newDelegate = delegate.get();
+            final boolean changed = newDelegate != previousDelegate;
+            if (changed) {
+                this.delegate = newDelegate;
+            }
+            return changed;
+        }
+
+        protected void setDelegate(Supplier<C> newDelegate) {
+            ensureMutable();
+            this.delegate = newDelegate.get();
+        }
+
+        protected void ensureMutable() {
+            if (!mutable) {
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+    static class ListView<T, C extends Seq<T>> extends HasDelegate<C> implements java.util.List<T> {
+
+        private static final long serialVersionUID = 1L;
+
+        ListView(C delegate, boolean mutable) {
+            super(delegate, mutable);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean add(T element) {
+            return setDelegateAndCheckChanged(() -> (C) getDelegate().append(element));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void add(int index, T element) {
+            setDelegate(() -> (C) getDelegate().insert(index, element));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean addAll(Collection<? extends T> collection) {
+            Objects.requireNonNull(collection, "collection is null");
+            return setDelegateAndCheckChanged(() -> (C) getDelegate().appendAll(collection));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean addAll(int index, Collection<? extends T> collection) {
+            Objects.requireNonNull(collection, "collection is null");
+            return setDelegateAndCheckChanged(() -> (C) getDelegate().insertAll(index, collection));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void clear() {
+            setDelegate(() -> (C) getDelegate().take(0));
+        }
+
+        @Override
+        public boolean contains(Object obj) {
+            @SuppressWarnings("unchecked") final T that = (T) obj;
+            return getDelegate().contains(that);
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> collection) {
+            Objects.requireNonNull(collection, "collection is null");
+            @SuppressWarnings("unchecked") final Collection<T> that = (Collection<T>) collection;
+            return getDelegate().containsAll(that);
+        }
+
+        @Override
+        public T get(int index) {
+            return getDelegate().get(index);
+        }
+
+        @Override
+        public int indexOf(Object obj) {
+            @SuppressWarnings("unchecked") final T that = (T) obj;
+            return getDelegate().indexOf(that);
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return getDelegate().isEmpty();
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return getDelegate().iterator();
+        }
+
+        @Override
+        public int lastIndexOf(Object obj) {
+            @SuppressWarnings("unchecked") final T that = (T) obj;
+            return getDelegate().lastIndexOf(that);
+        }
+
+        @Override
+        public java.util.ListIterator<T> listIterator() {
+            return new ListIterator<>(this, 0);
+        }
+
+        @Override
+        public java.util.ListIterator<T> listIterator(int index) {
+            return new ListIterator<>(this, index);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public T remove(int index) {
+            return setDelegateAndGetPreviousElement(index, () -> (C) getDelegate().removeAt(index));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean remove(Object obj) {
+            @SuppressWarnings("unchecked") final T that = (T) obj;
+            return setDelegateAndCheckChanged(() -> (C) getDelegate().remove(that));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean removeAll(Collection<?> collection) {
+            Objects.requireNonNull(collection, "collection is null");
+            @SuppressWarnings("unchecked") final Collection<T> that = (Collection<T>) collection;
+            return setDelegateAndCheckChanged(() -> (C) getDelegate().removeAll(that));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public boolean retainAll(Collection<?> collection) {
+            Objects.requireNonNull(collection, "collection is null");
+            @SuppressWarnings("unchecked") final Collection<T> that = (Collection<T>) collection;
+            return setDelegateAndCheckChanged(() -> (C) getDelegate().retainAll(that));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public T set(int index, T element) {
+            return setDelegateAndGetPreviousElement(index, () -> (C) getDelegate().update(index, element));
+        }
+
+        @Override
+        public int size() {
+            return getDelegate().size();
+        }
+
+        @Override
+        public List<T> subList(int fromIndex, int toIndex) {
+            return new ListView<>(getDelegate().subSequence(fromIndex, toIndex), isMutable());
+        }
+
+        @Override
+        public Object[] toArray() {
+            return getDelegate().toJavaArray();
+        }
+
+        @GwtIncompatible("reflection is not supported")
+        @SuppressWarnings("unchecked")
+        @Override
+        public <U> U[] toArray(U[] array) {
+            Objects.requireNonNull(array, "array is null");
+            final U[] target;
+            final int length = getDelegate().length();
+            if (array.length < length) {
+                final Class<? extends Object[]> newType = array.getClass();
+                target = (newType == Object[].class)
+                         ? (U[]) new Object[length]
+                         : (U[]) java.lang.reflect.Array.newInstance(newType.getComponentType(), length);
+            } else {
+                if (array.length > length) {
+                    array[length] = null;
+                }
+                target = array;
+            }
+            final Iterator<T> iter = iterator();
+            for (int i = 0; i < length; i++) {
+                target[i] = (U) iter.next();
+            }
+            return target;
+        }
+
+        // -- Object.*
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o instanceof java.util.List) {
+                return Collections.areEqual(getDelegate(), (java.util.List<?>) o);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            // DEV-NOTE: Ensures that hashCode calculation is stable, regardless of delegate.hashCode()
+            return Collections.hash(getDelegate());
+        }
+
+        @Override
+        public String toString() {
+            return getDelegate().mkString("[", ", ", "]");
+        }
+
+        // -- private helpers
+
+        private T setDelegateAndGetPreviousElement(int index, Supplier<C> delegate) {
+            ensureMutable();
+            final T previousElement = getDelegate().get(index);
+            setDelegate(delegate);
+            return previousElement;
+        }
+
+        // DEV-NOTE: ListIterator is intentionally not Serializable
+        private static class ListIterator<T, C extends Seq<T>> implements java.util.ListIterator<T> {
+
+            private ListView<T, C> list;
+            private int index;
+            private boolean dirty = true;
+
+            ListIterator(ListView<T, C> list, int index) {
+                if (index < 0 || index > list.size()) {
+                    throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + list.size());
+                }
+                this.list = list;
+                this.index = index;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return index < list.size();
+            }
+
+            @Override
+            public T next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                dirty = false;
+                return list.get(index++);
+            }
+
+            @Override
+            public int nextIndex() {
+                return index;
+            }
+
+            @Override
+            public boolean hasPrevious() {
+                return index > 0;
+            }
+
+            @Override
+            public T previous() {
+                if (!hasPrevious()) {
+                    throw new NoSuchElementException();
+                }
+                dirty = false;
+                return list.get(--index);
+            }
+
+            @Override
+            public int previousIndex() {
+                return index - 1;
+            }
+
+            @Override
+            public void remove() {
+                checkDirty();
+                list.remove(index);
+                dirty = true;
+            }
+
+            @Override
+            public void set(T value) {
+                checkDirty();
+                list.set(index, value);
+            }
+
+            @Override
+            public void add(T value) {
+                /* TODO:
+                 * The new element is inserted before the implicit
+                 * cursor: a subsequent call to {@code next} would be unaffected, and a
+                 * subsequent call to {@code previous} would return the new element.
+                 * (This call increases by one the value that would be returned by a
+                 * call to {@code nextIndex} or {@code previousIndex}.)
+                 */
+                // may throw a ClassCastException accordingly to j.u.ListIterator.add(T)
+                list.add(index++, value);
+                dirty = true;
+            }
+
+            private void checkDirty() {
+                if (dirty) {
+                    throw new IllegalStateException();
+                }
+            }
+        }
+    }
+
+    static abstract class SetView<T> extends HasDelegate<Set<T>> implements java.util.Set<T> {
+
+        private static final long serialVersionUID = 1L;
+
+        SetView(Set<T> delegate, boolean mutable) {
+            super(delegate, mutable);
+        }
+
+        // TODO
+    }
+
+    static abstract class NavigableSetView<T> extends HasDelegate<SortedSet<T>> implements java.util.NavigableSet<T> {
+
+        private static final long serialVersionUID = 1L;
+
+        NavigableSetView(SortedSet<T> delegate, boolean mutable) {
+            super(delegate, mutable);
+        }
+
+        // TODO
+    }
+
+    static abstract class MapView<K, V> extends HasDelegate<Map<K, V>> implements java.util.Map<K, V> {
+
+        private static final long serialVersionUID = 1L;
+
+        MapView(Map<K, V> delegate, boolean mutable) {
+            super(delegate, mutable);
+        }
+
+        // TODO
+    }
+
+    static abstract class NavigableMapView<K, V> extends HasDelegate<SortedMap<K, V>> implements java.util.NavigableMap<K, V> {
+
+        private static final long serialVersionUID = 1L;
+
+        NavigableMapView(SortedMap<K, V> delegate, boolean mutable) {
+            super(delegate, mutable);
+        }
+
+        // TODO
+    }
+}

--- a/javaslang/src/main/java/javaslang/collection/LinearSeq.java
+++ b/javaslang/src/main/java/javaslang/collection/LinearSeq.java
@@ -50,6 +50,12 @@ public interface LinearSeq<T> extends Seq<T> {
     LinearSeq<T> appendAll(Iterable<? extends T> elements);
 
     @Override
+    LinearSeq<T> asJavaImmutable(Consumer<? super java.util.List<T>> action);
+
+    @Override
+    LinearSeq<T> asJavaMutable(Consumer<? super java.util.List<T>> action);
+
+    @Override
     <R> LinearSeq<R> collect(PartialFunction<? super T, ? extends R> partialFunction);
 
     @Override

--- a/javaslang/src/main/java/javaslang/collection/List.java
+++ b/javaslang/src/main/java/javaslang/collection/List.java
@@ -16,6 +16,9 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
+import static javaslang.collection.JavaConverters.ChangePolicy.IMMUTABLE;
+import static javaslang.collection.JavaConverters.ChangePolicy.MUTABLE;
+
 /**
  * An immutable {@code List} is an eager sequence of elements. Its immutability makes it suitable for concurrent programming.
  * <p>
@@ -685,6 +688,25 @@ public interface List<T> extends Kind1<List<?>, T>, LinearSeq<T>, Stack<T> {
     }
 
     @Override
+    default java.util.List<T> asJavaImmutable() {
+        return JavaConverters.asJava(this, IMMUTABLE);
+    }
+
+    @Override
+    default List<T> asJavaImmutable(Consumer<? super java.util.List<T>> action) {
+        return Collections.asJava(this, action, IMMUTABLE);
+    }
+
+    @Override
+    default java.util.List<T> asJavaMutable() {
+        return JavaConverters.asJava(this, MUTABLE);
+    }
+
+    @Override
+    default List<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
+        return Collections.asJava(this, action, MUTABLE);
+    }
+
     default <R> List<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         return ofAll(iterator().<R> collect(partialFunction));
     }

--- a/javaslang/src/main/java/javaslang/collection/Queue.java
+++ b/javaslang/src/main/java/javaslang/collection/Queue.java
@@ -12,6 +12,9 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
+import static javaslang.collection.JavaConverters.ChangePolicy.IMMUTABLE;
+import static javaslang.collection.JavaConverters.ChangePolicy.MUTABLE;
+
 /**
  * An immutable {@code Queue} stores elements allowing a first-in-first-out (FIFO) retrieval.
  * <p>
@@ -648,10 +651,30 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
+    public java.util.List<T> asJavaImmutable() {
+        return JavaConverters.asJava(this, IMMUTABLE);
+    }
+
+    @Override
+    public Queue<T> asJavaImmutable(Consumer<? super java.util.List<T>> action) {
+        return Collections.asJava(this, action, IMMUTABLE);
+    }
+
+    @Override
+    public java.util.List<T> asJavaMutable() {
+        return JavaConverters.asJava(this, MUTABLE);
+    }
+
+    @Override
+    public Queue<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
+        return Collections.asJava(this, action, MUTABLE);
+    }
+
+    @Override
     public <R> Queue<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         return ofAll(iterator().<R> collect(partialFunction));
     }
-    
+
     @Override
     public Queue<Queue<T>> combinations() {
         return ofAll(toList().combinations().map(Queue::ofAll));

--- a/javaslang/src/main/java/javaslang/collection/Seq.java
+++ b/javaslang/src/main/java/javaslang/collection/Seq.java
@@ -81,6 +81,15 @@ import java.util.function.*;
  * <li>{@link #iterator(int)}</li>
  * </ul>
  *
+ * Views:
+ *
+ * <ul>
+ * <li>{@link #asJavaImmutable()}</li>
+ * <li>{@link #asJavaImmutable(Consumer)}</li>
+ * <li>{@link #asJavaMutable()}</li>
+ * <li>{@link #asJavaMutable(Consumer)}</li>
+ * </ul>
+ *
  * @param <T> Component type
  * @author Daniel Dietrich
  * @since 1.1.0
@@ -135,6 +144,50 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T>, Serializa
 
     @Override
     <R> Seq<R> collect(PartialFunction<? super T, ? extends R> partialFunction);
+
+    /**
+     * Creates an <strong>immutable</strong> {@link java.util.List} view on top of this {@code Seq},
+     * i.e. calling mutators will result in {@link UnsupportedOperationException} at runtime.
+     * <p>
+     * The difference to conversion methods {@code toJava*()} is that
+     *
+     * <ul>
+     * <li>A view is created in O(1) (constant time) whereas conversion takes O(n) (linear time), with n = collection size.</li>
+     * <li>The operations on a view have the same performance characteristics than the underlying persistent Javaslang collection whereas the performance characteristics of a converted collection are those of the Java standard collections.</li>
+     * </ul>
+     *
+     * @return A new immutable {@link java.util.Collection} view on this {@code Traversable}.
+     */
+    java.util.List<T> asJavaImmutable();
+
+    /**
+     * Creates an <strong>immutable</strong> {@link java.util.List} view on top of this {@code Seq}
+     * that is passed to the given {@code action}.
+     *
+     * @param action A side-effecting unit of work that operates on an immutable {@code java.util.List} view.
+     * @return this instance
+     * @see Seq#asJavaImmutable()
+     */
+    Seq<T> asJavaImmutable(Consumer<? super java.util.List<T>> action);
+
+    /**
+     * Creates a <strong>mutable</strong> {@link java.util.List} view on top of this {@code Seq},
+     * i.e. all mutator methods of the {@link java.util.List} are implemented.
+     *
+     * @return A new mutable {@link java.util.Collection} view on this {@code Traversable}.
+     * @see Seq#asJavaImmutable()
+     */
+    java.util.List<T> asJavaMutable();
+
+    /**
+     * Creates a <strong>mutable</strong> {@link java.util.List} view on top of this {@code Seq}
+     * that is passed to the given {@code action}.
+     *
+     * @param action A side-effecting unit of work that operates on a mutable {@code java.util.List} view.
+     * @return the (possibly mutated) instance of this type that was wrapped in the {@code java.util.List} view
+     * @see Seq#asJavaMutable()
+     */
+    Seq<T> asJavaMutable(Consumer<? super java.util.List<T>> action);
 
     /**
      * Returns the union of all combinations from k = 0 to length().

--- a/javaslang/src/main/java/javaslang/collection/Stream.java
+++ b/javaslang/src/main/java/javaslang/collection/Stream.java
@@ -16,6 +16,9 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
+import static javaslang.collection.JavaConverters.ChangePolicy.IMMUTABLE;
+import static javaslang.collection.JavaConverters.ChangePolicy.MUTABLE;
+
 /**
  * An immutable {@code Stream} is lazy sequence of elements which may be infinitely long.
  * Its immutability makes it suitable for concurrent programming.
@@ -829,6 +832,26 @@ public interface Stream<T> extends Kind1<Stream<?>, T>, LinearSeq<T> {
         return ofAll(iterator().<R> collect(partialFunction));
     }
     
+    @Override
+    default java.util.List<T> asJavaImmutable() {
+        return JavaConverters.asJava(this, IMMUTABLE);
+    }
+
+    @Override
+    default Stream<T> asJavaImmutable(Consumer<? super java.util.List<T>> action) {
+        return Collections.asJava(this, action, IMMUTABLE);
+    }
+
+    @Override
+    default java.util.List<T> asJavaMutable() {
+        return JavaConverters.asJava(this, MUTABLE);
+    }
+
+    @Override
+    default Stream<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
+        return Collections.asJava(this, action, MUTABLE);
+    }
+
     @Override
     default Stream<Stream<T>> combinations() {
         return Stream.rangeClosed(0, length()).map(this::combinations).flatMap(Function.identity());

--- a/javaslang/src/main/java/javaslang/collection/Vector.java
+++ b/javaslang/src/main/java/javaslang/collection/Vector.java
@@ -16,6 +16,8 @@ import java.util.stream.Collector;
 
 import static javaslang.collection.Collections.areEqual;
 import static javaslang.collection.Collections.withSize;
+import static javaslang.collection.JavaConverters.ChangePolicy.IMMUTABLE;
+import static javaslang.collection.JavaConverters.ChangePolicy.MUTABLE;
 
 /**
  * Vector is the default Seq implementation that provides effectively constant time access to any element.
@@ -597,6 +599,26 @@ public final class Vector<T> implements Kind1<Vector<?>, T>, IndexedSeq<T>, Seri
             final BitMappedTrie<T> that = trie.appendAll(iterable);
             return (that == trie) ? this : new Vector<>(that);
         }
+    }
+
+    @Override
+    public java.util.List<T> asJavaImmutable() {
+        return JavaConverters.asJava(this, IMMUTABLE);
+    }
+
+    @Override
+    public Vector<T> asJavaImmutable(Consumer<? super java.util.List<T>> action) {
+        return Collections.asJava(this, action, IMMUTABLE);
+    }
+
+    @Override
+    public java.util.List<T> asJavaMutable() {
+        return JavaConverters.asJava(this, MUTABLE);
+    }
+
+    @Override
+    public Vector<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
+        return Collections.asJava(this, action, MUTABLE);
     }
 
     @Override

--- a/javaslang/src/test/java/javaslang/collection/JavaConvertersTest.java
+++ b/javaslang/src/test/java/javaslang/collection/JavaConvertersTest.java
@@ -1,0 +1,1001 @@
+/*     / \____  _    _  ____   ______  / \ ____  __    _______
+ *    /  /    \/ \  / \/    \ /  /\__\/  //    \/  \  //  /\__\   JΛVΛSLΛNG
+ *  _/  /  /\  \  \/  /  /\  \\__\\  \  //  /\  \ /\\/ \ /__\ \   Copyright 2014-2017 Javaslang, http://javaslang.io
+ * /___/\_/  \_/\____/\_/  \_/\__\/__/\__\_/  \_//  \__/\_____/   Licensed under the Apache License, Version 2.0
+ */
+package javaslang.collection;
+
+import javaslang.collection.JavaConverters.ListView;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(Enclosed.class)
+public class JavaConvertersTest {
+
+    @RunWith(Parameterized.class)
+    public static class ListViewImmutableTest extends ListViewTest {
+
+        public ListViewImmutableTest(String name, ListFactory listFactory) {
+            super(listFactory);
+        }
+
+        @Parameterized.Parameters(name = "{index}: {0}")
+        public static java.util.Collection<Object[]> data() {
+            return java.util.Arrays.asList(new Object[][] {
+                    { "java.util.Arrays$ArrayList", new ListFactory(java.util.Arrays::asList) },
+                    { List.class.getName(), new ListFactory(ts -> List.of(ts).asJavaImmutable()) },
+                    { Vector.class.getName(), new ListFactory(ts -> Vector.of(ts).asJavaImmutable()) }
+            });
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class ListViewMutableTest extends ListViewTest {
+
+        public ListViewMutableTest(String name, ListFactory listFactory) {
+            super(listFactory);
+        }
+
+        @Parameterized.Parameters(name = "{index}: {0}")
+        public static java.util.Collection<Object[]> data() {
+            return java.util.Arrays.asList(new Object[][] {
+                    { java.util.ArrayList.class.getName(), new ListFactory(ts -> {
+                        final java.util.List<Object> list = new java.util.ArrayList<>();
+                        java.util.Collections.addAll(list, ts);
+                        return list;
+                    }) },
+                    { List.class.getName(), new ListFactory(ts -> List.of(ts).asJavaMutable()) },
+                    { Vector.class.getName(), new ListFactory(ts -> Vector.of(ts).asJavaMutable()) }
+            });
+        }
+    }
+}
+
+abstract class ListViewTest {
+
+    private final ListFactory listFactory;
+
+    protected ListViewTest(ListFactory listFactory) {
+        this.listFactory = listFactory;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected final <T> java.util.List<T> empty() {
+        return listFactory.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected final <T> java.util.List<T> ofNull() {
+        return listFactory.of((T) null);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected final <T> java.util.List<T> of(T t) {
+        return listFactory.of(t);
+    }
+    
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    protected final <T> java.util.List<T> of(T... ts) {
+        return listFactory.of(ts);
+    }
+
+    protected final <T> java.util.List<T> immutableList() {
+        return java.util.Collections.emptyList();
+    }
+
+    protected final <T> java.util.List<T> immutableList(T t) {
+        return java.util.Collections.singletonList(t);
+    }
+
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    protected final <T> java.util.List<T> immutableList(T... ts) {
+        return java.util.Arrays.asList(ts);
+    }
+
+    // -- add(T)
+
+    @Test
+    public void shouldAddElementToEmptyListView() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = empty();
+            assertThat(list.add(1)).isTrue();
+            assertThat(list).isEqualTo(immutableList(1));
+        });
+    }
+
+    @Test
+    public void shouldAddElementToEndOfNonEmptyListView() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = of(1);
+            assertThat(list.add(2)).isTrue();
+            assertThat(list).isEqualTo(immutableList(1, 2));
+        });
+    }
+
+    @Test
+    public void shouldAddSubtypeToEndOfNonEmptyListView() {
+        abstract class A {
+            @Override
+            public final int hashCode() {
+                return 0;
+            }
+        }
+        final class B extends A {
+            @Override
+            public boolean equals(Object o) {
+                return o instanceof B;
+            }
+        }
+        final class C extends A {
+            @Override
+            public boolean equals(Object o) {
+                return o instanceof C;
+            }
+        }
+        ifSupported(() -> {
+            final java.util.List<A> list = of(new B());
+            assertThat(list.add(new C())).isTrue();
+            assertThat(list).isEqualTo(immutableList(new B(), new C()));
+        });
+    }
+
+    @Test
+    public void shouldAddNull() {
+        ifSupported(() -> {
+            final java.util.List<Object> list = empty();
+            assertThat(list.add(null)).isTrue();
+            assertThat(list).isEqualTo(immutableList((Object) null));
+        });
+    }
+
+    @Test
+    public void shouldAddSelf() {
+        ifSupported(() -> {
+            final java.util.List<Object> list = empty();
+            assertThat(list.add(list)).isTrue();
+            assertThat(list).isEqualTo(list);
+        });
+    }
+
+    // -- add(int, T)
+
+    @Test
+    public void shouldThrowWhenAddingElementAtNegativeIndexToEmpty() {
+        ifSupported(() -> empty().add(-1, null), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenAddingElementAtNonExistingIndexToEmpty() {
+        ifSupported(() -> empty().add(1, null), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenAddingElementAtNegativeIndexToNonEmpty() {
+        ifSupported(() -> of(1).add(-1, null), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenAddingElementAtNonExistingIndexToNonEmpty() {
+        ifSupported(() -> of(1).add(2, null), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldAddNullToEmptyAtIndex0() {
+        ifSupported(() -> {
+            final java.util.List<Object> list = empty();
+            list.add(0, null);
+            assertThat(list).isEqualTo(immutableList((Object) null));
+        });
+    }
+
+    @Test
+    public void shouldAddNonNullToEmptyAtIndex0() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = empty();
+            list.add(0, 1);
+            assertThat(list).isEqualTo(immutableList(1));
+        });
+    }
+
+    @Test
+    public void shouldAddElementAtSizeIndexToNonEmpty() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = of(1);
+            list.add(1, 2);
+            assertThat(list).isEqualTo(immutableList(1, 2));
+        });
+    }
+
+    // -- addAll(Collection)
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNPEWhenAddingAllNullCollectionToEmpty() {
+        empty().addAll(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNPEWhenAddingAllNullCollectionToNonEmpty() {
+        of(1).addAll(null);
+    }
+
+    @Test
+    public void shouldReturnFalseIfAddAllEmptyToEmpty() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = empty();
+            final java.util.List<Integer> javaList = immutableList();
+            assertThat(list.addAll(javaList)).isFalse();
+            assertThat(list).isEqualTo(javaList);
+        });
+    }
+
+    @Test
+    public void shouldReturnFalseIfAddAllEmptyToNonEmpty() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = of(1);
+            assertThat(list.addAll(immutableList())).isFalse();
+            assertThat(list).isEqualTo(of(1));
+        });
+    }
+
+    @Test
+    public void shouldReturnTrueIfAddAllNonEmptyToEmpty() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = empty();
+            final java.util.List<Integer> javaList = immutableList(1);
+            assertThat(list.addAll(javaList)).isTrue();
+            assertThat(list).isEqualTo(javaList);
+        });
+    }
+
+    @Test
+    public void shouldReturnTrueIfAddAllNonEmptyToNonEmpty() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = of(1, 2, 3);
+            assertThat(list.addAll(immutableList(1, 2, 3))).isTrue();
+            assertThat(list).isEqualTo(immutableList(1, 2, 3, 1, 2, 3));
+        });
+    }
+
+    // -- addAll(int, Collection)
+
+    @Test
+    public void shouldThrowNPEWhenAddingAllNullCollectionAtFirstIndexToEmpty() {
+        assertThatThrownBy(() -> empty().addAll(0, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void shouldThrowNPEWhenAddingAllNullCollectionAtFirstIndexToNonEmpty() {
+        assertThatThrownBy(() -> of(1).addAll(0, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenAddingAllCollectionElementsAtNegativeIndexToEmpty() {
+        ifSupported(() -> empty().addAll(-1, immutableList(1, 2, 3)), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenAddingAllCollectionElementsAtNonExistingIndexToEmpty() {
+        ifSupported(() -> empty().addAll(1, immutableList(1, 2, 3)), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenAddingAllCollectionElementsAtNegativeIndexToNonEmpty() {
+        ifSupported(() -> of(1).addAll(-1, immutableList(1, 2, 3)), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenAddingAllCollectionElementsAtNonExistingIndexToNonEmpty() {
+        ifSupported(() -> of(1).addAll(2, immutableList(1, 2, 3)), IndexOutOfBoundsException.class);
+    }
+
+
+    @Test
+    public void shouldAddAllCollectionElementsAtFirstIndexToNonEmpty() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = of(4);
+            assertThat(list.addAll(0, immutableList(1, 2, 3))).isTrue();
+            assertThat(list).isEqualTo(immutableList(1, 2, 3, 4));
+        });
+    }
+
+    @Test
+    public void shouldAddAllCollectionElementsAtSizeIndexToEmpty() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = empty();
+            final java.util.List<Integer> javaList = immutableList(1, 2, 3);
+            assertThat(list.addAll(0, javaList)).isTrue();
+            assertThat(list).isEqualTo(javaList);
+        });
+    }
+
+    @Test
+    public void shouldAddAllCollectionElementsAtSizeIndexToNonEmpty() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = of(1);
+            assertThat(list.addAll(1, immutableList(2, 3))).isTrue();
+            assertThat(list).isEqualTo(of(1, 2, 3));
+        });
+    }
+
+    // -- clear()
+
+    @Test
+    public void shouldThrowWhenCallingClearOnEmpty() {
+        ifSupported(() -> {
+            final java.util.List<Integer> empty = empty();
+            empty.clear();
+            assertThat(empty).isEqualTo(immutableList());
+        });
+    }
+
+    @Test
+    public void shouldThrowWhenCallingClearOnNonEmpty() {
+        ifSupported(() -> {
+            final java.util.List<Integer> list = of(1);
+            list.clear();
+            assertThat(list).isEqualTo(immutableList());
+        });
+    }
+
+    // -- contains(Object)
+
+    @Test
+    public void shouldRecognizeThatEmptyListViewDoesNotContainElement() {
+        assertThat(empty().contains(1)).isFalse();
+    }
+
+    @Test
+    public void shouldRecognizeThatNonEmptyListViewDoesNotContainElement() {
+        assertThat(of(1).contains(2)).isFalse();
+    }
+
+    @Test
+    public void shouldRecognizeThatNWhenEmptyListViewContainElement() {
+        assertThat(of(1).contains(1)).isTrue();
+    }
+
+    @Test
+    public void shouldEnsureThatEmptyListViewContainsPermitsNullElements() {
+        assertThat(empty().contains(null)).isFalse();
+    }
+
+    @Test
+    public void shouldEnsureThatNonEmptyListViewContainsPermitsNullElements() {
+        assertThat(ofNull().contains(null)).isTrue();
+    }
+
+    @Test
+    public void shouldBehaveLikeStandardJavaWhenCallingContainsOfIncompatibleTypeOnEmpty() {
+        assertThat(empty().contains("")).isFalse();
+    }
+
+    @Test
+    public void shouldBehaveLikeStandardJavaWhenCallingContainsOfIncompatibleTypeWhenNotEmpty() {
+        assertThat(of(1).contains("")).isFalse();
+    }
+
+    @Test
+    public void shouldRecognizeListContainsSelf() {
+        ifSupported(() -> {
+            final java.util.List<Object> list = empty();
+            list.add(list);
+            assertThat(list.contains(list)).isTrue();
+        });
+    }
+
+    // -- containsAll(Collection)
+
+    @Test
+    public void shouldThrowNPEWhenCallingContainsAllNullWhenEmpty() {
+        assertThatThrownBy(() -> empty().containsAll(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void shouldThrowNPEWhenCallingContainsAllNullWhenNotEmpty() {
+        assertThatThrownBy(() -> of(1).containsAll(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void shouldRecognizeNonEmptyContainsAllEmpty() {
+        assertThat(of(1).containsAll(immutableList())).isTrue();
+    }
+
+    @Test
+    public void shouldRecognizeNonEmptyContainsAllNonEmpty() {
+        assertThat(of(1).containsAll(immutableList(1))).isTrue();
+    }
+
+    @Test
+    public void shouldRecognizeNonEmptyNotContainsAllNonEmpty() {
+        assertThat(of(1, 2).containsAll(immutableList(1, 3))).isFalse();
+    }
+
+    @Test
+    public void shouldRecognizeEmptyContainsAllEmpty() {
+        assertThat(empty().containsAll(immutableList())).isTrue();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowOnEmptyContainsAllGivenNull() {
+        empty().containsAll(null);
+    }
+
+    @Test
+    public void shouldRecognizeListContainsAllSelf() {
+        ifSupported(() -> {
+            final java.util.List<Object> list = empty();
+            list.add(list);
+            assertThat(list.containsAll(list)).isTrue();
+        });
+    }
+
+    // -- equals(Object)
+
+    @Test
+    public void shouldRecognizeEqualsSame() {
+        final java.util.List<Integer> list = of(1);
+        assertThat(list.equals(list)).isTrue();
+    }
+
+    @Test
+    public void shouldRecognizeEmptyEqualsEmpty() {
+        assertThat(empty().equals(empty())).isTrue();
+    }
+
+    @Test
+    public void shouldRecognizeNonEmptyEqualsNonEmpty() {
+        assertThat(of(1).equals(of(1))).isTrue();
+    }
+
+    @Test
+    public void shouldRecognizeNonEmptyNotEqualsNonEmpty() {
+        assertThat(of(1, 2).equals(of(1, 3))).isFalse();
+    }
+
+    @Test
+    public void shouldRecognizeEmptyNotEqualsNonEmpty() {
+        assertThat(empty().equals(of(1))).isFalse();
+    }
+
+    @Test
+    public void shouldRecognizeNonEmptyNotEqualsEmpty() {
+        assertThat(of(1).equals(empty())).isFalse();
+    }
+
+    @Test
+    public void shouldRecognizeEmptyNotEqualsNull() {
+        assertThat(empty().equals(null)).isFalse();
+    }
+
+    @Test
+    public void shouldRecognizeNonEmptyNotEqualsNull() {
+        assertThat(of(1).equals(null)).isFalse();
+    }
+
+    @Test
+    public void shouldRecognizeNonEqualityOfSameValuesOfDifferentType() {
+        assertThat(of(1).equals(of(1.0d))).isFalse();
+    }
+
+    @Test
+    public void shouldRecognizeSelfEqualityOfListThatContainsItself() {
+        ifSupported(() -> {
+            final java.util.List<Object> list = empty();
+            list.add(list);
+            assertThat(list.equals(list)).isTrue();
+        });
+    }
+
+    // -- get(int)
+
+    @Test
+    public void shouldThrowWhenEmptyGetWithNegativeIndex() {
+        assertThatThrownBy(() -> empty().get(-1))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenEmptyGetWithIndexEqualsSize() {
+        assertThatThrownBy(() -> empty().get(0))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenNonEmptyGetWithNegativeIndex() {
+        assertThatThrownBy(() -> of(1).get(-1))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenNonEmptyGetWithIndexEqualsSize() {
+        assertThatThrownBy(() -> of(1).get(1))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldGetAtFirstIndex() {
+        assertThat(of(1, 2, 3).get(0)).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldGetAtLastIndex() {
+        assertThat(of(1, 2, 3).get(2)).isEqualTo(3);
+    }
+
+    // -- hashCode()
+
+    @Test
+    public void shouldCalculateHashCodeOfEmptyLikeJava() {
+        assertThat(empty().hashCode()).isEqualTo(immutableList().hashCode());
+    }
+
+    @Test
+    public void shouldCalculateHashCodeOfNonEmptyLikeJava() {
+        assertThat(of(1, 2, 3).hashCode()).isEqualTo(immutableList(1, 2, 3).hashCode());
+    }
+
+    @Test
+    public void shouldThrowInsteadOfLoopingInfinitelyWhenComputingHashCodeOfListThatContainsItself() {
+        ifSupported(() -> {
+            final java.util.List<Object> list = empty();
+            list.add(list);
+            list.hashCode();
+        }, StackOverflowError.class);
+    }
+
+    // -- indexOf(Object)
+
+    @Test
+    public void shouldReturnIndexOfNonExistingElementWhenEmpty() {
+        assertThat(empty().indexOf(0)).isEqualTo(-1);
+    }
+
+    @Test
+    public void shouldReturnIndexOfNonExistingElementWhenNonEmpty() {
+        assertThat(of(1, 2, 3).indexOf(0)).isEqualTo(-1);
+    }
+
+    @Test
+    public void shouldReturnIndexOfFirstOccurrenceWhenNonEmpty() {
+        assertThat(of(1, 2, 3, 2).indexOf(2)).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldReturnIndexOfNullWhenNonEmpty() {
+        assertThat(of(1, null, 2, null).indexOf(null)).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldReturnIndexOfWrongTypedElementWhenNonEmpty() {
+        assertThat(of(1, null, 2).indexOf("a")).isEqualTo(-1);
+    }
+
+    // -- isEmpty()
+
+    @Test
+    public void shouldReturnTrueWhenCallingIsEmptyWhenEmpty() {
+        assertThat(empty().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseWhenCallingIsEmptyWhenNotEmpty() {
+        assertThat(of(1).isEmpty()).isFalse();
+    }
+
+    // -- iterator()
+
+    @Test
+    public void shouldReturnIteratorWhenEmpty() {
+        assertThat(empty().iterator()).isNotNull();
+    }
+
+    @Test
+    public void shouldReturnIteratorWhenNotEmpty() {
+        assertThat(of(1).iterator()).isNotNull();
+    }
+
+    @Test
+    public void shouldReturnEmptyIteratorWhenEmpty() {
+        assertThat(empty().iterator().hasNext()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnNonEmptyIteratorWhenNotEmpty() {
+        assertThat(of(1).iterator().hasNext()).isTrue();
+    }
+
+    @Test
+    public void shouldThrowWhenCallingNextOnIteratorWhenEmpty() {
+        assertThatThrownBy(() -> empty().iterator().next())
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void shouldNotThrowWhenCallingNextOnIteratorWhenNotEmpty() {
+        assertThat(of(1).iterator().next()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldThrowWhenCallingNextTooOftenOnIteratorWhenNotEmpty() {
+        final java.util.Iterator<Integer> iterator = of(1).iterator();
+        assertThatThrownBy(() -> {
+            iterator.next();
+            iterator.next();
+        }).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void shouldIteratorAsExpectedWhenCallingIteratorWhenNotEmpty() {
+        final java.util.Iterator<Integer> iterator = of(1, 2, 3).iterator();
+        assertThat(iterator.next()).isEqualTo(1);
+        assertThat(iterator.next()).isEqualTo(2);
+        assertThat(iterator.next()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldNotHaveNextWhenAllIteratorElementsWereConsumedByNext() {
+        final java.util.Iterator<Integer> iterator = of(1).iterator();
+        iterator.next();
+        assertThat(iterator.hasNext()).isFalse();
+    }
+
+    // -- TODO: iterator().remove()
+
+    // -- lastIndexOf()
+
+    @Test
+    public void shouldReturnLastIndexOfNonExistingElementWhenEmpty() {
+        assertThat(empty().lastIndexOf(0)).isEqualTo(-1);
+    }
+
+    @Test
+    public void shouldReturnLastIndexOfNonExistingElementWhenNonEmpty() {
+        assertThat(of(1, 2, 3).lastIndexOf(0)).isEqualTo(-1);
+    }
+
+    @Test
+    public void shouldReturnLastIndexOfFirstOccurrenceWhenNonEmpty() {
+        assertThat(of(1, 2, 3, 2).lastIndexOf(2)).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldReturnLastIndexOfNullWhenNonEmpty() {
+        assertThat(of(1, null, 2, null).lastIndexOf(null)).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldReturnLastIndexOfWrongTypedElementWhenNonEmpty() {
+        assertThat(of(1, null, 2).lastIndexOf("a")).isEqualTo(-1);
+    }
+
+    // -- listIterator()
+
+    @Test
+    public void shouldReturnListIteratorWhenEmpty() {
+        assertThat(empty().listIterator()).isNotNull();
+    }
+
+    @Test
+    public void shouldReturnListIteratorWhenNotEmpty() {
+        assertThat(of(1).listIterator()).isNotNull();
+    }
+
+    @Test
+    public void shouldReturnEmptyListIteratorWhenEmpty() {
+        assertThat(empty().listIterator().hasNext()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnNonEmptyListIteratorWhenNotEmpty() {
+        assertThat(of(1).listIterator().hasNext()).isTrue();
+    }
+
+    @Test
+    public void shouldThrowWhenCallingNextOnListIteratorWhenEmpty() {
+        assertThatThrownBy(() -> empty().listIterator().next())
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void shouldNotThrowWhenCallingNextOnListIteratorWhenNotEmpty() {
+        assertThat(of(1).listIterator().next()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldThrowWhenCallingNextTooOftenOnListIteratorWhenNotEmpty() {
+        final java.util.Iterator<Integer> iterator = of(1).listIterator();
+        assertThatThrownBy(() -> {
+            iterator.next();
+            iterator.next();
+        }).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void shouldIteratorAsExpectedWhenCallingListIteratorWhenNotEmpty() {
+        final java.util.Iterator<Integer> iterator = of(1, 2, 3).listIterator();
+        assertThat(iterator.next()).isEqualTo(1);
+        assertThat(iterator.next()).isEqualTo(2);
+        assertThat(iterator.next()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldNotHaveNextWhenAllListIteratorElementsWereConsumedByNext() {
+        final java.util.Iterator<Integer> iterator = of(1).listIterator();
+        iterator.next();
+        assertThat(iterator.hasNext()).isFalse();
+    }
+
+    // -- listIterator(int)
+
+    @Test
+    public void shouldThrowWhenListIteratorAtNegativeIndexWhenEmpty() {
+        assertThatThrownBy(() -> empty().listIterator(-1))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenListIteratorAtNegativeIndexWhenNotEmpty() {
+        assertThatThrownBy(() -> of(1).listIterator(-1))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldNotThrowWhenListIteratorAtSizeIndexWhenEmpty() {
+        assertThat(empty().listIterator(0)).isNotNull();
+    }
+
+    @Test
+    public void shouldNotThrowWhenListIteratorAtSizeIndexWhenNotEmpty() {
+        assertThat(of(1).listIterator(1)).isNotNull();
+    }
+
+    @Test
+    public void shouldThrowWhenListIteratorAtIndexGreaterSizeWhenEmpty() {
+        assertThatThrownBy(() -> empty().listIterator(1))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenListIteratorAtIndexGreaterSizeWhenNotEmpty() {
+        assertThatThrownBy(() -> of(1).listIterator(2))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldReturnEmptyListIteratorAtFirstIndexWhenEmpty() {
+        assertThat(empty().listIterator(0).hasNext()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnNonEmptyListIteratorAtFirstIndexWhenNotEmpty() {
+        assertThat(of(1).listIterator(0).hasNext()).isTrue();
+    }
+
+    @Test
+    public void shouldThrowWhenCallingNextOnListIteratorAtFirstIndexWhenEmpty() {
+        assertThatThrownBy(() -> empty().listIterator(0).next())
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void shouldNotThrowWhenCallingNextOnListIteratorAtFirstIndexWhenNotEmpty() {
+        assertThat(of(1).listIterator(0).next()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldThrowWhenCallingNextTooOftenOnListIteratorAtFirstIndexWhenNotEmpty() {
+        final java.util.Iterator<Integer> iterator = of(1).listIterator(0);
+        assertThatThrownBy(() -> {
+            iterator.next();
+            iterator.next();
+        }).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void shouldIteratorAsExpectedWhenCallingListIteratorAtFirstIndexWhenNotEmpty() {
+        final java.util.Iterator<Integer> iterator = of(1, 2, 3).listIterator(0);
+        assertThat(iterator.next()).isEqualTo(1);
+        assertThat(iterator.next()).isEqualTo(2);
+        assertThat(iterator.next()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldIteratorAsExpectedWhenCallingListIteratorAtNonFirstIndexWhenNotEmpty() {
+        final java.util.Iterator<Integer> iterator = of(1, 2, 3).listIterator(1);
+        assertThat(iterator.next()).isEqualTo(2);
+        assertThat(iterator.next()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldNotHaveNextWhenAllListIteratorElementsAtFirstIndexWereConsumedByNext() {
+        final java.util.Iterator<Integer> iterator = of(1).listIterator(0);
+        iterator.next();
+        assertThat(iterator.hasNext()).isFalse();
+    }
+
+    // -- TODO: listIterator().add()/.remove()/.set()
+
+    // -- TODO: listIterator(int).add()/.remove()/.set()
+
+    // -- remove(int)
+
+    @Test
+    public void shouldThrowWhenRemovingElementAtNegativeIndexWhenEmpty() {
+        ifSupported(() -> empty().remove(-1), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenRemovingElementAtNegativeIndexWhenNotEmpty() {
+        ifSupported(() -> of(1).remove(-1), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenRemovingElementAtSizeIndexWhenEmpty() {
+        ifSupported(() -> empty().remove(0), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenRemovingElementAtSizeIndexWhenNotEmpty() {
+        ifSupported(() -> of(1).remove(1), IndexOutOfBoundsException.class);
+    }
+
+    // TODO: more remove(int) tests
+
+    // -- TODO: remove(Object)
+
+    // -- removeAll(Collection)
+
+    @Test
+    public void shouldThrowNPEWhenCallingRemoveAllNullWhenEmpty() {
+        assertThatThrownBy(() -> empty().removeAll(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void shouldThrowNPEWhenCallingRemoveAllNullWhenNotEmpty() {
+        assertThatThrownBy(() -> of(1).removeAll(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // TODO: more removeAll(Collection) tests
+
+    // -- TODO: replaceAll(UnaryOperator)
+
+    // -- retainAll(Collection)
+
+    @Test
+    public void shouldThrowNPEWhenCallingRetainAllNullWhenEmpty() {
+        assertThatThrownBy(() -> empty().retainAll(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void shouldThrowNPEWhenCallingRetainAllNullWhenNotEmpty() {
+        assertThatThrownBy(() -> of(1).retainAll(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // -- TODO: more retainAll(Collection) tests
+
+    // -- set(int, T)
+
+    @Test
+    public void shouldThrowWhenSettingElementAtNegativeIndexWhenEmpty() {
+        ifSupported(() -> empty().set(-1, null), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenSettingElementAtNegativeIndexWhenNotEmpty() {
+        ifSupported(() -> of(1).set(-1, null), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenSettingElementAtSizeIndexWhenEmpty() {
+        ifSupported(() -> empty().set(0, null), IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    public void shouldThrowWhenSettingElementAtSizeIndexWhenNotEmpty() {
+        ifSupported(() -> of(1).set(1, null), IndexOutOfBoundsException.class);
+    }
+
+    // TODO: more set(int, T) tests
+
+    // -- size()
+
+    @Test
+    public void shouldReturnSizeOfEmpty() {
+        assertThat(empty().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReturnSizeOfNonEmpty() {
+        assertThat(of(1, 2, 3).size()).isEqualTo(3);
+    }
+
+    // -- TODO: sort(Comparator)
+
+    // -- TODO: spliterator()
+
+    // -- TODO: subList(int, int)
+
+    // -- TODO: toArray()
+
+    // -- TODO: toArray(T[])
+
+    @Test
+    public void shouldThrowNPEWhenCallingToArrayNullWhenEmpty() {
+        assertThatThrownBy(() -> empty().toArray(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void shouldThrowNPEWhenCallingToArrayNullWhenNotEmpty() {
+        assertThatThrownBy(() -> of(1).toArray(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // --- helpers
+
+    @SafeVarargs
+    private final void ifSupported(Runnable test, Class<? extends Throwable>... expectedExceptionTypes) {
+        try {
+            test.run();
+            if (!isMutable()) {
+                Assert.fail("Operation should throw " + UnsupportedOperationException.class.getName());
+            }
+        } catch (Throwable x) {
+            if (!isMutable()) {
+                if (!(x instanceof UnsupportedOperationException) && isJavaslang()) {
+                    Assert.fail("Operation should throw " + UnsupportedOperationException.class.getName() + " but found " + x.getClass().getName());
+                }
+            } else {
+                final Class<? extends Throwable> actualType = x.getClass();
+                for (Class<? extends Throwable> expectedType : expectedExceptionTypes) {
+                    if (expectedType.isAssignableFrom(actualType)) {
+                        return;
+                    }
+                }
+                throw x;
+            }
+        }
+    }
+
+    private boolean isJavaslang() {
+        return listFactory.of().getClass().getName().startsWith("javaslang.collection.");
+    }
+
+    private boolean isMutable() {
+        final java.util.List<?> list = listFactory.of();
+        return isJavaslang() ? ((ListView<?, ?>) list).isMutable() : list instanceof java.util.ArrayList;
+    }
+
+    static final class ListFactory {
+
+        private final Function<Object[], java.util.List<Object>> listFactory;
+
+        ListFactory(Function<Object[], java.util.List<Object>> listFactory) {
+            this.listFactory = listFactory;
+        }
+
+        @SuppressWarnings("unchecked")
+        <T> java.util.List<T> of(T... elements) {
+            return (java.util.List<T>) listFactory.apply(elements);
+        }
+    }
+}

--- a/javaslang/src/test/java/javaslang/collection/JavaConvertersTest.java
+++ b/javaslang/src/test/java/javaslang/collection/JavaConvertersTest.java
@@ -654,7 +654,14 @@ abstract class ListViewTest {
         assertThat(iterator.hasNext()).isFalse();
     }
 
-    // -- TODO: iterator().remove()
+    // -- iterator().remove()
+
+    @Test
+    public void shouldThrowWhenCallingRemoveOnEmptyIterator() {
+        ifSupported(() -> empty().iterator().remove(), IllegalStateException.class);
+    }
+
+    // -- TODO: more iterator().remove() tests
 
     // -- lastIndexOf()
 

--- a/pom.xml
+++ b/pom.xml
@@ -286,11 +286,16 @@ Note: The maven build currently needs to be started from the javaslang root dir
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.version}</version>
+<!--
+ Disabled concurrent tests (enabling them improves build time by ~25% on my local machine).
+ If enabled, the Travis-CI builds stall because of JUnit's experimental @RunWith(Enclosed.class).
+ See javaslang.collection.JavaConvertersTest.java
                     <configuration>
                         <parallel>all</parallel>
-                        <threadCount>4</threadCount>
+                        <threadCount>2</threadCount>
                         <reuseForks>true</reuseForks>
                     </configuration>
+ -->
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Addresses #1728

This is in an early state. The following things are to be done:

* [x] Name methods asJavaMutable() and asJavaImmutable() (instead of asJava())
* [ ] Write failing unit tests that cover all(!) details of the java.util API (especially the exceptional cases)
* [ ] ~~Optimize the *.ofAll(Iterable) methods in the way that we check for instanceof View and return delegate if possible~~ We will not do that in a first step. It would pull the concept of collection views into the persistent collections. But both concerns should be separated.
* [x] Solve remaining TODOs
* [ ] **Re-enable Sputnik in .travis.yml**
---
**Note:** We already have two PRs (#1736 by @paplorinc , #1751 by @seanf) that target the issue. But there are too many details to mention / refactor. It is most economic to do it myself. Please understand me.