### PR TITLE
Add a fold operation to Option

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -361,6 +361,18 @@ public interface Option<T> extends Value<T>, Serializable {
     }
 
     /**
+     * Folds either the {@code None} or the {@code Some} side of the Option value.
+     *
+     * @param ifNone  maps the left value if this is a None
+     * @param f maps the value if this is a Some
+     * @param <U>         type of the folded value
+     * @return A value of type U
+     */
+    default <U> U fold(Supplier<? extends U> ifNone, Function<? super T, ? extends U> f) {
+        return this.<U>map(f).getOrElse(ifNone);
+    }
+
+    /**
      * Applies an action to this value, if this option is defined, otherwise does nothing.
      *
      * @param action An action which can be applied to an optional value

--- a/vavr/src/test/java/io/vavr/control/OptionTest.java
+++ b/vavr/src/test/java/io/vavr/control/OptionTest.java
@@ -616,4 +616,22 @@ public class OptionTest extends AbstractValueTest {
     public void shouldReturnSizeWhenSpliterator() {
         assertThat(of(1).spliterator().getExactSizeIfKnown()).isEqualTo(1);
     }
+
+    @Test
+    public void foldStringToInt() {
+        assertThat(Option.some("1").fold(() -> -1, Integer::valueOf)).isEqualTo(1);
+        assertThat(Option.<String>none().fold(() -> -1, Integer::valueOf)).isEqualTo(-1);
+    }
+
+    @Test
+    public void foldEither() {
+        Either<String, Integer> right = Option.some(1).fold(() -> {
+            throw new AssertionError("Must not happen");
+        }, Either::right);
+        Either<String, Integer> left = Option.<Integer>none().fold(() -> Either.left("Empty"), ignore -> {
+            throw new AssertionError("Must not happen");
+        });
+        assertThat(right.get()).isEqualTo(1);
+        assertThat(left.getLeft()).isEqualTo("Empty");
+    }
 }


### PR DESCRIPTION
This is useful whenever you need to handle both cases of an option.
This is implemented in terms of map and getOrElse, but most operations
on Option could be implemented in terms of fold. Then the implementation
would of course be different.