### PR TITLE
Removes Value.getOption

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1512,7 +1512,7 @@ def generateMainClasses(): Unit = {
                     val supplier = if (!checked && i == 0) s"$func::get" else if (checked && i == 0) s"$func::apply" else s"() -> $func.apply($params)"
                     val lambdaArgs = if (i == 1) params else s"($params)"
                     xs"""
-                      return $lambdaArgs -> ${im.getType("io.vavr.control.Try")}.<R>of($supplier).getOption();
+                      return $lambdaArgs -> ${im.getType("io.vavr.control.Try")}.<R>of($supplier).toOption();
                     """
                   }
               }

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction0.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction0.java
@@ -77,7 +77,7 @@ public interface CheckedFunction0<R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <R> Function0<Option<R>> lift(CheckedFunction0<? extends R> partialFunction) {
-        return () -> Try.<R>of(partialFunction::apply).getOption();
+        return () -> Try.<R>of(partialFunction::apply).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
@@ -81,7 +81,7 @@ public interface CheckedFunction1<T1, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, R> Function1<T1, Option<R>> lift(CheckedFunction1<? super T1, ? extends R> partialFunction) {
-        return t1 -> Try.<R>of(() -> partialFunction.apply(t1)).getOption();
+        return t1 -> Try.<R>of(() -> partialFunction.apply(t1)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
@@ -85,7 +85,7 @@ public interface CheckedFunction2<T1, T2, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, R> Function2<T1, T2, Option<R>> lift(CheckedFunction2<? super T1, ? super T2, ? extends R> partialFunction) {
-        return (t1, t2) -> Try.<R>of(() -> partialFunction.apply(t1, t2)).getOption();
+        return (t1, t2) -> Try.<R>of(() -> partialFunction.apply(t1, t2)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
@@ -87,7 +87,7 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, R> Function3<T1, T2, T3, Option<R>> lift(CheckedFunction3<? super T1, ? super T2, ? super T3, ? extends R> partialFunction) {
-        return (t1, t2, t3) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3)).getOption();
+        return (t1, t2, t3) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
@@ -90,7 +90,7 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, T4, R> Function4<T1, T2, T3, T4, Option<R>> lift(CheckedFunction4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> partialFunction) {
-        return (t1, t2, t3, t4) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4)).getOption();
+        return (t1, t2, t3, t4) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
@@ -93,7 +93,7 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, T4, T5, R> Function5<T1, T2, T3, T4, T5, Option<R>> lift(CheckedFunction5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> partialFunction) {
-        return (t1, t2, t3, t4, t5) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5)).getOption();
+        return (t1, t2, t3, t4, t5) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
@@ -96,7 +96,7 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, T4, T5, T6, R> Function6<T1, T2, T3, T4, T5, T6, Option<R>> lift(CheckedFunction6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> partialFunction) {
-        return (t1, t2, t3, t4, t5, t6) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6)).getOption();
+        return (t1, t2, t3, t4, t5, t6) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
@@ -99,7 +99,7 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, T4, T5, T6, T7, R> Function7<T1, T2, T3, T4, T5, T6, T7, Option<R>> lift(CheckedFunction7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> partialFunction) {
-        return (t1, t2, t3, t4, t5, t6, t7) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6, t7)).getOption();
+        return (t1, t2, t3, t4, t5, t6, t7) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6, t7)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
@@ -102,7 +102,7 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lam
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function8<T1, T2, T3, T4, T5, T6, T7, T8, Option<R>> lift(CheckedFunction8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> partialFunction) {
-        return (t1, t2, t3, t4, t5, t6, t7, t8) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6, t7, t8)).getOption();
+        return (t1, t2, t3, t4, t5, t6, t7, t8) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6, t7, t8)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function0.java
+++ b/vavr/src-gen/main/java/io/vavr/Function0.java
@@ -77,7 +77,7 @@ public interface Function0<R> extends Lambda<R>, Supplier<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <R> Function0<Option<R>> lift(Supplier<? extends R> partialFunction) {
-        return () -> Try.<R>of(partialFunction::get).getOption();
+        return () -> Try.<R>of(partialFunction::get).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -82,7 +82,7 @@ public interface Function1<T1, R> extends Lambda<R>, Function<T1, R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, R> Function1<T1, Option<R>> lift(Function<? super T1, ? extends R> partialFunction) {
-        return t1 -> Try.<R>of(() -> partialFunction.apply(t1)).getOption();
+        return t1 -> Try.<R>of(() -> partialFunction.apply(t1)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function2.java
+++ b/vavr/src-gen/main/java/io/vavr/Function2.java
@@ -85,7 +85,7 @@ public interface Function2<T1, T2, R> extends Lambda<R>, BiFunction<T1, T2, R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, R> Function2<T1, T2, Option<R>> lift(BiFunction<? super T1, ? super T2, ? extends R> partialFunction) {
-        return (t1, t2) -> Try.<R>of(() -> partialFunction.apply(t1, t2)).getOption();
+        return (t1, t2) -> Try.<R>of(() -> partialFunction.apply(t1, t2)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function3.java
+++ b/vavr/src-gen/main/java/io/vavr/Function3.java
@@ -87,7 +87,7 @@ public interface Function3<T1, T2, T3, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, R> Function3<T1, T2, T3, Option<R>> lift(Function3<? super T1, ? super T2, ? super T3, ? extends R> partialFunction) {
-        return (t1, t2, t3) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3)).getOption();
+        return (t1, t2, t3) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function4.java
+++ b/vavr/src-gen/main/java/io/vavr/Function4.java
@@ -90,7 +90,7 @@ public interface Function4<T1, T2, T3, T4, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, T4, R> Function4<T1, T2, T3, T4, Option<R>> lift(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> partialFunction) {
-        return (t1, t2, t3, t4) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4)).getOption();
+        return (t1, t2, t3, t4) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function5.java
+++ b/vavr/src-gen/main/java/io/vavr/Function5.java
@@ -93,7 +93,7 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, T4, T5, R> Function5<T1, T2, T3, T4, T5, Option<R>> lift(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> partialFunction) {
-        return (t1, t2, t3, t4, t5) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5)).getOption();
+        return (t1, t2, t3, t4, t5) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function6.java
+++ b/vavr/src-gen/main/java/io/vavr/Function6.java
@@ -96,7 +96,7 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, T4, T5, T6, R> Function6<T1, T2, T3, T4, T5, T6, Option<R>> lift(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> partialFunction) {
-        return (t1, t2, t3, t4, t5, t6) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6)).getOption();
+        return (t1, t2, t3, t4, t5, t6) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function7.java
+++ b/vavr/src-gen/main/java/io/vavr/Function7.java
@@ -99,7 +99,7 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<R> {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, T4, T5, T6, T7, R> Function7<T1, T2, T3, T4, T5, T6, T7, Option<R>> lift(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> partialFunction) {
-        return (t1, t2, t3, t4, t5, t6, t7) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6, t7)).getOption();
+        return (t1, t2, t3, t4, t5, t6, t7) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6, t7)).toOption();
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function8.java
+++ b/vavr/src-gen/main/java/io/vavr/Function8.java
@@ -102,7 +102,7 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lambda<R> 
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function8<T1, T2, T3, T4, T5, T6, T7, T8, Option<R>> lift(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> partialFunction) {
-        return (t1, t2, t3, t4, t5, t6, t7, t8) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6, t7, t8)).getOption();
+        return (t1, t2, t3, t4, t5, t6, t7, t8) -> Try.<R>of(() -> partialFunction.apply(t1, t2, t3, t4, t5, t6, t7, t8)).toOption();
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/Value.java
+++ b/vavr/src/main/java/io/vavr/Value.java
@@ -40,7 +40,6 @@ import static io.vavr.API.*;
  *
  * <ul>
  * <li>{@link #get()}</li>
- * <li>{@link #getOption()}</li>
  * <li>{@link #getOrElse(Object)}</li>
  * <li>{@link #getOrElse(Supplier)}</li>
  * <li>{@link #getOrElseThrow(Supplier)}</li>
@@ -327,22 +326,11 @@ public interface Value<T> extends Iterable<T> {
      * However, there exist use-cases, where implementations may throw other exceptions. See {@link Try#get()}.
      * <p>
      * <strong>Additional note:</strong> Dynamic proxies will wrap an undeclared exception in a {@link java.lang.reflect.UndeclaredThrowableException}.
-     * <p>
-     * <strong>Hint:</strong> A safe variant of {@code get()} is {@link #getOption()}.
      *
      * @return the underlying value if this is not empty, otherwise {@code get()} throws a {@code Throwable}
      */
     T get();
-
-    /**
-     * Gets the underlying value as Option.
-     *
-     * @return Some(value) if a value is present, None otherwise
-     */
-    default Option<T> getOption() {
-        return isEmpty() ? Option.none() : Option.some(get());
-    }
-
+    
     /**
      * Returns the underlying value if present, otherwise {@code other}.
      *
@@ -944,7 +932,7 @@ public interface Value<T> extends Iterable<T> {
         if (this instanceof Option) {
             return (Option<T>) this;
         } else {
-            return getOption();
+            return isEmpty() ? Option.none() : Option.some(get());
         }
     }
 

--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -252,11 +252,6 @@ public interface Option<T> extends Value<T>, Serializable {
     @Override
     T get();
 
-    @Override
-    default Option<T> getOption() {
-        return this;
-    }
-
     /**
      * Returns the value if this is a {@code Some} or the {@code other} value if this is a {@code None}.
      * <p>

--- a/vavr/src/test/java/io/vavr/AbstractValueTest.java
+++ b/vavr/src/test/java/io/vavr/AbstractValueTest.java
@@ -98,19 +98,7 @@ public abstract class AbstractValueTest {
     public void shouldGetNonEmpty() {
         assertThat(of(1).get()).isEqualTo(1);
     }
-
-    // -- getOption()
-
-    @Test
-    public void shouldGetOptionEmpty() {
-        assertThat(empty().getOption()).isEqualTo(Option.none());
-    }
-
-    @Test
-    public void shouldGetOptionNonEmpty() {
-        assertThat(of(1).getOption()).isEqualTo(Option.of(1));
-    }
-
+    
     // -- getOrElse(T)
 
     @Test


### PR DESCRIPTION
...in favor of `toOption()`. Both methods had the same semantics.