### PR TITLE
Fixed range-check of Seq.subSequence

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -1225,9 +1225,8 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
 
     @Override
     public Array<T> subSequence(int beginIndex, int endIndex) {
-        if (beginIndex < 0 || beginIndex > endIndex || endIndex > length()) {
-            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + ") on Array of length " + length());
-        } else if (beginIndex == endIndex) {
+        Collections.subSequenceRangeCheck(beginIndex, endIndex, length());
+        if (beginIndex == endIndex) {
             return empty();
         } else if (beginIndex == 0 && endIndex == length()) {
             return this;

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -1686,7 +1686,7 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
         }
         final int subLen = endIndex - beginIndex;
         if (subLen < 0) {
-            throw new IndexOutOfBoundsException("beginIndex " + beginIndex + " > endIndex " + endIndex);
+            throw new IllegalArgumentException("beginIndex " + beginIndex + " > endIndex " + endIndex);
         }
         if (beginIndex == 0 && endIndex == length()) {
             return this;

--- a/vavr/src/main/java/io/vavr/collection/Collections.java
+++ b/vavr/src/main/java/io/vavr/collection/Collections.java
@@ -305,6 +305,14 @@ final class Collections {
         return ofAll.apply(list);
     }
 
+    static void subSequenceRangeCheck(int beginIndex, int endIndex, int length) {
+        if (beginIndex < 0 || endIndex > length) {
+            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + "), length = " + length);
+        } else if (beginIndex > endIndex) {
+            throw new IllegalArgumentException("subSequence(" + beginIndex + ", " + endIndex + ")");
+        }
+    }
+
     static <T> Iterator<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
         if (n <= 0) {

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -1369,9 +1369,8 @@ public interface List<T> extends LinearSeq<T>, Stack<T> {
 
     @Override
     default List<T> subSequence(int beginIndex, int endIndex) {
-        if (beginIndex < 0 || beginIndex > endIndex || endIndex > length()) {
-            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + ") on List of length " + length());
-        } else if (beginIndex == endIndex) {
+        Collections.subSequenceRangeCheck(beginIndex, endIndex, length());
+        if (beginIndex == endIndex) {
             return empty();
         } else if (beginIndex == 0 && endIndex == length()) {
             return this;

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -1128,9 +1128,8 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
 
     @Override
     public Queue<T> subSequence(int beginIndex, int endIndex) {
-        if (beginIndex < 0 || beginIndex > endIndex || endIndex > length()) {
-            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + ") on Queue of length " + length());
-        } else if (beginIndex == endIndex) {
+        Collections.subSequenceRangeCheck(beginIndex, endIndex, length());
+        if (beginIndex == endIndex) {
             return empty();
         } else if (beginIndex == 0 && endIndex == length()) {
             return this;

--- a/vavr/src/main/java/io/vavr/collection/Seq.java
+++ b/vavr/src/main/java/io/vavr/collection/Seq.java
@@ -959,9 +959,9 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T>, Serializa
      * @param beginIndex the beginning index, inclusive
      * @param endIndex   the end index, exclusive
      * @return the specified subsequence
-     * @throws IndexOutOfBoundsException if {@code beginIndex} or {@code endIndex} is negative,
-     *                                   if {@code endIndex} is greater than {@code length()},
-     *                                   or if {@code beginIndex} is greater than {@code endIndex}
+     * @throws IndexOutOfBoundsException if {@code beginIndex} or {@code endIndex} is negative or
+     *                                   if {@code endIndex} is greater than {@code length()}
+     * @throws IllegalArgumentException  if {@code beginIndex} is greater than {@code endIndex}
      */
     Seq<T> subSequence(int beginIndex, int endIndex);
 

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -1451,8 +1451,11 @@ public interface Stream<T> extends LinearSeq<T> {
 
     @Override
     default Stream<T> subSequence(int beginIndex, int endIndex) {
-        if (beginIndex < 0 || beginIndex > endIndex) {
+        if (beginIndex < 0) {
             throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + ")");
+        }
+        if (beginIndex > endIndex) {
+            throw new IllegalArgumentException("subSequence(" + beginIndex + ", " + endIndex + ")");
         }
         if (beginIndex == endIndex) {
             return Empty.instance();

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -1078,11 +1078,8 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
 
     @Override
     public Vector<T> subSequence(int beginIndex, int endIndex) {
-        if ((beginIndex >= 0) && (beginIndex <= endIndex) && (endIndex <= length())) {
-            return slice(beginIndex, endIndex);
-        } else {
-            throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + ") on Vector of size " + length());
-        }
+        Collections.subSequenceRangeCheck(beginIndex, endIndex, length());
+        return slice(beginIndex, endIndex);
     }
 
     @Override

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -1822,12 +1822,12 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         assertThat(actual).isEmpty();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void shouldThrowOnSubSequenceOnNonNilWhenBeginIndexIsGreaterThanEndIndex() {
         of(1, 2, 3).subSequence(1, 0);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void shouldThrowOnSubSequenceOnNilWhenBeginIndexIsGreaterThanEndIndex() {
         empty().subSequence(1, 0);
     }
@@ -1852,7 +1852,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         of(1, 2, 3).subSequence(1, 4).mkString(); // force computation of last element, e.g. because Stream is lazy
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void shouldThrowOnSubSequenceWhenBeginIndexIsGreaterThanEndIndex() {
         of(1, 2, 3).subSequence(2, 1).mkString(); // force computation of last element, e.g. because Stream is lazy
     }

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -3192,24 +3192,24 @@ public class CharSeqTest {
         assertThat(actual).isSameAs(CharSeq.empty());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void shouldThrowOnSubSequenceOnNonNilWhenBeginIndexIsGreaterThanEndIndex() {
         CharSeq.of('1', '2', '3').subSequence(1, 0);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void shouldThrowOnSubSequenceOnNilWhenBeginIndexIsGreaterThanEndIndex() {
         CharSeq.empty().subSequence(1, 0);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void shouldThrowOnSubSequenceOnNonNilWhenBeginIndexExceedsLowerBound() {
-        CharSeq.of('1', '2', '3').subSequence(-'1', '2');
+        CharSeq.of('1', '2', '3').subSequence(-1, 2);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void shouldThrowOnSubSequenceOnNilWhenBeginIndexExceedsLowerBound() {
-        CharSeq.empty().subSequence(-'1', '2');
+        CharSeq.empty().subSequence(-1, 2);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)


### PR DESCRIPTION
When start &gt; end of a range (start, end) and both start, end are within their bounds, then the result should be an IllegalArgumentException instead of an IndexOutOfBoundsException.

Java's ArrayList.subList behaves the same for example.