### PR TITLE
Fixes CharSeq creation

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -112,7 +112,7 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
      *
      * @param elements An Iterable of elements.
      * @return A string containing the given elements in the same order.
-     * @throws NullPointerException if {@code elements} is null
+     * @throws NullPointerException if {@code elements} is null or {@code elements} contains null
      */
     public static CharSeq ofAll(Iterable<? extends Character> elements) {
         Objects.requireNonNull(elements, "elements is null");
@@ -121,7 +121,7 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
         }
         final StringBuilder sb = new StringBuilder();
         for (Character character : elements) {
-            sb.append(character);
+            sb.append(character.charValue());
         }
         return sb.length() == 0 ? EMPTY : of(sb);
     }

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class CharSeqTest {
 
@@ -51,6 +52,13 @@ public class CharSeqTest {
 
     protected StringAssert assertThat(String actual) {
         return new StringAssert(actual) {};
+    }
+
+    // -- ofAll
+
+    @Test
+    public void shouldThrowWhenCreatingCharSeqFromIterableThatContainsNull() {
+        assertThatThrownBy(() -> CharSeq.ofAll(Arrays.asList('1', null))).isInstanceOf(NullPointerException.class);
     }
 
     // -- exists


### PR DESCRIPTION
Null elements should lead to a NPE when calling CharSeq.ofAll(Iterable).

BEFORE:

```java
// does not compile (OK)
CharSeq.of(1, null);

// = 1null
CharSeq.ofAll(List.of('1', null));
```

AFTER:

```java
// does not compile (OK)
CharSeq.of(1, null);

// throws NPE (OK)
CharSeq.ofAll(List.of('1', null));
```
