### PR TITLE
LinkedHashMap.put(existing key) should keep order #1838

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -701,14 +701,14 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public LinkedHashMap<K, V> put(K key, V value) {
-        Queue<Tuple2<K, V>> newList = list;
-        HashMap<K, V> newMap = map;
-        if (containsKey(key)) {
-            newList = newList.filter(t -> !Objects.equals(t._1, key));
-            newMap = newMap.remove(key);
+        final Queue<Tuple2<K, V>> newList;
+        final Option<V> currentEntry = get(key);
+        if (currentEntry.isDefined()) {
+            newList = list.replace(Tuple.of(key, currentEntry.get()), Tuple.of(key, value));
+        } else {
+            newList = list.append(Tuple.of(key, value));
         }
-        newList = newList.append(Tuple.of(key, value));
-        newMap = newMap.put(key, value);
+        final HashMap<K, V> newMap = map.put(key, value);
         return new LinkedHashMap<>(newList, newMap);
     }
 
@@ -901,7 +901,11 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        return Collections.equals(this, o);
+        if (o instanceof LinkedHashMap) {
+            return Collections.equals(this.list, ((LinkedHashMap<?, ?>) o).list);
+        } else {
+            return Collections.equals(this, o);
+        }
     }
 
     @Override

--- a/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
@@ -39,11 +39,15 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
             public IterableAssert<T> isEqualTo(Object obj) {
                 @SuppressWarnings("unchecked")
                 final Iterable<T> expected = (Iterable<T>) obj;
-                final java.util.Map<T, Integer> actualMap = countMap(actual);
-                final java.util.Map<T, Integer> expectedMap = countMap(expected);
-                assertThat(actualMap.size()).isEqualTo(expectedMap.size());
-                actualMap.forEach((k, v) -> assertThat(v).isEqualTo(expectedMap.get(k)));
-                return this;
+                if (actual instanceof LinkedHashMap && obj instanceof LinkedHashMap) {
+                    return super.isEqualTo(expected);
+                } else {
+                    final java.util.Map<T, Integer> actualMap = countMap(actual);
+                    final java.util.Map<T, Integer> expectedMap = countMap(expected);
+                    assertThat(actualMap.size()).isEqualTo(expectedMap.size());
+                    actualMap.forEach((k, v) -> assertThat(v).isEqualTo(expectedMap.get(k)));
+                    return this;
+                }
             }
 
             private java.util.Map<T, Integer> countMap(Iterable<? extends T> it) {

--- a/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
@@ -181,18 +181,23 @@ public class LinkedHashMapTest extends AbstractMapTest {
     // -- put
 
     @Test
-    public void shouldAppendToTheEndWhenPuttingAnExistingKeyAndNonExistingValue() {
+    public void shouldIgnoreOrderOfEntriesWhenComparingForEquality() {
+        // intentionally ignore this test
+    }
+
+    @Test
+    public void shouldKeepOrderWhenPuttingAnExistingKeyAndNonExistingValue() {
         final Map<Integer, String> map = mapOf(1, "a", 2, "b", 3, "c");
         final Map<Integer, String> actual = map.put(1, "d");
-        final Map<Integer, String> expected = mapOf(2, "b", 3, "c", 1, "d");
+        final Map<Integer, String> expected = mapOf(1, "d", 2, "b", 3, "c");
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
-    public void shouldAppendToTheEndWhenPuttingAnExistingKeyAndExistingValue() {
+    public void shouldKeepOrderWhenPuttingAnExistingKeyAndExistingValue() {
         final Map<Integer, String> map = mapOf(1, "a", 2, "b", 3, "c");
         final Map<Integer, String> actual = map.put(1, "a");
-        final Map<Integer, String> expected = mapOf(2, "b", 3, "c", 1, "a");
+        final Map<Integer, String> expected = mapOf(1, "a", 2, "b", 3, "c");
         assertThat(actual).isEqualTo(expected);
     }
 


### PR DESCRIPTION
Also equality of `LinkedHashMap` with `LinkedHashMap` fixed (see #1555)