### PR TITLE
fix gwt again

### DIFF
--- a/vavr/src/main/java/io/vavr/Predicates.java
+++ b/vavr/src/main/java/io/vavr/Predicates.java
@@ -33,6 +33,7 @@ public final class Predicates {
      * @throws NullPointerException if {@code type} is null
      */
     // DEV-NOTE: We need Class<? extends T> instead of Class<T>, see {@link TryTest#shouldRecoverSuccessUsingCase()}
+    @GwtIncompatible
     public static <T> Predicate<T> instanceOf(Class<? extends T> type) {
         Objects.requireNonNull(type, "type is null");
         return obj -> obj != null && type.isAssignableFrom(obj.getClass());

--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -595,22 +595,26 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
             return wrap(arr);
         }
     }
-    
+
+    @GwtIncompatible
     @Override
     public java.util.List<T> asJava() {
         return JavaConverters.asJava(this, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public Array<T> asJava(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public java.util.List<T> asJavaMutable() {
         return JavaConverters.asJava(this, MUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public Array<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, MUTABLE);

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -388,21 +388,25 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
         return of(sb);
     }
 
+    @GwtIncompatible
     @Override
     public java.util.List<Character> asJava() {
         return JavaConverters.asJava(this, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public CharSeq asJava(Consumer<? super java.util.List<Character>> action) {
         return Collections.asJava(this, action, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public java.util.List<Character> asJavaMutable() {
         return JavaConverters.asJava(this, MUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public CharSeq asJavaMutable(Consumer<? super java.util.List<Character>> action) {
         return Collections.asJava(this, action, MUTABLE);

--- a/vavr/src/main/java/io/vavr/collection/Collections.java
+++ b/vavr/src/main/java/io/vavr/collection/Collections.java
@@ -34,6 +34,7 @@ final class Collections {
         return iter1.hasNext() == iter2.hasNext();
     }
 
+    @GwtIncompatible
     static <T, C extends Seq<T>> C asJava(C source, Consumer<? super java.util.List<T>> action, ChangePolicy changePolicy) {
         Objects.requireNonNull(action, "action is null");
         final ListView<T, C> view = JavaConverters.asJava(source, changePolicy);

--- a/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
@@ -50,9 +50,11 @@ public interface IndexedSeq<T> extends Seq<T> {
     @Override
     IndexedSeq<T> appendAll(Iterable<? extends T> elements);
 
+    @GwtIncompatible
     @Override
     IndexedSeq<T> asJava(Consumer<? super java.util.List<T>> action);
 
+    @GwtIncompatible
     @Override
     IndexedSeq<T> asJavaMutable(Consumer<? super java.util.List<T>> action);
 

--- a/vavr/src/main/java/io/vavr/collection/JavaConverters.java
+++ b/vavr/src/main/java/io/vavr/collection/JavaConverters.java
@@ -24,6 +24,7 @@ class JavaConverters {
     private JavaConverters() {
     }
 
+    @GwtIncompatible
     static <T, C extends Seq<T>> ListView<T, C> asJava(C seq, ChangePolicy changePolicy) {
         return new ListView<>(seq, changePolicy.isMutable());
     }
@@ -87,6 +88,7 @@ class JavaConverters {
         }
     }
 
+    @GwtIncompatible("reflection is not supported")
     static class ListView<T, C extends Seq<T>> extends HasDelegate<C> implements java.util.List<T> {
 
         private static final long serialVersionUID = 1L;
@@ -242,7 +244,6 @@ class JavaConverters {
             return getDelegate().toJavaArray();
         }
 
-        @GwtIncompatible("reflection is not supported")
         @SuppressWarnings("unchecked")
         @Override
         public <U> U[] toArray(U[] array) {

--- a/vavr/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/LinearSeq.java
@@ -49,9 +49,11 @@ public interface LinearSeq<T> extends Seq<T> {
     @Override
     LinearSeq<T> appendAll(Iterable<? extends T> elements);
 
+    @GwtIncompatible
     @Override
     LinearSeq<T> asJava(Consumer<? super java.util.List<T>> action);
 
+    @GwtIncompatible
     @Override
     LinearSeq<T> asJavaMutable(Consumer<? super java.util.List<T>> action);
 

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -722,21 +722,25 @@ public interface List<T> extends LinearSeq<T> {
         return List.<T> ofAll(elements).prependAll(this);
     }
 
+    @GwtIncompatible
     @Override
     default java.util.List<T> asJava() {
         return JavaConverters.asJava(this, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     default List<T> asJava(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     default java.util.List<T> asJavaMutable() {
         return JavaConverters.asJava(this, MUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     default List<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, MUTABLE);

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -649,21 +649,25 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
         return enqueueAll(elements);
     }
 
+    @GwtIncompatible
     @Override
     public java.util.List<T> asJava() {
         return JavaConverters.asJava(this, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public Queue<T> asJava(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public java.util.List<T> asJavaMutable() {
         return JavaConverters.asJava(this, MUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public Queue<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, MUTABLE);

--- a/vavr/src/main/java/io/vavr/collection/Seq.java
+++ b/vavr/src/main/java/io/vavr/collection/Seq.java
@@ -157,6 +157,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T>, Serializa
      *
      * @return A new immutable {@link java.util.Collection} view on this {@code Traversable}.
      */
+    @GwtIncompatible
     java.util.List<T> asJava();
 
     /**
@@ -167,6 +168,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T>, Serializa
      * @return this instance
      * @see Seq#asJava()
      */
+    @GwtIncompatible
     Seq<T> asJava(Consumer<? super java.util.List<T>> action);
 
     /**
@@ -176,6 +178,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T>, Serializa
      * @return A new mutable {@link java.util.Collection} view on this {@code Traversable}.
      * @see Seq#asJava()
      */
+    @GwtIncompatible
     java.util.List<T> asJavaMutable();
 
     /**
@@ -186,6 +189,7 @@ public interface Seq<T> extends Traversable<T>, Function1<Integer, T>, Serializa
      * @return this instance, if only read operations are performed on the {@code java.util.List} view or a new instance of this type, if write operations are performed on the {@code java.util.List} view.
      * @see Seq#asJavaMutable()
      */
+    @GwtIncompatible
     Seq<T> asJavaMutable(Consumer<? super java.util.List<T>> action);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -822,21 +822,25 @@ public interface Stream<T> extends LinearSeq<T> {
         return isEmpty() ? this : new AppendSelf<>((Cons<T>) this, mapper).stream();
     }
 
+    @GwtIncompatible
     @Override
     default java.util.List<T> asJava() {
         return JavaConverters.asJava(this, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     default Stream<T> asJava(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     default java.util.List<T> asJavaMutable() {
         return JavaConverters.asJava(this, MUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     default Stream<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, MUTABLE);

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -599,21 +599,25 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
         }
     }
 
+    @GwtIncompatible
     @Override
     public java.util.List<T> asJava() {
         return JavaConverters.asJava(this, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public Vector<T> asJava(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, IMMUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public java.util.List<T> asJavaMutable() {
         return JavaConverters.asJava(this, MUTABLE);
     }
 
+    @GwtIncompatible
     @Override
     public Vector<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, MUTABLE);


### PR DESCRIPTION
See vavr-io/vavr-gwt-example#3

Actually all errors finds each time in the first stage of compilation.
```
[INFO]    Ignored 10 units with compilation errors in first pass.
[INFO] Compile with -strict or with -logLevel set to TRACE or DEBUG to see all errors.
```
Two of these "`Ignored 10 units`" are `Predicates` and `JavaConverters`. But because of very bad tests coverage, at the second stage of compilation GWT includes in dead code all problem methods. And all tests passes.