### PR TITLE
improve ConcatIterator

### DIFF
--- a/vavr-benchmark/src/test/java/io/vavr/collection/IteratorBenchmark.java
+++ b/vavr-benchmark/src/test/java/io/vavr/collection/IteratorBenchmark.java
@@ -74,7 +74,7 @@ public class IteratorBenchmark {
     @State(Scope.Benchmark)
     public static class Concat {
 
-        @Param({ "10", "20" /*, "100", "1000"*/ })
+        @Param({ "10", "20" , "100", "1000" })
         private int size;
 
         @Benchmark

--- a/vavr/src/main/java/io/vavr/collection/Iterator.java
+++ b/vavr/src/main/java/io/vavr/collection/Iterator.java
@@ -64,7 +64,11 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
         if (iterables.length == 0) {
             return empty();
         } else {
-            return new ConcatIterator<>(Stream.of(iterables).map(Iterator::ofAll).iterator());
+            ConcatIterator<T> res = new ConcatIterator<>();
+            for (Iterable<? extends T> iterable : iterables) {
+                res.append(iterable.iterator());
+            }
+            return res;
         }
     }
 
@@ -80,7 +84,11 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
         if (!iterables.iterator().hasNext()) {
             return empty();
         } else {
-            return new ConcatIterator<>(Stream.ofAll(iterables).map(Iterator::ofAll).iterator());
+            ConcatIterator<T> res = new ConcatIterator<>();
+            for (Iterable<? extends T> iterable : iterables) {
+                res.append(iterable.iterator());
+            }
+            return res;
         }
     }
 
@@ -1995,26 +2003,87 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
 
 interface IteratorModule {
 
+    // inspired by Scala's ConcatIterator
     final class ConcatIterator<T> extends AbstractIterator<T> {
 
-        private final Iterator<? extends Iterator<? extends T>> iterators;
-        private Iterator<? extends T> current = Iterator.empty();
+        private static class Cell<T> {
 
-        ConcatIterator(Iterator<? extends Iterator<? extends T>> iterators) {
-            this.iterators = iterators;
+            Iterator<T> it;
+            Cell<T> next;
+
+            static <T> Cell<T> of(Iterator<T> it) {
+                Cell<T> cell = new Cell<>();
+                cell.it = it;
+                return cell;
+            }
+
+            Cell<T> append(Iterator<T> it) {
+                Cell<T> cell = of(it);
+                next = cell;
+                return cell;
+            }
+
+            Cell<T> prepend(Iterator<T> it) {
+                Cell<T> cell = of(it);
+                cell.next = this;
+                return cell;
+            }
+        }
+
+        private Iterator<T> curr;
+
+        private Cell<T> tail;
+        private Cell<T> last;
+
+        private boolean hasNextCalculated;
+
+        void append(java.util.Iterator<? extends T> that) {
+            Iterator<T> it = Iterator.ofAll(that);
+            if (tail == null) {
+                tail = last = Cell.of(it);
+            } else {
+                last = last.append(Iterator.ofAll(that));
+            }
+        }
+
+        @Override
+        public Iterator<T> concat(java.util.Iterator<? extends T> that) {
+            append(that);
+            return this;
         }
 
         @Override
         public boolean hasNext() {
-            while (!current.hasNext() && !iterators.isEmpty()) {
-                current = iterators.next();
+            if (hasNextCalculated) {
+                return curr != null;
             }
-            return current.hasNext();
+            hasNextCalculated = true;
+            while(true) {
+                if (curr != null) {
+                    if (curr.hasNext()) {
+                        return true;
+                    } else {
+                        curr = null;
+                    }
+                }
+                if (tail == null) {
+                    return false;
+                }
+                curr = tail.it;
+                tail = tail.next;
+                while (curr instanceof ConcatIterator) {
+                    ConcatIterator<T> it = (ConcatIterator<T>) curr;
+                    curr = it.curr;
+                    it.last.next = tail;
+                    tail = it.tail;
+                }
+            }
         }
 
         @Override
         public T getNext() {
-            return current.next();
+            hasNextCalculated = false;
+            return curr.next();
         }
     }
 

--- a/vavr/src/main/java/io/vavr/collection/Iterator.java
+++ b/vavr/src/main/java/io/vavr/collection/Iterator.java
@@ -2022,12 +2022,6 @@ interface IteratorModule {
                 next = cell;
                 return cell;
             }
-
-            Cell<T> prepend(Iterator<T> it) {
-                Cell<T> cell = of(it);
-                cell.next = this;
-                return cell;
-            }
         }
 
         private Iterator<T> curr;
@@ -2038,11 +2032,11 @@ interface IteratorModule {
         private boolean hasNextCalculated;
 
         void append(java.util.Iterator<? extends T> that) {
-            Iterator<T> it = Iterator.ofAll(that);
+            final Iterator<T> it = Iterator.ofAll(that);
             if (tail == null) {
                 tail = last = Cell.of(it);
             } else {
-                last = last.append(Iterator.ofAll(that));
+                last = last.append(it);
             }
         }
 

--- a/vavr/src/test/java/io/vavr/collection/IteratorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/IteratorTest.java
@@ -267,6 +267,17 @@ public class IteratorTest extends AbstractTraversableTest {
         assertThat(concat(List.of(1, 2), List.of(3))).isEqualTo(Iterator.of(1, 2, 3));
     }
 
+    @Test
+    public void shouldConcatNetedConcatIterators() {
+        assertThat(concat(List.of(1, 2), List.of(3), concat(List.of(4, 5)))).isEqualTo(Iterator.of(1, 2, 3, 4, 5));
+        assertThat(concat(concat(List.of(4, 5)), List.of(1, 2), List.of(3))).isEqualTo(Iterator.of(4, 5, 1, 2, 3));
+    }
+
+    @Test
+    public void shouldConcatToConcatIterator() {
+        assertThat(concat(List.of(1, 2)).concat(List.of(3).iterator())).isEqualTo(Iterator.of(1, 2, 3));
+    }
+
     // -- concat
 
     @Test
@@ -451,6 +462,7 @@ public class IteratorTest extends AbstractTraversableTest {
         multipleHasNext(() -> Iterator.ofAll(Iterator.of(1, 2, 3).toJavaList().iterator()));
         multipleHasNext(() -> Iterator.ofAll(Iterator.of(1, 2, 3).toJavaList()));
 
+        multipleHasNext(() -> Iterator.concat(List.of(Iterator.empty(), Iterator.of(1, 2, 3))));
         multipleHasNext(() -> Iterator.concat(List.of(Iterator.of(1, 2, 3), Iterator.of(1, 2, 3))));
         multipleHasNext(() -> Iterator.concat(Iterator.of(1, 2, 3), Iterator.of(1, 2, 3)));
         multipleHasNext(() -> Iterator.continually(() -> 1), 5);


### PR DESCRIPTION
See #2005 
```
Target             Impl                  Params  Count            Score  ±     Error    Unit  scala_persistent  vavr_persistent
IteratorBenchmark  scala_persistent          10      5     2,516,805.84  ±     5.65%   ops/s                             0.89×
IteratorBenchmark  scala_persistent          20      5     1,412,594.83  ±     9.46%   ops/s                             0.77×
IteratorBenchmark  scala_persistent         100      5       286,046.91  ±     1.46%   ops/s                             0.72×
IteratorBenchmark  scala_persistent        1000      5        28,910.28  ±    72.00%   ops/s                             0.73×
IteratorBenchmark  vavr_persistent           10      5     2,820,759.98  ±     4.30%   ops/s            1.12×                 
IteratorBenchmark  vavr_persistent           20      5     1,825,800.14  ±     7.18%   ops/s            1.29×                 
IteratorBenchmark  vavr_persistent          100      5       399,723.11  ±     1.46%   ops/s            1.40×                 
IteratorBenchmark  vavr_persistent         1000      5        39,369.96  ±     3.55%   ops/s            1.36×                 
```

@nfekete please review