### PR TITLE
Issue/1968 Remove Try.CheckedFunction and Try.CheckedSupplier

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -52,7 +52,7 @@ def generateMainClasses(): Unit = {
       val IteratorType = im.getType("io.vavr.collection.Iterator")
       val EitherType = im.getType("io.vavr.control.Either")
       val FutureType = im.getType("io.vavr.concurrent.Future")
-      val CheckedSupplierType = im.getType("io.vavr.control.Try.CheckedSupplier")
+      val CheckedFunction0Type = im.getType("io.vavr.CheckedFunction0")
       val TryType = im.getType("io.vavr.control.Try")
       val ValidationType = im.getType("io.vavr.control.Validation")
       val CharSeqType = im.getType("io.vavr.collection.CharSeq")
@@ -465,19 +465,19 @@ def generateMainClasses(): Unit = {
           // -- Future
 
           /$javadoc
-           * Alias for {@link $FutureType#of($TryType.$CheckedSupplierType)}
+           * Alias for {@link $FutureType#of($CheckedFunction0Type)}
            *
            * @param <T>         Type of the computation result.
            * @param computation A computation.
            * @return A new {@link $FutureType} instance.
            * @throws NullPointerException if computation is null.
            */
-          public static <T> $FutureType<T> Future($CheckedSupplierType<? extends T> computation) {
+          public static <T> $FutureType<T> Future($CheckedFunction0Type<? extends T> computation) {
               return $FutureType.of(computation);
           }
 
           /$javadoc
-           * Alias for {@link $FutureType#of($ExecutorServiceType, $TryType.$CheckedSupplierType)}
+           * Alias for {@link $FutureType#of($ExecutorServiceType, $CheckedFunction0Type)}
            *
            * @param <T>             Type of the computation result.
            * @param executorService An executor service.
@@ -485,7 +485,7 @@ def generateMainClasses(): Unit = {
            * @return A new {@link $FutureType} instance.
            * @throws NullPointerException if one of executorService or computation is null.
            */
-          public static <T> $FutureType<T> Future($ExecutorServiceType executorService, $CheckedSupplierType<? extends T> computation) {
+          public static <T> $FutureType<T> Future($ExecutorServiceType executorService, $CheckedFunction0Type<? extends T> computation) {
               return $FutureType.of(executorService, computation);
           }
 
@@ -565,14 +565,14 @@ def generateMainClasses(): Unit = {
           // -- Try
 
           /$javadoc
-           * Alias for {@link $TryType#of($CheckedSupplierType)}
+           * Alias for {@link $TryType#of($CheckedFunction0Type)}
            *
            * @param <T>      Component type
            * @param supplier A checked supplier
            * @return {@link $TryType.Success} if no exception occurs, otherwise {@link $TryType.Failure} if an
            * exception occurs calling {@code supplier.get()}.
            */
-          public static <T> $TryType<T> Try($CheckedSupplierType<? extends T> supplier) {
+          public static <T> $TryType<T> Try($CheckedFunction0Type<? extends T> supplier) {
               return $TryType.of(supplier);
           }
 

--- a/vavr/src-gen/main/java/io/vavr/API.java
+++ b/vavr/src-gen/main/java/io/vavr/API.java
@@ -17,7 +17,6 @@ import io.vavr.concurrent.Future;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
-import io.vavr.control.Try.CheckedSupplier;
 import io.vavr.control.Validation;
 import java.io.PrintStream;
 import java.util.Comparator;
@@ -794,19 +793,19 @@ public final class API {
     // -- Future
 
     /**
-     * Alias for {@link Future#of(Try.CheckedSupplier)}
+     * Alias for {@link Future#of(CheckedFunction0)}
      *
      * @param <T>         Type of the computation result.
      * @param computation A computation.
      * @return A new {@link Future} instance.
      * @throws NullPointerException if computation is null.
      */
-    public static <T> Future<T> Future(CheckedSupplier<? extends T> computation) {
+    public static <T> Future<T> Future(CheckedFunction0<? extends T> computation) {
         return Future.of(computation);
     }
 
     /**
-     * Alias for {@link Future#of(ExecutorService, Try.CheckedSupplier)}
+     * Alias for {@link Future#of(ExecutorService, CheckedFunction0)}
      *
      * @param <T>             Type of the computation result.
      * @param executorService An executor service.
@@ -814,7 +813,7 @@ public final class API {
      * @return A new {@link Future} instance.
      * @throws NullPointerException if one of executorService or computation is null.
      */
-    public static <T> Future<T> Future(ExecutorService executorService, CheckedSupplier<? extends T> computation) {
+    public static <T> Future<T> Future(ExecutorService executorService, CheckedFunction0<? extends T> computation) {
         return Future.of(executorService, computation);
     }
 
@@ -894,14 +893,14 @@ public final class API {
     // -- Try
 
     /**
-     * Alias for {@link Try#of(CheckedSupplier)}
+     * Alias for {@link Try#of(CheckedFunction0)}
      *
      * @param <T>      Component type
      * @param supplier A checked supplier
      * @return {@link Try.Success} if no exception occurs, otherwise {@link Try.Failure} if an
      * exception occurs calling {@code supplier.get()}.
      */
-    public static <T> Try<T> Try(CheckedSupplier<? extends T> supplier) {
+    public static <T> Try<T> Try(CheckedFunction0<? extends T> supplier) {
         return Try.of(supplier);
     }
 

--- a/vavr/src/main/java/io/vavr/CheckedConsumer.java
+++ b/vavr/src/main/java/io/vavr/CheckedConsumer.java
@@ -1,0 +1,24 @@
+/*                        __    __  __  __    __  ___
+ *                       \  \  /  /    \  \  /  /  __/
+ *                        \  \/  /  /\  \  \/  /  /
+ *                         \____/__/  \__\____/__/.ɪᴏ
+ * ᶜᵒᵖʸʳᶦᵍʰᵗ ᵇʸ ᵛᵃᵛʳ ⁻ ˡᶦᶜᵉⁿˢᵉᵈ ᵘⁿᵈᵉʳ ᵗʰᵉ ᵃᵖᵃᶜʰᵉ ˡᶦᶜᵉⁿˢᵉ ᵛᵉʳˢᶦᵒⁿ ᵗʷᵒ ᵈᵒᵗ ᶻᵉʳᵒ
+ */
+package io.vavr;
+
+/**
+ * A {@linkplain java.util.function.Consumer} which may throw.
+ *
+ * @param <T> the type of value supplied to this consumer.
+ */
+@FunctionalInterface
+public interface CheckedConsumer<T> {
+
+    /**
+     * Performs side-effects.
+     *
+     * @param value a value
+     * @throws Throwable if an error occurs
+     */
+    void accept(T value) throws Throwable;
+}

--- a/vavr/src/main/java/io/vavr/CheckedPredicate.java
+++ b/vavr/src/main/java/io/vavr/CheckedPredicate.java
@@ -1,0 +1,34 @@
+/*                        __    __  __  __    __  ___
+ *                       \  \  /  /    \  \  /  /  __/
+ *                        \  \/  /  /\  \  \/  /  /
+ *                         \____/__/  \__\____/__/.ɪᴏ
+ * ᶜᵒᵖʸʳᶦᵍʰᵗ ᵇʸ ᵛᵃᵛʳ ⁻ ˡᶦᶜᵉⁿˢᵉᵈ ᵘⁿᵈᵉʳ ᵗʰᵉ ᵃᵖᵃᶜʰᵉ ˡᶦᶜᵉⁿˢᵉ ᵛᵉʳˢᶦᵒⁿ ᵗʷᵒ ᵈᵒᵗ ᶻᵉʳᵒ
+ */
+package io.vavr;
+
+/**
+ * A {@linkplain java.util.function.Predicate} which may throw.
+ *
+ * @param <T> the type of the input to the predicate
+ */
+@FunctionalInterface
+public interface CheckedPredicate<T> {
+
+    /**
+     * Evaluates this predicate on the given argument.
+     *
+     * @param t the input argument
+     * @return {@code true} if the input argument matches the predicate, otherwise {@code false}
+     * @throws Throwable if an error occurs
+     */
+    boolean test(T t) throws Throwable;
+
+    /**
+     * Negates this predicate.
+     *
+     * @return A new CheckedPredicate.
+     */
+    default CheckedPredicate<T> negate() {
+        return t -> !test(t);
+    }
+}

--- a/vavr/src/main/java/io/vavr/CheckedRunnable.java
+++ b/vavr/src/main/java/io/vavr/CheckedRunnable.java
@@ -1,0 +1,21 @@
+/*                        __    __  __  __    __  ___
+ *                       \  \  /  /    \  \  /  /  __/
+ *                        \  \/  /  /\  \  \/  /  /
+ *                         \____/__/  \__\____/__/.ɪᴏ
+ * ᶜᵒᵖʸʳᶦᵍʰᵗ ᵇʸ ᵛᵃᵛʳ ⁻ ˡᶦᶜᵉⁿˢᵉᵈ ᵘⁿᵈᵉʳ ᵗʰᵉ ᵃᵖᵃᶜʰᵉ ˡᶦᶜᵉⁿˢᵉ ᵛᵉʳˢᶦᵒⁿ ᵗʷᵒ ᵈᵒᵗ ᶻᵉʳᵒ
+ */
+package io.vavr;
+
+/**
+ * A {@linkplain Runnable} which may throw.
+ */
+@FunctionalInterface
+public interface CheckedRunnable {
+
+    /**
+     * Performs side-effects.
+     *
+     * @throws Throwable if an error occurs
+     */
+    void run() throws Throwable;
+}

--- a/vavr/src/main/java/io/vavr/Value.java
+++ b/vavr/src/main/java/io/vavr/Value.java
@@ -44,7 +44,7 @@ import static io.vavr.API.*;
  * <li>{@link #getOrElse(Object)}</li>
  * <li>{@link #getOrElse(Supplier)}</li>
  * <li>{@link #getOrElseThrow(Supplier)}</li>
- * <li>{@link #getOrElseTry(Try.CheckedSupplier)}</li>
+ * <li>{@link #getOrElseTry(CheckedFunction0)}</li>
  * <li>{@link #getOrNull()}</li>
  * <li>{@link #map(Function)}</li>
  * <li>{@link #stringPrefix()}</li>
@@ -382,7 +382,7 @@ public interface Value<T> extends Iterable<T> {
      * @throws NullPointerException  if supplier is null
      * @throws Try.NonFatalException containing the original exception if this Value was empty and the Try failed.
      */
-    default T getOrElseTry(Try.CheckedSupplier<? extends T> supplier) {
+    default T getOrElseTry(CheckedFunction0<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return isEmpty() ? Try.of(supplier).get() : get();
     }

--- a/vavr/src/main/java/io/vavr/concurrent/Future.java
+++ b/vavr/src/main/java/io/vavr/concurrent/Future.java
@@ -6,15 +6,12 @@
  */
 package io.vavr.concurrent;
 
-import io.vavr.PartialFunction;
-import io.vavr.Tuple;
-import io.vavr.Value;
+import io.vavr.*;
 import io.vavr.collection.Iterator;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
-import io.vavr.Tuple2;
 import io.vavr.collection.List;
 
 import java.util.NoSuchElementException;
@@ -1004,7 +1001,7 @@ public interface Future<T> extends Value<T> {
         return flatMapTry(mapper::apply);
     }
 
-    default <U> Future<U> flatMapTry(Try.CheckedFunction<? super T, ? extends Future<? extends U>> mapper) {
+    default <U> Future<U> flatMapTry(CheckedFunction1<? super T, ? extends Future<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         final Promise<U> promise = Promise.make(executorService());
         onComplete((Try<T> result) -> result.mapTry(mapper)
@@ -1099,7 +1096,7 @@ public interface Future<T> extends Value<T> {
         return transformValue(t -> t.map(mapper::apply));
     }
 
-    default <U> Future<U> mapTry(Try.CheckedFunction<? super T, ? extends U> mapper) {
+    default <U> Future<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return transformValue(t -> t.mapTry(mapper::apply));
     }

--- a/vavr/src/main/java/io/vavr/concurrent/Future.java
+++ b/vavr/src/main/java/io/vavr/concurrent/Future.java
@@ -469,7 +469,7 @@ public interface Future<T> extends Value<T> {
      * @return A new Future instance which results in nothing.
      * @throws NullPointerException if unit is null.
      */
-    static Future<Void> run(Try.CheckedRunnable unit) {
+    static Future<Void> run(CheckedRunnable unit) {
         return run(DEFAULT_EXECUTOR_SERVICE, unit);
     }
 
@@ -481,7 +481,7 @@ public interface Future<T> extends Value<T> {
      * @return A new Future instance which results in nothing.
      * @throws NullPointerException if one of executorService or unit is null.
      */
-    static Future<Void> run(ExecutorService executorService, Try.CheckedRunnable unit) {
+    static Future<Void> run(ExecutorService executorService, CheckedRunnable unit) {
         Objects.requireNonNull(executorService, "executorService is null");
         Objects.requireNonNull(unit, "unit is null");
         return Future.of(executorService, () -> {
@@ -786,13 +786,13 @@ public interface Future<T> extends Value<T> {
     }
 
     /**
-     * Filters the result of this {@code Future} by calling {@link Try#filterTry(Try.CheckedPredicate)}.
+     * Filters the result of this {@code Future} by calling {@link Try#filterTry(CheckedPredicate)}.
      *
      * @param predicate A checked predicate
      * @return A new {@code Future}
      * @throws NullPointerException if {@code predicate} is null
      */
-    default Future<T> filterTry(Try.CheckedPredicate<? super T> predicate) {
+    default Future<T> filterTry(CheckedPredicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         final Promise<T> promise = Promise.make(executorService());
         onComplete(result -> promise.complete(result.filterTry(predicate)));

--- a/vavr/src/main/java/io/vavr/concurrent/Future.java
+++ b/vavr/src/main/java/io/vavr/concurrent/Future.java
@@ -401,7 +401,7 @@ public interface Future<T> extends Value<T> {
      * @return A new Future instance.
      * @throws NullPointerException if computation is null.
      */
-    static <T> Future<T> of(Try.CheckedSupplier<? extends T> computation) {
+    static <T> Future<T> of(CheckedFunction0<? extends T> computation) {
         return Future.of(DEFAULT_EXECUTOR_SERVICE, computation);
     }
 
@@ -414,7 +414,7 @@ public interface Future<T> extends Value<T> {
      * @return A new Future instance.
      * @throws NullPointerException if one of executorService or computation is null.
      */
-    static <T> Future<T> of(ExecutorService executorService, Try.CheckedSupplier<? extends T> computation) {
+    static <T> Future<T> of(ExecutorService executorService, CheckedFunction0<? extends T> computation) {
         Objects.requireNonNull(executorService, "executorService is null");
         Objects.requireNonNull(computation, "computation is null");
         final FutureImpl<T> future = new FutureImpl<>(executorService);

--- a/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
+++ b/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
@@ -6,6 +6,7 @@
  */
 package io.vavr.concurrent;
 
+import io.vavr.CheckedFunction0;
 import io.vavr.collection.Queue;
 import io.vavr.control.Try;
 import io.vavr.control.Option;
@@ -21,7 +22,7 @@ import java.util.function.Consumer;
  * Once a {@code FutureImpl} is created, one (and only one) of the following methods is called
  * to complete it with a result:
  * <ul>
- * <li>{@link #run(Try.CheckedSupplier)} - typically called within a {@code Future} factory method</li>
+ * <li>{@link #run(CheckedFunction0)} - typically called within a {@code Future} factory method</li>
  * <li>{@link #tryComplete(Try)} - explicit write operation, typically called by {@code Promise}</li>
  * </ul>
  * <p>
@@ -90,7 +91,7 @@ final class FutureImpl<T> implements Future<T> {
     private java.util.concurrent.Future<?> job = null;
 
     /**
-     * Creates a Future, {@link #run(Try.CheckedSupplier)} has to be called separately.
+     * Creates a Future, {@link #run(CheckedFunction0)} has to be called separately.
      *
      * @param executorService An {@link ExecutorService} to run and control the computation and to perform the actions.
      */
@@ -180,7 +181,7 @@ final class FutureImpl<T> implements Future<T> {
      * @throws IllegalStateException if the Future is pending, completed or cancelled
      * @throws NullPointerException  if {@code computation} is null.
      */
-    void run(Try.CheckedSupplier<? extends T> computation) {
+    void run(CheckedFunction0<? extends T> computation) {
         Objects.requireNonNull(computation, "computation is null");
         synchronized (lock) {
             if (job != null) {

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -859,64 +859,6 @@ public interface Try<T> extends Value<T>, Serializable {
     String toString();
 
     /**
-     * A {@linkplain java.util.function.Consumer} which may throw.
-     *
-     * @param <T> the type of value supplied to this consumer.
-     */
-    @FunctionalInterface
-    interface CheckedConsumer<T> {
-
-        /**
-         * Performs side-effects.
-         *
-         * @param value a value
-         * @throws Throwable if an error occurs
-         */
-        void accept(T value) throws Throwable;
-    }
-
-    /**
-     * A {@linkplain java.util.function.Predicate} which may throw.
-     *
-     * @param <T> the type of the input to the predicate
-     */
-    @FunctionalInterface
-    interface CheckedPredicate<T> {
-
-        /**
-         * Evaluates this predicate on the given argument.
-         *
-         * @param t the input argument
-         * @return {@code true} if the input argument matches the predicate, otherwise {@code false}
-         * @throws Throwable if an error occurs
-         */
-        boolean test(T t) throws Throwable;
-
-        /**
-         * Negates this predicate.
-         *
-         * @return A new CheckedPredicate.
-         */
-        default CheckedPredicate<T> negate() {
-            return t -> !test(t);
-        }
-    }
-
-    /**
-     * A {@linkplain java.lang.Runnable} which may throw.
-     */
-    @FunctionalInterface
-    interface CheckedRunnable {
-
-        /**
-         * Performs side-effects.
-         *
-         * @throws Throwable if an error occurs
-         */
-        void run() throws Throwable;
-    }
-
-    /**
      * A succeeded Try.
      *
      * @param <T> component type of this Success

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -34,17 +34,17 @@ public interface Try<T> extends Value<T>, Serializable {
     long serialVersionUID = 1L;
 
     /**
-     * Creates a Try of a CheckedSupplier.
+     * Creates a Try of a CheckedFunction0.
      *
      * @param supplier A checked supplier
      * @param <T>      Component type
-     * @return {@code Success(supplier.get())} if no exception occurs, otherwise {@code Failure(throwable)} if an
-     * exception occurs calling {@code supplier.get()}.
+     * @return {@code Success(supplier.apply())} if no exception occurs, otherwise {@code Failure(throwable)} if an
+     * exception occurs calling {@code supplier.apply()}.
      */
-    static <T> Try<T> of(CheckedSupplier<? extends T> supplier) {
+    static <T> Try<T> of(CheckedFunction0<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         try {
-            return new Success<>(supplier.get());
+            return new Success<>(supplier.apply());
         } catch (Throwable t) {
             return new Failure<>(t);
         }
@@ -917,23 +917,6 @@ public interface Try<T> extends Value<T>, Serializable {
     }
 
     /**
-     * A {@linkplain java.util.function.Supplier} which may throw.
-     *
-     * @param <R> the type of results supplied by this supplier
-     */
-    @FunctionalInterface
-    interface CheckedSupplier<R> {
-
-        /**
-         * Gets a result.
-         *
-         * @return a result
-         * @throws Throwable if an error occurs
-         */
-        R get() throws Throwable;
-    }
-
-    /**
      * A succeeded Try.
      *
      * @param <T> component type of this Success
@@ -1081,7 +1064,7 @@ public interface Try<T> extends Value<T>, Serializable {
      * @param <T1> Type of the 1st resource.
      * @return a new {@link WithResources1} instance.
      */
-    static <T1 extends AutoCloseable> WithResources1<T1> withResources(CheckedSupplier<? extends T1> t1Supplier) {
+    static <T1 extends AutoCloseable> WithResources1<T1> withResources(CheckedFunction0<? extends T1> t1Supplier) {
         return new WithResources1<>(t1Supplier);
     }
 
@@ -1094,7 +1077,7 @@ public interface Try<T> extends Value<T>, Serializable {
      * @param <T2> Type of the 2nd resource.
      * @return a new {@link WithResources2} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable> WithResources2<T1, T2> withResources(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier) {
+    static <T1 extends AutoCloseable, T2 extends AutoCloseable> WithResources2<T1, T2> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier) {
         return new WithResources2<>(t1Supplier, t2Supplier);
     }
 
@@ -1109,7 +1092,7 @@ public interface Try<T> extends Value<T>, Serializable {
      * @param <T3> Type of the 3rd resource.
      * @return a new {@link WithResources3} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable> WithResources3<T1, T2, T3> withResources(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier) {
+    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable> WithResources3<T1, T2, T3> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier) {
         return new WithResources3<>(t1Supplier, t2Supplier, t3Supplier);
     }
 
@@ -1126,7 +1109,7 @@ public interface Try<T> extends Value<T>, Serializable {
      * @param <T4> Type of the 4th resource.
      * @return a new {@link WithResources4} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable> WithResources4<T1, T2, T3, T4> withResources(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier, CheckedSupplier<? extends T4> t4Supplier) {
+    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable> WithResources4<T1, T2, T3, T4> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier) {
         return new WithResources4<>(t1Supplier, t2Supplier, t3Supplier, t4Supplier);
     }
 
@@ -1145,7 +1128,7 @@ public interface Try<T> extends Value<T>, Serializable {
      * @param <T5> Type of the 5th resource.
      * @return a new {@link WithResources5} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable> WithResources5<T1, T2, T3, T4, T5> withResources(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier, CheckedSupplier<? extends T4> t4Supplier, CheckedSupplier<? extends T5> t5Supplier) {
+    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable> WithResources5<T1, T2, T3, T4, T5> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier) {
         return new WithResources5<>(t1Supplier, t2Supplier, t3Supplier, t4Supplier, t5Supplier);
     }
 
@@ -1166,7 +1149,7 @@ public interface Try<T> extends Value<T>, Serializable {
      * @param <T6> Type of the 6th resource.
      * @return a new {@link WithResources6} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable> WithResources6<T1, T2, T3, T4, T5, T6> withResources(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier, CheckedSupplier<? extends T4> t4Supplier, CheckedSupplier<? extends T5> t5Supplier, CheckedSupplier<? extends T6> t6Supplier) {
+    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable> WithResources6<T1, T2, T3, T4, T5, T6> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier) {
         return new WithResources6<>(t1Supplier, t2Supplier, t3Supplier, t4Supplier, t5Supplier, t6Supplier);
     }
 
@@ -1189,7 +1172,7 @@ public interface Try<T> extends Value<T>, Serializable {
      * @param <T7> Type of the 7th resource.
      * @return a new {@link WithResources7} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable> WithResources7<T1, T2, T3, T4, T5, T6, T7> withResources(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier, CheckedSupplier<? extends T4> t4Supplier, CheckedSupplier<? extends T5> t5Supplier, CheckedSupplier<? extends T6> t6Supplier, CheckedSupplier<? extends T7> t7Supplier) {
+    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable> WithResources7<T1, T2, T3, T4, T5, T6, T7> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier, CheckedFunction0<? extends T7> t7Supplier) {
         return new WithResources7<>(t1Supplier, t2Supplier, t3Supplier, t4Supplier, t5Supplier, t6Supplier, t7Supplier);
     }
 
@@ -1214,7 +1197,7 @@ public interface Try<T> extends Value<T>, Serializable {
      * @param <T8> Type of the 8th resource.
      * @return a new {@link WithResources8} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable, T8 extends AutoCloseable> WithResources8<T1, T2, T3, T4, T5, T6, T7, T8> withResources(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier, CheckedSupplier<? extends T4> t4Supplier, CheckedSupplier<? extends T5> t5Supplier, CheckedSupplier<? extends T6> t6Supplier, CheckedSupplier<? extends T7> t7Supplier, CheckedSupplier<? extends T8> t8Supplier) {
+    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable, T8 extends AutoCloseable> WithResources8<T1, T2, T3, T4, T5, T6, T7, T8> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier, CheckedFunction0<? extends T7> t7Supplier, CheckedFunction0<? extends T8> t8Supplier) {
         return new WithResources8<>(t1Supplier, t2Supplier, t3Supplier, t4Supplier, t5Supplier, t6Supplier, t7Supplier, t8Supplier);
     }
 
@@ -1225,9 +1208,9 @@ public interface Try<T> extends Value<T>, Serializable {
      */
     final class WithResources1<T1 extends AutoCloseable> {
 
-        private final CheckedSupplier<? extends T1> t1Supplier;
+        private final CheckedFunction0<? extends T1> t1Supplier;
 
-        private WithResources1(CheckedSupplier<? extends T1> t1Supplier) {
+        private WithResources1(CheckedFunction0<? extends T1> t1Supplier) {
             this.t1Supplier = t1Supplier;
         }
 
@@ -1241,7 +1224,7 @@ public interface Try<T> extends Value<T>, Serializable {
         @SuppressWarnings("try")/* https://bugs.openjdk.java.net/browse/JDK-8155591 */
         public <R> Try<R> of(CheckedFunction1<? super T1, ? extends R> f) {
             return Try.of(() -> {
-                try (T1 t1 = t1Supplier.get()) {
+                try (T1 t1 = t1Supplier.apply()) {
                     return f.apply(t1);
                 }
             });
@@ -1256,10 +1239,10 @@ public interface Try<T> extends Value<T>, Serializable {
      */
     final class WithResources2<T1 extends AutoCloseable, T2 extends AutoCloseable> {
 
-        private final CheckedSupplier<? extends T1> t1Supplier;
-        private final CheckedSupplier<? extends T2> t2Supplier;
+        private final CheckedFunction0<? extends T1> t1Supplier;
+        private final CheckedFunction0<? extends T2> t2Supplier;
 
-        private WithResources2(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier) {
+        private WithResources2(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier) {
             this.t1Supplier = t1Supplier;
             this.t2Supplier = t2Supplier;
         }
@@ -1274,7 +1257,7 @@ public interface Try<T> extends Value<T>, Serializable {
         @SuppressWarnings("try")/* https://bugs.openjdk.java.net/browse/JDK-8155591 */
         public <R> Try<R> of(CheckedFunction2<? super T1, ? super T2, ? extends R> f) {
             return Try.of(() -> {
-                try (T1 t1 = t1Supplier.get(); T2 t2 = t2Supplier.get()) {
+                try (T1 t1 = t1Supplier.apply(); T2 t2 = t2Supplier.apply()) {
                     return f.apply(t1, t2);
                 }
             });
@@ -1290,11 +1273,11 @@ public interface Try<T> extends Value<T>, Serializable {
      */
     final class WithResources3<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable> {
 
-        private final CheckedSupplier<? extends T1> t1Supplier;
-        private final CheckedSupplier<? extends T2> t2Supplier;
-        private final CheckedSupplier<? extends T3> t3Supplier;
+        private final CheckedFunction0<? extends T1> t1Supplier;
+        private final CheckedFunction0<? extends T2> t2Supplier;
+        private final CheckedFunction0<? extends T3> t3Supplier;
 
-        private WithResources3(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier) {
+        private WithResources3(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier) {
             this.t1Supplier = t1Supplier;
             this.t2Supplier = t2Supplier;
             this.t3Supplier = t3Supplier;
@@ -1310,7 +1293,7 @@ public interface Try<T> extends Value<T>, Serializable {
         @SuppressWarnings("try")/* https://bugs.openjdk.java.net/browse/JDK-8155591 */
         public <R> Try<R> of(CheckedFunction3<? super T1, ? super T2, ? super T3, ? extends R> f) {
             return Try.of(() -> {
-                try (T1 t1 = t1Supplier.get(); T2 t2 = t2Supplier.get(); T3 t3 = t3Supplier.get()) {
+                try (T1 t1 = t1Supplier.apply(); T2 t2 = t2Supplier.apply(); T3 t3 = t3Supplier.apply()) {
                     return f.apply(t1, t2, t3);
                 }
             });
@@ -1327,12 +1310,12 @@ public interface Try<T> extends Value<T>, Serializable {
      */
     final class WithResources4<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable> {
 
-        private final CheckedSupplier<? extends T1> t1Supplier;
-        private final CheckedSupplier<? extends T2> t2Supplier;
-        private final CheckedSupplier<? extends T3> t3Supplier;
-        private final CheckedSupplier<? extends T4> t4Supplier;
+        private final CheckedFunction0<? extends T1> t1Supplier;
+        private final CheckedFunction0<? extends T2> t2Supplier;
+        private final CheckedFunction0<? extends T3> t3Supplier;
+        private final CheckedFunction0<? extends T4> t4Supplier;
 
-        private WithResources4(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier, CheckedSupplier<? extends T4> t4Supplier) {
+        private WithResources4(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier) {
             this.t1Supplier = t1Supplier;
             this.t2Supplier = t2Supplier;
             this.t3Supplier = t3Supplier;
@@ -1349,7 +1332,7 @@ public interface Try<T> extends Value<T>, Serializable {
         @SuppressWarnings("try")/* https://bugs.openjdk.java.net/browse/JDK-8155591 */
         public <R> Try<R> of(CheckedFunction4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
             return Try.of(() -> {
-                try (T1 t1 = t1Supplier.get(); T2 t2 = t2Supplier.get(); T3 t3 = t3Supplier.get(); T4 t4 = t4Supplier.get()) {
+                try (T1 t1 = t1Supplier.apply(); T2 t2 = t2Supplier.apply(); T3 t3 = t3Supplier.apply(); T4 t4 = t4Supplier.apply()) {
                     return f.apply(t1, t2, t3, t4);
                 }
             });
@@ -1367,13 +1350,13 @@ public interface Try<T> extends Value<T>, Serializable {
      */
     final class WithResources5<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable> {
 
-        private final CheckedSupplier<? extends T1> t1Supplier;
-        private final CheckedSupplier<? extends T2> t2Supplier;
-        private final CheckedSupplier<? extends T3> t3Supplier;
-        private final CheckedSupplier<? extends T4> t4Supplier;
-        private final CheckedSupplier<? extends T5> t5Supplier;
+        private final CheckedFunction0<? extends T1> t1Supplier;
+        private final CheckedFunction0<? extends T2> t2Supplier;
+        private final CheckedFunction0<? extends T3> t3Supplier;
+        private final CheckedFunction0<? extends T4> t4Supplier;
+        private final CheckedFunction0<? extends T5> t5Supplier;
 
-        private WithResources5(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier, CheckedSupplier<? extends T4> t4Supplier, CheckedSupplier<? extends T5> t5Supplier) {
+        private WithResources5(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier) {
             this.t1Supplier = t1Supplier;
             this.t2Supplier = t2Supplier;
             this.t3Supplier = t3Supplier;
@@ -1391,7 +1374,7 @@ public interface Try<T> extends Value<T>, Serializable {
         @SuppressWarnings("try")/* https://bugs.openjdk.java.net/browse/JDK-8155591 */
         public <R> Try<R> of(CheckedFunction5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
             return Try.of(() -> {
-                try (T1 t1 = t1Supplier.get(); T2 t2 = t2Supplier.get(); T3 t3 = t3Supplier.get(); T4 t4 = t4Supplier.get(); T5 t5 = t5Supplier.get()) {
+                try (T1 t1 = t1Supplier.apply(); T2 t2 = t2Supplier.apply(); T3 t3 = t3Supplier.apply(); T4 t4 = t4Supplier.apply(); T5 t5 = t5Supplier.apply()) {
                     return f.apply(t1, t2, t3, t4, t5);
                 }
             });
@@ -1410,14 +1393,14 @@ public interface Try<T> extends Value<T>, Serializable {
      */
     final class WithResources6<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable> {
 
-        private final CheckedSupplier<? extends T1> t1Supplier;
-        private final CheckedSupplier<? extends T2> t2Supplier;
-        private final CheckedSupplier<? extends T3> t3Supplier;
-        private final CheckedSupplier<? extends T4> t4Supplier;
-        private final CheckedSupplier<? extends T5> t5Supplier;
-        private final CheckedSupplier<? extends T6> t6Supplier;
+        private final CheckedFunction0<? extends T1> t1Supplier;
+        private final CheckedFunction0<? extends T2> t2Supplier;
+        private final CheckedFunction0<? extends T3> t3Supplier;
+        private final CheckedFunction0<? extends T4> t4Supplier;
+        private final CheckedFunction0<? extends T5> t5Supplier;
+        private final CheckedFunction0<? extends T6> t6Supplier;
 
-        private WithResources6(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier, CheckedSupplier<? extends T4> t4Supplier, CheckedSupplier<? extends T5> t5Supplier, CheckedSupplier<? extends T6> t6Supplier) {
+        private WithResources6(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier) {
             this.t1Supplier = t1Supplier;
             this.t2Supplier = t2Supplier;
             this.t3Supplier = t3Supplier;
@@ -1436,7 +1419,7 @@ public interface Try<T> extends Value<T>, Serializable {
         @SuppressWarnings("try")/* https://bugs.openjdk.java.net/browse/JDK-8155591 */
         public <R> Try<R> of(CheckedFunction6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
             return Try.of(() -> {
-                try (T1 t1 = t1Supplier.get(); T2 t2 = t2Supplier.get(); T3 t3 = t3Supplier.get(); T4 t4 = t4Supplier.get(); T5 t5 = t5Supplier.get(); T6 t6 = t6Supplier.get()) {
+                try (T1 t1 = t1Supplier.apply(); T2 t2 = t2Supplier.apply(); T3 t3 = t3Supplier.apply(); T4 t4 = t4Supplier.apply(); T5 t5 = t5Supplier.apply(); T6 t6 = t6Supplier.apply()) {
                     return f.apply(t1, t2, t3, t4, t5, t6);
                 }
             });
@@ -1456,15 +1439,15 @@ public interface Try<T> extends Value<T>, Serializable {
      */
     final class WithResources7<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable> {
 
-        private final CheckedSupplier<? extends T1> t1Supplier;
-        private final CheckedSupplier<? extends T2> t2Supplier;
-        private final CheckedSupplier<? extends T3> t3Supplier;
-        private final CheckedSupplier<? extends T4> t4Supplier;
-        private final CheckedSupplier<? extends T5> t5Supplier;
-        private final CheckedSupplier<? extends T6> t6Supplier;
-        private final CheckedSupplier<? extends T7> t7Supplier;
+        private final CheckedFunction0<? extends T1> t1Supplier;
+        private final CheckedFunction0<? extends T2> t2Supplier;
+        private final CheckedFunction0<? extends T3> t3Supplier;
+        private final CheckedFunction0<? extends T4> t4Supplier;
+        private final CheckedFunction0<? extends T5> t5Supplier;
+        private final CheckedFunction0<? extends T6> t6Supplier;
+        private final CheckedFunction0<? extends T7> t7Supplier;
 
-        private WithResources7(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier, CheckedSupplier<? extends T4> t4Supplier, CheckedSupplier<? extends T5> t5Supplier, CheckedSupplier<? extends T6> t6Supplier, CheckedSupplier<? extends T7> t7Supplier) {
+        private WithResources7(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier, CheckedFunction0<? extends T7> t7Supplier) {
             this.t1Supplier = t1Supplier;
             this.t2Supplier = t2Supplier;
             this.t3Supplier = t3Supplier;
@@ -1484,7 +1467,7 @@ public interface Try<T> extends Value<T>, Serializable {
         @SuppressWarnings("try")/* https://bugs.openjdk.java.net/browse/JDK-8155591 */
         public <R> Try<R> of(CheckedFunction7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
             return Try.of(() -> {
-                try (T1 t1 = t1Supplier.get(); T2 t2 = t2Supplier.get(); T3 t3 = t3Supplier.get(); T4 t4 = t4Supplier.get(); T5 t5 = t5Supplier.get(); T6 t6 = t6Supplier.get(); T7 t7 = t7Supplier.get()) {
+                try (T1 t1 = t1Supplier.apply(); T2 t2 = t2Supplier.apply(); T3 t3 = t3Supplier.apply(); T4 t4 = t4Supplier.apply(); T5 t5 = t5Supplier.apply(); T6 t6 = t6Supplier.apply(); T7 t7 = t7Supplier.apply()) {
                     return f.apply(t1, t2, t3, t4, t5, t6, t7);
                 }
             });
@@ -1505,16 +1488,16 @@ public interface Try<T> extends Value<T>, Serializable {
      */
     final class WithResources8<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable, T8 extends AutoCloseable> {
 
-        private final CheckedSupplier<? extends T1> t1Supplier;
-        private final CheckedSupplier<? extends T2> t2Supplier;
-        private final CheckedSupplier<? extends T3> t3Supplier;
-        private final CheckedSupplier<? extends T4> t4Supplier;
-        private final CheckedSupplier<? extends T5> t5Supplier;
-        private final CheckedSupplier<? extends T6> t6Supplier;
-        private final CheckedSupplier<? extends T7> t7Supplier;
-        private final CheckedSupplier<? extends T8> t8Supplier;
+        private final CheckedFunction0<? extends T1> t1Supplier;
+        private final CheckedFunction0<? extends T2> t2Supplier;
+        private final CheckedFunction0<? extends T3> t3Supplier;
+        private final CheckedFunction0<? extends T4> t4Supplier;
+        private final CheckedFunction0<? extends T5> t5Supplier;
+        private final CheckedFunction0<? extends T6> t6Supplier;
+        private final CheckedFunction0<? extends T7> t7Supplier;
+        private final CheckedFunction0<? extends T8> t8Supplier;
 
-        private WithResources8(CheckedSupplier<? extends T1> t1Supplier, CheckedSupplier<? extends T2> t2Supplier, CheckedSupplier<? extends T3> t3Supplier, CheckedSupplier<? extends T4> t4Supplier, CheckedSupplier<? extends T5> t5Supplier, CheckedSupplier<? extends T6> t6Supplier, CheckedSupplier<? extends T7> t7Supplier, CheckedSupplier<? extends T8> t8Supplier) {
+        private WithResources8(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier, CheckedFunction0<? extends T7> t7Supplier, CheckedFunction0<? extends T8> t8Supplier) {
             this.t1Supplier = t1Supplier;
             this.t2Supplier = t2Supplier;
             this.t3Supplier = t3Supplier;
@@ -1535,7 +1518,7 @@ public interface Try<T> extends Value<T>, Serializable {
         @SuppressWarnings("try"/* https://bugs.openjdk.java.net/browse/JDK-8155591 */)
         public <R> Try<R> of(CheckedFunction8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
             return Try.of(() -> {
-                try (T1 t1 = t1Supplier.get(); T2 t2 = t2Supplier.get(); T3 t3 = t3Supplier.get(); T4 t4 = t4Supplier.get(); T5 t5 = t5Supplier.get(); T6 t6 = t6Supplier.get(); T7 t7 = t7Supplier.get(); T8 t8 = t8Supplier.get()) {
+                try (T1 t1 = t1Supplier.apply(); T2 t2 = t2Supplier.apply(); T3 t3 = t3Supplier.apply(); T4 t4 = t4Supplier.apply(); T5 t5 = t5Supplier.apply(); T6 t6 = t6Supplier.apply(); T7 t7 = t7Supplier.apply(); T8 t8 = t8Supplier.apply()) {
                     return f.apply(t1, t2, t3, t4, t5, t6, t7, t8);
                 }
             });

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -414,7 +414,7 @@ public interface Try<T> extends Value<T>, Serializable {
     }
 
     /**
-     * Shortcut for {@code flatMapTry(mapper::apply)}, see {@link #flatMapTry(CheckedFunction)}.
+     * Shortcut for {@code flatMapTry(mapper::apply)}, see {@link #flatMapTry(CheckedFunction1)}.
      *
      * @param mapper A mapper
      * @param <U>    The new component type
@@ -423,7 +423,7 @@ public interface Try<T> extends Value<T>, Serializable {
      */
     default <U> Try<U> flatMap(Function<? super T, ? extends Try<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return flatMapTry((CheckedFunction<T, Try<? extends U>>) mapper::apply);
+        return flatMapTry((CheckedFunction1<T, Try<? extends U>>) mapper::apply);
     }
 
     /**
@@ -435,7 +435,7 @@ public interface Try<T> extends Value<T>, Serializable {
      * @throws NullPointerException if {@code mapper} is null
      */
     @SuppressWarnings("unchecked")
-    default <U> Try<U> flatMapTry(CheckedFunction<? super T, ? extends Try<? extends U>> mapper) {
+    default <U> Try<U> flatMapTry(CheckedFunction1<? super T, ? extends Try<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isFailure()) {
             return (Failure<U>) this;
@@ -523,7 +523,7 @@ public interface Try<T> extends Value<T>, Serializable {
     }
 
     /**
-     * Shortcut for {@code mapTry(mapper::apply)}, see {@link #mapTry(CheckedFunction)}.
+     * Shortcut for {@code mapTry(mapper::apply)}, see {@link #mapTry(CheckedFunction1)}.
      *
      * @param <U>    The new component type
      * @param mapper A checked function
@@ -576,7 +576,7 @@ public interface Try<T> extends Value<T>, Serializable {
      * @throws NullPointerException if {@code mapper} is null
      */
     @SuppressWarnings("unchecked")
-    default <U> Try<U> mapTry(CheckedFunction<? super T, ? extends U> mapper) {
+    default <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isFailure()) {
             return (Failure<U>) this;
@@ -873,25 +873,6 @@ public interface Try<T> extends Value<T>, Serializable {
          * @throws Throwable if an error occurs
          */
         void accept(T value) throws Throwable;
-    }
-
-    /**
-     * A {@linkplain java.util.function.Function} which may throw.
-     *
-     * @param <T> the type of the input to the function
-     * @param <R> the result type of the function
-     */
-    @FunctionalInterface
-    interface CheckedFunction<T, R> {
-
-        /**
-         * Applies this function to the given argument.
-         *
-         * @param t the function argument
-         * @return the function result
-         * @throws Throwable if an error occurs
-         */
-        R apply(T t) throws Throwable;
     }
 
     /**

--- a/vavr/src/test/java/io/vavr/concurrent/Concurrent.java
+++ b/vavr/src/test/java/io/vavr/concurrent/Concurrent.java
@@ -6,6 +6,7 @@
  */
 package io.vavr.concurrent;
 
+import io.vavr.CheckedFunction0;
 import io.vavr.control.Try;
 
 import java.util.Random;
@@ -51,14 +52,14 @@ final class Concurrent {
         Try.run(() -> Thread.sleep(RND.nextInt(SLEEP_MAX_MILLIS)));
     }
 
-    static <T> Try.CheckedSupplier<T> zZz(T value) {
+    static <T> CheckedFunction0<T> zZz(T value) {
         return () -> {
             zZz();
             return value;
         };
     }
 
-    static <T, X extends Throwable> Try.CheckedSupplier<T> zZz(X exception) {
+    static <T, X extends Throwable> CheckedFunction0<T> zZz(X exception) {
         return () -> {
             zZz();
             throw exception;

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -11,11 +11,8 @@ import static io.vavr.Predicates.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
+import io.vavr.*;
 import io.vavr.collection.Seq;
-import io.vavr.AbstractValueTest;
-import io.vavr.Function1;
-import io.vavr.PartialFunction;
-import io.vavr.Serializables;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
@@ -1481,7 +1478,7 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldNegateCheckedPredicate() {
-        final Try.CheckedPredicate<Integer> greaterThanZero = i -> i > 0;
+        final CheckedPredicate<Integer> greaterThanZero = i -> i > 0;
         final int num = 1;
         try {
             assertThat(greaterThanZero.test(num)).isTrue();

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -239,19 +239,19 @@ public class TryTest extends AbstractValueTest {
     // -- Try.of
 
     @Test
-    public void shouldCreateSuccessWhenCallingTryOfCheckedSupplier() {
+    public void shouldCreateSuccessWhenCallingTryOfCheckedFunction0() {
         assertThat(Try.of(() -> 1) instanceof Try.Success).isTrue();
     }
 
     @Test
-    public void shouldCreateFailureWhenCallingTryOfCheckedSupplier() {
+    public void shouldCreateFailureWhenCallingTryOfCheckedFunction0() {
         assertThat(Try.of(() -> {
             throw new Error("error");
         }) instanceof Try.Failure).isTrue();
     }
 
     @Test
-    public void shouldThrowNullPointerExceptionWhenCallingTryOfCheckedSupplier() {
+    public void shouldThrowNullPointerExceptionWhenCallingTryOfCheckedFunction0() {
         assertThatThrownBy(() -> Try.of(null)).isInstanceOf(NullPointerException.class).hasMessage("supplier is null");
     }
 


### PR DESCRIPTION
Hello, I replaced both Try.CheckedFunction  and Try.CheckedSupplier with CheckedFunction*.
I'm not sure if Try.CheckedRunnable, Try.CheckedPredicate or Try.CheckedConsumer should also be migrated to something different, please leave me feedback.