### PR TITLE
Renames lambda class, removes Lambda.Memoized from public API

### DIFF
--- a/vavr-test/src/test/java/io/vavr/test/GenTest.java
+++ b/vavr-test/src/test/java/io/vavr/test/GenTest.java
@@ -145,7 +145,7 @@ public class GenTest {
 
     @Test
     public void shouldChooseCharWhenMinEqualsMax() {
-        assertForAll(() -> Gen.choose('λ', 'λ').apply(RANDOM), c -> c == 'λ');
+        assertForAll(() -> Gen.choose('a', 'a').apply(RANDOM), c -> c == 'a');
     }
 
     // -- choose(array)

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1452,9 +1452,8 @@ def generateMainClasses(): Unit = {
            * @param <R> return type of the function
            * @author Daniel Dietrich
            */
-          @SuppressWarnings("deprecation")
           @FunctionalInterface
-          public interface $className$fullGenerics extends λ<R>$additionalExtends {
+          public interface $className$fullGenerics extends Lambda<R>$additionalExtends {
 
               /$javadoc
                * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction0.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction0.java
@@ -22,9 +22,8 @@ import java.util.function.Supplier;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface CheckedFunction0<R> extends λ<R> {
+public interface CheckedFunction0<R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
@@ -24,9 +24,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface CheckedFunction1<T1, R> extends λ<R> {
+public interface CheckedFunction1<T1, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
@@ -26,9 +26,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface CheckedFunction2<T1, T2, R> extends λ<R> {
+public interface CheckedFunction2<T1, T2, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
@@ -26,9 +26,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface CheckedFunction3<T1, T2, T3, R> extends λ<R> {
+public interface CheckedFunction3<T1, T2, T3, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
@@ -27,9 +27,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface CheckedFunction4<T1, T2, T3, T4, R> extends λ<R> {
+public interface CheckedFunction4<T1, T2, T3, T4, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
@@ -28,9 +28,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends λ<R> {
+public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
@@ -29,9 +29,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
+public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
@@ -30,9 +30,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
+public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
@@ -31,9 +31,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
+public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/Function0.java
+++ b/vavr/src-gen/main/java/io/vavr/Function0.java
@@ -22,9 +22,8 @@ import java.util.function.Supplier;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface Function0<R> extends λ<R>, Supplier<R> {
+public interface Function0<R> extends Lambda<R>, Supplier<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -25,9 +25,8 @@ import java.util.function.Predicate;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface Function1<T1, R> extends λ<R>, Function<T1, R> {
+public interface Function1<T1, R> extends Lambda<R>, Function<T1, R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/Function2.java
+++ b/vavr/src-gen/main/java/io/vavr/Function2.java
@@ -26,9 +26,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface Function2<T1, T2, R> extends λ<R>, BiFunction<T1, T2, R> {
+public interface Function2<T1, T2, R> extends Lambda<R>, BiFunction<T1, T2, R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/Function3.java
+++ b/vavr/src-gen/main/java/io/vavr/Function3.java
@@ -26,9 +26,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface Function3<T1, T2, T3, R> extends λ<R> {
+public interface Function3<T1, T2, T3, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/Function4.java
+++ b/vavr/src-gen/main/java/io/vavr/Function4.java
@@ -27,9 +27,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface Function4<T1, T2, T3, T4, R> extends λ<R> {
+public interface Function4<T1, T2, T3, T4, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/Function5.java
+++ b/vavr/src-gen/main/java/io/vavr/Function5.java
@@ -28,9 +28,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface Function5<T1, T2, T3, T4, T5, R> extends λ<R> {
+public interface Function5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/Function6.java
+++ b/vavr/src-gen/main/java/io/vavr/Function6.java
@@ -29,9 +29,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface Function6<T1, T2, T3, T4, T5, T6, R> extends λ<R> {
+public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/Function7.java
+++ b/vavr/src-gen/main/java/io/vavr/Function7.java
@@ -30,9 +30,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends λ<R> {
+public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src-gen/main/java/io/vavr/Function8.java
+++ b/vavr/src-gen/main/java/io/vavr/Function8.java
@@ -31,9 +31,8 @@ import java.util.function.Function;
  * @param <R> return type of the function
  * @author Daniel Dietrich
  */
-@SuppressWarnings("deprecation")
 @FunctionalInterface
-public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends λ<R> {
+public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lambda<R> {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.

--- a/vavr/src/main/java/io/vavr/Lambda.java
+++ b/vavr/src/main/java/io/vavr/Lambda.java
@@ -10,6 +10,8 @@ import java.io.Serializable;
 import java.util.Map;
 
 /**
+ * <strong>INTERNAL API - This class is subject to change.</strong>
+ * <p>
  * This is a general definition of a (checked/unchecked) function of unknown parameters and a return type R.
  * <p>
  * A checked function may throw an exception. The exception type cannot be expressed as a generic type parameter
@@ -17,10 +19,8 @@ import java.util.Map;
  *
  * @param <R> Return type of the function.
  * @author Daniel Dietrich
- * @deprecated Will be removed from the public API (an internally renamed to Lambda) in 0.9.0
  */
-@Deprecated
-public interface λ<R> extends Serializable {
+interface Lambda<R> extends Serializable {
 
     /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
@@ -38,21 +38,21 @@ public interface λ<R> extends Serializable {
      *
      * @return a curried function equivalent to this.
      */
-    λ<?> curried();
+    Lambda<?> curried();
 
     /**
      * Returns a tupled version of this function.
      *
      * @return a tupled function equivalent to this.
      */
-    λ<R> tupled();
+    Lambda<R> tupled();
 
     /**
      * Returns a reversed version of this function. This may be useful in a recursive context.
      *
      * @return a reversed function equivalent to this.
      */
-    λ<R> reversed();
+    Lambda<R> reversed();
 
     /**
      * Returns a memoizing version of this function, which computes the return value for given arguments only one time.
@@ -62,7 +62,7 @@ public interface λ<R> extends Serializable {
      *
      * @return a memoizing function equivalent to this.
      */
-    λ<R> memoized();
+    Lambda<R> memoized();
 
     /**
      * Checks if this function is memoizing (= caching) computed values.
@@ -75,9 +75,7 @@ public interface λ<R> extends Serializable {
 
     /**
      * Zero Abstract Method (ZAM) interface for marking functions as memoized using intersection types.
-     * @deprecated Will be removed (from the public API) in 0.9.0
      */
-    @Deprecated
     interface Memoized {
         static <T extends Tuple, R> R of(Map<T, R> cache, T key, Function1<T, R> tupled) {
             synchronized (cache) {
@@ -90,6 +88,5 @@ public interface λ<R> extends Serializable {
                 }
             }
         }
-
     }
 }

--- a/vavr/src/main/java/io/vavr/package-info.java
+++ b/vavr/src/main/java/io/vavr/package-info.java
@@ -1,4 +1,4 @@
 /**
- * The io.vavr package contains core types like {@linkplain io.vavr.λ}, {@linkplain io.vavr.Lazy} and {@linkplain io.vavr.Tuple}.
+ * The io.vavr package contains core types like {@linkplain io.vavr.Lambda}, {@linkplain io.vavr.Lazy} and {@linkplain io.vavr.Tuple}.
  */
 package io.vavr;


### PR DESCRIPTION
&lambda; has to be an internal class with a non-unicode name. I can't imagine a reason for making it public. We had problems, especially with cloud services that did not handle unicode characters correctly (*cough* AWS Lambda *cough*).