### PR TITLE
Let PartialFunction extend Function1

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1485,6 +1485,19 @@ def generateMainClasses(): Unit = {
                * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
                */
               long serialVersionUID = 1L;
+              
+              /$javadoc
+               * Returns a function that always returns the constant
+               * value that you give in parameter.
+               *
+               ${(1 to i).gen(j => s"* @param <T$j> generic parameter type $j of the resulting function")("\n")}
+               * @param <R> the result type
+               * @param value the value to be returned
+               * @return a function always returning the given value
+               */
+              static $fullGenerics $className$fullGenerics constant(R value) {
+                  return ($params) -> value;
+              }
 
               /$javadoc
                * Creates a {@code $className} based on
@@ -1627,19 +1640,6 @@ def generateMainClasses(): Unit = {
               @Override
               default int arity() {
                   return $i;
-              }
-
-              /**
-               * Returns a function that always returns the constant
-               * value that you give in parameter.
-               *
-               ${(1 to i).gen(j => s"* @param <T$j> generic parameter type $j of the resulting function")("\n")}
-               * @param <R> the result type
-               * @param value the value to be returned
-               * @return a function always returning the given value
-               */
-              static $fullGenerics $className$fullGenerics constant(R value) {
-                  return ($params) -> value;
               }
 
               @Override

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -820,7 +820,7 @@ def generateMainClasses(): Unit = {
         """
       }
 
-      def genMatch(im: ImportManager, packageName: String, className: String): String = {
+      def genMatch(im: ImportManager, packageName: String, className: String): String =
         xs"""
           //
           // Structural Pattern Matching
@@ -923,6 +923,9 @@ def generateMainClasses(): Unit = {
           @GwtIncompatible
           public static <T> Pattern0<T> $$(T prototype) {
               return new Pattern0<T>() {
+
+                  private static final long serialVersionUID = 1L;
+
                   @Override
                   public T apply(T obj) {
                       return obj;
@@ -995,6 +998,9 @@ def generateMainClasses(): Unit = {
           public static <T> Pattern0<T> $$($PredicateType<? super T> predicate) {
               $Objects.requireNonNull(predicate, "predicate is null");
               return new Pattern0<T>() {
+
+                  private static final long serialVersionUID = 1L;
+
                   @Override
                   public T apply(T obj) {
                       return obj;
@@ -1050,9 +1056,16 @@ def generateMainClasses(): Unit = {
 
               // javac needs fqn's here
               public interface Case<T, R> extends $PartialFunctionType<T, R> {
+
+                  /**
+                   * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+                   */
+                  long serialVersionUID = 1L;
               }
 
               public static final class Case0<T, R> implements Case<T, R> {
+
+                  private static final long serialVersionUID = 1L;
 
                   private final Pattern0<T> pattern;
                   private final $FunctionType<? super T, ? extends R> f;
@@ -1083,6 +1096,8 @@ def generateMainClasses(): Unit = {
                 }
                 xs"""
                   public static final class Case$i<T, $generics, R> implements Case<T, R> {
+
+                      private static final long serialVersionUID = 1L;
 
                       private final Pattern$i<T, $generics> pattern;
                       private final $functionType<$argTypes, ? extends R> f;
@@ -1127,7 +1142,12 @@ def generateMainClasses(): Unit = {
 
               public static abstract class Pattern0<T> implements Pattern<T, T> {
 
+                  private static final long serialVersionUID = 1L;
+
                   private static final Pattern0<Object> ANY = new Pattern0<Object>() {
+
+                      private static final long serialVersionUID = 1L;
+
                       @Override
                       public Object apply(Object obj) {
                           return obj;
@@ -1149,6 +1169,9 @@ def generateMainClasses(): Unit = {
                   //           possible: `Pattern0<Some<String>> p = Pattern0.of(Some.class);`
                   public static <T> Pattern0<T> of(Class<? super T> type) {
                       return new Pattern0<T>() {
+
+                          private static final long serialVersionUID = 1L;
+
                           @Override
                           public T apply(T obj) {
                               return obj;
@@ -1159,9 +1182,6 @@ def generateMainClasses(): Unit = {
                               return obj != null && type.isAssignableFrom(obj.getClass());
                           }
                       };
-                  }
-
-                  private Pattern0() {
                   }
               }
 
@@ -1175,8 +1195,13 @@ def generateMainClasses(): Unit = {
                 xs"""
                   public static abstract class Pattern$i<T, $resultGenerics> implements Pattern<T, $resultType> {
 
+                      private static final long serialVersionUID = 1L;
+
                       public static <T, $declaredGenerics> Pattern$i<T, $resultGenerics> of(Class<? super T> type, $args, Function<T, $unapplyTupleType> unapply) {
                           return new Pattern$i<T, $resultGenerics>() {
+
+                              private static final long serialVersionUID = 1L;
+
                               @SuppressWarnings("unchecked")
                               @Override
                               public $resultType apply(T obj) {
@@ -1205,7 +1230,6 @@ def generateMainClasses(): Unit = {
               })("\n\n")}
           }
         """
-      }
 
       def genShortcuts(im: ImportManager, packageName: String, className: String): String = {
 
@@ -1667,10 +1691,14 @@ def generateMainClasses(): Unit = {
                     Objects.requireNonNull(isDefinedAt, "isDefinedAt is null");
                     final Function1<T1, R> self = this;
                     return new PartialFunction<T1, R>() {
+
+                        private static final long serialVersionUID = 1L;
+
                         @Override
                         public boolean isDefinedAt(T1 t1) {
                             return isDefinedAt.test(t1);
                         }
+
                         @Override
                         public R apply(T1 t1) {
                           return self.apply(t1);

--- a/vavr/src-gen/main/java/io/vavr/API.java
+++ b/vavr/src-gen/main/java/io/vavr/API.java
@@ -3030,6 +3030,9 @@ public final class API {
     @GwtIncompatible
     public static <T> Pattern0<T> $(T prototype) {
         return new Pattern0<T>() {
+
+            private static final long serialVersionUID = 1L;
+
             @Override
             public T apply(T obj) {
                 return obj;
@@ -3102,6 +3105,9 @@ public final class API {
     public static <T> Pattern0<T> $(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return new Pattern0<T>() {
+
+            private static final long serialVersionUID = 1L;
+
             @Override
             public T apply(T obj) {
                 return obj;
@@ -3157,9 +3163,16 @@ public final class API {
 
         // javac needs fqn's here
         public interface Case<T, R> extends PartialFunction<T, R> {
+
+            /**
+             * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+             */
+            long serialVersionUID = 1L;
         }
 
         public static final class Case0<T, R> implements Case<T, R> {
+
+            private static final long serialVersionUID = 1L;
 
             private final Pattern0<T> pattern;
             private final Function<? super T, ? extends R> f;
@@ -3182,6 +3195,8 @@ public final class API {
 
         public static final class Case1<T, T1, R> implements Case<T, R> {
 
+            private static final long serialVersionUID = 1L;
+
             private final Pattern1<T, T1> pattern;
             private final Function<? super T1, ? extends R> f;
 
@@ -3202,6 +3217,8 @@ public final class API {
         }
 
         public static final class Case2<T, T1, T2, R> implements Case<T, R> {
+
+            private static final long serialVersionUID = 1L;
 
             private final Pattern2<T, T1, T2> pattern;
             private final BiFunction<? super T1, ? super T2, ? extends R> f;
@@ -3224,6 +3241,8 @@ public final class API {
 
         public static final class Case3<T, T1, T2, T3, R> implements Case<T, R> {
 
+            private static final long serialVersionUID = 1L;
+
             private final Pattern3<T, T1, T2, T3> pattern;
             private final Function3<? super T1, ? super T2, ? super T3, ? extends R> f;
 
@@ -3244,6 +3263,8 @@ public final class API {
         }
 
         public static final class Case4<T, T1, T2, T3, T4, R> implements Case<T, R> {
+
+            private static final long serialVersionUID = 1L;
 
             private final Pattern4<T, T1, T2, T3, T4> pattern;
             private final Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f;
@@ -3266,6 +3287,8 @@ public final class API {
 
         public static final class Case5<T, T1, T2, T3, T4, T5, R> implements Case<T, R> {
 
+            private static final long serialVersionUID = 1L;
+
             private final Pattern5<T, T1, T2, T3, T4, T5> pattern;
             private final Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f;
 
@@ -3286,6 +3309,8 @@ public final class API {
         }
 
         public static final class Case6<T, T1, T2, T3, T4, T5, T6, R> implements Case<T, R> {
+
+            private static final long serialVersionUID = 1L;
 
             private final Pattern6<T, T1, T2, T3, T4, T5, T6> pattern;
             private final Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f;
@@ -3308,6 +3333,8 @@ public final class API {
 
         public static final class Case7<T, T1, T2, T3, T4, T5, T6, T7, R> implements Case<T, R> {
 
+            private static final long serialVersionUID = 1L;
+
             private final Pattern7<T, T1, T2, T3, T4, T5, T6, T7> pattern;
             private final Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f;
 
@@ -3328,6 +3355,8 @@ public final class API {
         }
 
         public static final class Case8<T, T1, T2, T3, T4, T5, T6, T7, T8, R> implements Case<T, R> {
+
+            private static final long serialVersionUID = 1L;
 
             private final Pattern8<T, T1, T2, T3, T4, T5, T6, T7, T8> pattern;
             private final Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f;
@@ -3366,7 +3395,12 @@ public final class API {
 
         public static abstract class Pattern0<T> implements Pattern<T, T> {
 
+            private static final long serialVersionUID = 1L;
+
             private static final Pattern0<Object> ANY = new Pattern0<Object>() {
+
+                private static final long serialVersionUID = 1L;
+
                 @Override
                 public Object apply(Object obj) {
                     return obj;
@@ -3388,6 +3422,9 @@ public final class API {
             //           possible: `Pattern0<Some<String>> p = Pattern0.of(Some.class);`
             public static <T> Pattern0<T> of(Class<? super T> type) {
                 return new Pattern0<T>() {
+
+                    private static final long serialVersionUID = 1L;
+
                     @Override
                     public T apply(T obj) {
                         return obj;
@@ -3399,15 +3436,17 @@ public final class API {
                     }
                 };
             }
-
-            private Pattern0() {
-            }
         }
 
         public static abstract class Pattern1<T, T1> implements Pattern<T, T1> {
 
+            private static final long serialVersionUID = 1L;
+
             public static <T, T1 extends U1, U1> Pattern1<T, T1> of(Class<? super T> type, Pattern<T1, ?> p1, Function<T, Tuple1<U1>> unapply) {
                 return new Pattern1<T, T1>() {
+
+                    private static final long serialVersionUID = 1L;
+
                     @SuppressWarnings("unchecked")
                     @Override
                     public T1 apply(T obj) {
@@ -3431,8 +3470,13 @@ public final class API {
 
         public static abstract class Pattern2<T, T1, T2> implements Pattern<T, Tuple2<T1, T2>> {
 
+            private static final long serialVersionUID = 1L;
+
             public static <T, T1 extends U1, U1, T2 extends U2, U2> Pattern2<T, T1, T2> of(Class<? super T> type, Pattern<T1, ?> p1, Pattern<T2, ?> p2, Function<T, Tuple2<U1, U2>> unapply) {
                 return new Pattern2<T, T1, T2>() {
+
+                    private static final long serialVersionUID = 1L;
+
                     @SuppressWarnings("unchecked")
                     @Override
                     public Tuple2<T1, T2> apply(T obj) {
@@ -3457,8 +3501,13 @@ public final class API {
 
         public static abstract class Pattern3<T, T1, T2, T3> implements Pattern<T, Tuple3<T1, T2, T3>> {
 
+            private static final long serialVersionUID = 1L;
+
             public static <T, T1 extends U1, U1, T2 extends U2, U2, T3 extends U3, U3> Pattern3<T, T1, T2, T3> of(Class<? super T> type, Pattern<T1, ?> p1, Pattern<T2, ?> p2, Pattern<T3, ?> p3, Function<T, Tuple3<U1, U2, U3>> unapply) {
                 return new Pattern3<T, T1, T2, T3>() {
+
+                    private static final long serialVersionUID = 1L;
+
                     @SuppressWarnings("unchecked")
                     @Override
                     public Tuple3<T1, T2, T3> apply(T obj) {
@@ -3484,8 +3533,13 @@ public final class API {
 
         public static abstract class Pattern4<T, T1, T2, T3, T4> implements Pattern<T, Tuple4<T1, T2, T3, T4>> {
 
+            private static final long serialVersionUID = 1L;
+
             public static <T, T1 extends U1, U1, T2 extends U2, U2, T3 extends U3, U3, T4 extends U4, U4> Pattern4<T, T1, T2, T3, T4> of(Class<? super T> type, Pattern<T1, ?> p1, Pattern<T2, ?> p2, Pattern<T3, ?> p3, Pattern<T4, ?> p4, Function<T, Tuple4<U1, U2, U3, U4>> unapply) {
                 return new Pattern4<T, T1, T2, T3, T4>() {
+
+                    private static final long serialVersionUID = 1L;
+
                     @SuppressWarnings("unchecked")
                     @Override
                     public Tuple4<T1, T2, T3, T4> apply(T obj) {
@@ -3512,8 +3566,13 @@ public final class API {
 
         public static abstract class Pattern5<T, T1, T2, T3, T4, T5> implements Pattern<T, Tuple5<T1, T2, T3, T4, T5>> {
 
+            private static final long serialVersionUID = 1L;
+
             public static <T, T1 extends U1, U1, T2 extends U2, U2, T3 extends U3, U3, T4 extends U4, U4, T5 extends U5, U5> Pattern5<T, T1, T2, T3, T4, T5> of(Class<? super T> type, Pattern<T1, ?> p1, Pattern<T2, ?> p2, Pattern<T3, ?> p3, Pattern<T4, ?> p4, Pattern<T5, ?> p5, Function<T, Tuple5<U1, U2, U3, U4, U5>> unapply) {
                 return new Pattern5<T, T1, T2, T3, T4, T5>() {
+
+                    private static final long serialVersionUID = 1L;
+
                     @SuppressWarnings("unchecked")
                     @Override
                     public Tuple5<T1, T2, T3, T4, T5> apply(T obj) {
@@ -3541,8 +3600,13 @@ public final class API {
 
         public static abstract class Pattern6<T, T1, T2, T3, T4, T5, T6> implements Pattern<T, Tuple6<T1, T2, T3, T4, T5, T6>> {
 
+            private static final long serialVersionUID = 1L;
+
             public static <T, T1 extends U1, U1, T2 extends U2, U2, T3 extends U3, U3, T4 extends U4, U4, T5 extends U5, U5, T6 extends U6, U6> Pattern6<T, T1, T2, T3, T4, T5, T6> of(Class<? super T> type, Pattern<T1, ?> p1, Pattern<T2, ?> p2, Pattern<T3, ?> p3, Pattern<T4, ?> p4, Pattern<T5, ?> p5, Pattern<T6, ?> p6, Function<T, Tuple6<U1, U2, U3, U4, U5, U6>> unapply) {
                 return new Pattern6<T, T1, T2, T3, T4, T5, T6>() {
+
+                    private static final long serialVersionUID = 1L;
+
                     @SuppressWarnings("unchecked")
                     @Override
                     public Tuple6<T1, T2, T3, T4, T5, T6> apply(T obj) {
@@ -3571,8 +3635,13 @@ public final class API {
 
         public static abstract class Pattern7<T, T1, T2, T3, T4, T5, T6, T7> implements Pattern<T, Tuple7<T1, T2, T3, T4, T5, T6, T7>> {
 
+            private static final long serialVersionUID = 1L;
+
             public static <T, T1 extends U1, U1, T2 extends U2, U2, T3 extends U3, U3, T4 extends U4, U4, T5 extends U5, U5, T6 extends U6, U6, T7 extends U7, U7> Pattern7<T, T1, T2, T3, T4, T5, T6, T7> of(Class<? super T> type, Pattern<T1, ?> p1, Pattern<T2, ?> p2, Pattern<T3, ?> p3, Pattern<T4, ?> p4, Pattern<T5, ?> p5, Pattern<T6, ?> p6, Pattern<T7, ?> p7, Function<T, Tuple7<U1, U2, U3, U4, U5, U6, U7>> unapply) {
                 return new Pattern7<T, T1, T2, T3, T4, T5, T6, T7>() {
+
+                    private static final long serialVersionUID = 1L;
+
                     @SuppressWarnings("unchecked")
                     @Override
                     public Tuple7<T1, T2, T3, T4, T5, T6, T7> apply(T obj) {
@@ -3602,8 +3671,13 @@ public final class API {
 
         public static abstract class Pattern8<T, T1, T2, T3, T4, T5, T6, T7, T8> implements Pattern<T, Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> {
 
+            private static final long serialVersionUID = 1L;
+
             public static <T, T1 extends U1, U1, T2 extends U2, U2, T3 extends U3, U3, T4 extends U4, U4, T5 extends U5, U5, T6 extends U6, U6, T7 extends U7, U7, T8 extends U8, U8> Pattern8<T, T1, T2, T3, T4, T5, T6, T7, T8> of(Class<? super T> type, Pattern<T1, ?> p1, Pattern<T2, ?> p2, Pattern<T3, ?> p3, Pattern<T4, ?> p4, Pattern<T5, ?> p5, Pattern<T6, ?> p6, Pattern<T7, ?> p7, Pattern<T8, ?> p8, Function<T, Tuple8<U1, U2, U3, U4, U5, U6, U7, U8>> unapply) {
                 return new Pattern8<T, T1, T2, T3, T4, T5, T6, T7, T8>() {
+
+                    private static final long serialVersionUID = 1L;
+
                     @SuppressWarnings("unchecked")
                     @Override
                     public Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> apply(T obj) {

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction0.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction0.java
@@ -33,6 +33,19 @@ public interface CheckedFunction0<R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <R> CheckedFunction0<R> constant(R value) {
+        return () -> value;
+    }
+
+    /**
      * Creates a {@code CheckedFunction0} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -117,19 +130,6 @@ public interface CheckedFunction0<R> extends Lambda<R> {
     @Override
     default int arity() {
         return 0;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <R> CheckedFunction0<R> constant(R value) {
-        return () -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
@@ -35,6 +35,19 @@ public interface CheckedFunction1<T1, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, R> CheckedFunction1<T1, R> constant(R value) {
+        return (t1) -> value;
+    }
+
+    /**
      * Creates a {@code CheckedFunction1} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -134,19 +147,6 @@ public interface CheckedFunction1<T1, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 1;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, R> CheckedFunction1<T1, R> constant(R value) {
-        return (t1) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
@@ -37,6 +37,20 @@ public interface CheckedFunction2<T1, T2, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, R> CheckedFunction2<T1, T2, R> constant(R value) {
+        return (t1, t2) -> value;
+    }
+
+    /**
      * Creates a {@code CheckedFunction2} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -141,20 +155,6 @@ public interface CheckedFunction2<T1, T2, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 2;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, R> CheckedFunction2<T1, T2, R> constant(R value) {
-        return (t1, t2) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
@@ -37,6 +37,21 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, R> CheckedFunction3<T1, T2, T3, R> constant(R value) {
+        return (t1, t2, t3) -> value;
+    }
+
+    /**
      * Creates a {@code CheckedFunction3} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -157,21 +172,6 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 3;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, R> CheckedFunction3<T1, T2, T3, R> constant(R value) {
-        return (t1, t2, t3) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
@@ -38,6 +38,22 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <T4> generic parameter type 4 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, R> CheckedFunction4<T1, T2, T3, T4, R> constant(R value) {
+        return (t1, t2, t3, t4) -> value;
+    }
+
+    /**
      * Creates a {@code CheckedFunction4} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -175,22 +191,6 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 4;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, R> CheckedFunction4<T1, T2, T3, T4, R> constant(R value) {
-        return (t1, t2, t3, t4) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
@@ -39,6 +39,23 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <T4> generic parameter type 4 of the resulting function
+     * @param <T5> generic parameter type 5 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, R> CheckedFunction5<T1, T2, T3, T4, T5, R> constant(R value) {
+        return (t1, t2, t3, t4, t5) -> value;
+    }
+
+    /**
      * Creates a {@code CheckedFunction5} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -194,23 +211,6 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 5;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, R> CheckedFunction5<T1, T2, T3, T4, T5, R> constant(R value) {
-        return (t1, t2, t3, t4, t5) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
@@ -40,6 +40,24 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <T4> generic parameter type 4 of the resulting function
+     * @param <T5> generic parameter type 5 of the resulting function
+     * @param <T6> generic parameter type 6 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, R> CheckedFunction6<T1, T2, T3, T4, T5, T6, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6) -> value;
+    }
+
+    /**
      * Creates a {@code CheckedFunction6} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -214,24 +232,6 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 6;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, R> CheckedFunction6<T1, T2, T3, T4, T5, T6, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
@@ -41,6 +41,25 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <T4> generic parameter type 4 of the resulting function
+     * @param <T5> generic parameter type 5 of the resulting function
+     * @param <T6> generic parameter type 6 of the resulting function
+     * @param <T7> generic parameter type 7 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, T7, R> CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6, t7) -> value;
+    }
+
+    /**
      * Creates a {@code CheckedFunction7} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -235,25 +254,6 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<
     @Override
     default int arity() {
         return 7;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <T7> generic parameter type 7 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, R> CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6, t7) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
@@ -42,6 +42,26 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lam
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <T4> generic parameter type 4 of the resulting function
+     * @param <T5> generic parameter type 5 of the resulting function
+     * @param <T6> generic parameter type 6 of the resulting function
+     * @param <T7> generic parameter type 7 of the resulting function
+     * @param <T8> generic parameter type 8 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, T7, T8, R> CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6, t7, t8) -> value;
+    }
+
+    /**
      * Creates a {@code CheckedFunction8} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -257,26 +277,6 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lam
     @Override
     default int arity() {
         return 8;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <T7> generic parameter type 7 of the resulting function
-     * @param <T8> generic parameter type 8 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, T8, R> CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6, t7, t8) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Function0.java
+++ b/vavr/src-gen/main/java/io/vavr/Function0.java
@@ -33,6 +33,19 @@ public interface Function0<R> extends Lambda<R>, Supplier<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <R> Function0<R> constant(R value) {
+        return () -> value;
+    }
+
+    /**
      * Creates a {@code Function0} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -127,19 +140,6 @@ public interface Function0<R> extends Lambda<R>, Supplier<R> {
     @Override
     default int arity() {
         return 0;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <R> Function0<R> constant(R value) {
-        return () -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -187,10 +187,14 @@ public interface Function1<T1, R> extends Lambda<R>, Function<T1, R> {
         Objects.requireNonNull(isDefinedAt, "isDefinedAt is null");
         final Function1<T1, R> self = this;
         return new PartialFunction<T1, R>() {
+
+            private static final long serialVersionUID = 1L;
+
             @Override
             public boolean isDefinedAt(T1 t1) {
                 return isDefinedAt.test(t1);
             }
+
             @Override
             public R apply(T1 t1) {
               return self.apply(t1);

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -36,6 +36,19 @@ public interface Function1<T1, R> extends Lambda<R>, Function<T1, R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, R> Function1<T1, R> constant(R value) {
+        return (t1) -> value;
+    }
+
+    /**
      * Creates a {@code Function1} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -135,19 +148,6 @@ public interface Function1<T1, R> extends Lambda<R>, Function<T1, R> {
     @Override
     default int arity() {
         return 1;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, R> Function1<T1, R> constant(R value) {
-        return (t1) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Function2.java
+++ b/vavr/src-gen/main/java/io/vavr/Function2.java
@@ -37,6 +37,20 @@ public interface Function2<T1, T2, R> extends Lambda<R>, BiFunction<T1, T2, R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, R> Function2<T1, T2, R> constant(R value) {
+        return (t1, t2) -> value;
+    }
+
+    /**
      * Creates a {@code Function2} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -141,20 +155,6 @@ public interface Function2<T1, T2, R> extends Lambda<R>, BiFunction<T1, T2, R> {
     @Override
     default int arity() {
         return 2;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, R> Function2<T1, T2, R> constant(R value) {
-        return (t1, t2) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Function3.java
+++ b/vavr/src-gen/main/java/io/vavr/Function3.java
@@ -37,6 +37,21 @@ public interface Function3<T1, T2, T3, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, R> Function3<T1, T2, T3, R> constant(R value) {
+        return (t1, t2, t3) -> value;
+    }
+
+    /**
      * Creates a {@code Function3} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -157,21 +172,6 @@ public interface Function3<T1, T2, T3, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 3;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, R> Function3<T1, T2, T3, R> constant(R value) {
-        return (t1, t2, t3) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Function4.java
+++ b/vavr/src-gen/main/java/io/vavr/Function4.java
@@ -38,6 +38,22 @@ public interface Function4<T1, T2, T3, T4, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <T4> generic parameter type 4 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, R> Function4<T1, T2, T3, T4, R> constant(R value) {
+        return (t1, t2, t3, t4) -> value;
+    }
+
+    /**
      * Creates a {@code Function4} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -175,22 +191,6 @@ public interface Function4<T1, T2, T3, T4, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 4;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, R> Function4<T1, T2, T3, T4, R> constant(R value) {
-        return (t1, t2, t3, t4) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Function5.java
+++ b/vavr/src-gen/main/java/io/vavr/Function5.java
@@ -39,6 +39,23 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <T4> generic parameter type 4 of the resulting function
+     * @param <T5> generic parameter type 5 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, R> Function5<T1, T2, T3, T4, T5, R> constant(R value) {
+        return (t1, t2, t3, t4, t5) -> value;
+    }
+
+    /**
      * Creates a {@code Function5} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -194,23 +211,6 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 5;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, R> Function5<T1, T2, T3, T4, T5, R> constant(R value) {
-        return (t1, t2, t3, t4, t5) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Function6.java
+++ b/vavr/src-gen/main/java/io/vavr/Function6.java
@@ -40,6 +40,24 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <T4> generic parameter type 4 of the resulting function
+     * @param <T5> generic parameter type 5 of the resulting function
+     * @param <T6> generic parameter type 6 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, R> Function6<T1, T2, T3, T4, T5, T6, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6) -> value;
+    }
+
+    /**
      * Creates a {@code Function6} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -214,24 +232,6 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 6;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, R> Function6<T1, T2, T3, T4, T5, T6, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Function7.java
+++ b/vavr/src-gen/main/java/io/vavr/Function7.java
@@ -41,6 +41,25 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <T4> generic parameter type 4 of the resulting function
+     * @param <T5> generic parameter type 5 of the resulting function
+     * @param <T6> generic parameter type 6 of the resulting function
+     * @param <T7> generic parameter type 7 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, T7, R> Function7<T1, T2, T3, T4, T5, T6, T7, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6, t7) -> value;
+    }
+
+    /**
      * Creates a {@code Function7} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -235,25 +254,6 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<R> {
     @Override
     default int arity() {
         return 7;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <T7> generic parameter type 7 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, R> Function7<T1, T2, T3, T4, T5, T6, T7, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6, t7) -> value;
     }
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Function8.java
+++ b/vavr/src-gen/main/java/io/vavr/Function8.java
@@ -42,6 +42,26 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lambda<R> 
     long serialVersionUID = 1L;
 
     /**
+     * Returns a function that always returns the constant
+     * value that you give in parameter.
+     *
+     * @param <T1> generic parameter type 1 of the resulting function
+     * @param <T2> generic parameter type 2 of the resulting function
+     * @param <T3> generic parameter type 3 of the resulting function
+     * @param <T4> generic parameter type 4 of the resulting function
+     * @param <T5> generic parameter type 5 of the resulting function
+     * @param <T6> generic parameter type 6 of the resulting function
+     * @param <T7> generic parameter type 7 of the resulting function
+     * @param <T8> generic parameter type 8 of the resulting function
+     * @param <R> the result type
+     * @param value the value to be returned
+     * @return a function always returning the given value
+     */
+    static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> constant(R value) {
+        return (t1, t2, t3, t4, t5, t6, t7, t8) -> value;
+    }
+
+    /**
      * Creates a {@code Function8} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -257,26 +277,6 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lambda<R> 
     @Override
     default int arity() {
         return 8;
-    }
-
-    /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <T7> generic parameter type 7 of the resulting function
-     * @param <T8> generic parameter type 8 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6, t7, t8) -> value;
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/PartialFunction.java
+++ b/vavr/src/main/java/io/vavr/PartialFunction.java
@@ -19,7 +19,12 @@ package io.vavr;
  * @param <R> type of the function output, called <em>codomain</em> of the function
  * @author Daniel Dietrich
  */
-public interface PartialFunction<T, R> {
+public interface PartialFunction<T, R> extends Function1<T, R> {
+
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
 
     /**
      * Applies this function to the given argument and returns the result.

--- a/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
@@ -162,6 +162,11 @@ public interface IndexedSeq<T> extends Seq<T> {
     IndexedSeq<T> intersperse(T element);
 
     @Override
+    default boolean isDefinedAt(Integer index) {
+        return 0 <= index && index < length();
+    }
+
+    @Override
     default T last() {
         if (isEmpty()) {
             throw new NoSuchElementException("last of empty IndexedSeq");

--- a/vavr/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/LinearSeq.java
@@ -145,6 +145,12 @@ public interface LinearSeq<T> extends Seq<T> {
     LinearSeq<T> intersperse(T element);
 
     @Override
+    default boolean isDefinedAt(Integer index) {
+        // we can't use length() because of infinite long sequences
+        return 0 <= index && drop(index).nonEmpty();
+    }
+
+    @Override
     default int lastIndexOfSlice(Iterable<? extends T> that, int end) {
         Objects.requireNonNull(that, "that is null");
         return LinearSeqModule.Slice.lastIndexOfSlice(this, that, end);

--- a/vavr/src/main/java/io/vavr/collection/Map.java
+++ b/vavr/src/main/java/io/vavr/collection/Map.java
@@ -80,7 +80,7 @@ import java.util.function.*;
  * @param <V> Value type
  * @author Daniel Dietrich, Ruslan Sennov
  */
-public interface Map<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, V>, PartialFunction<K, V>, Serializable {
+public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K, V>, Serializable {
 
     long serialVersionUID = 1L;
 

--- a/vavr/src/main/java/io/vavr/collection/Multimap.java
+++ b/vavr/src/main/java/io/vavr/collection/Multimap.java
@@ -74,7 +74,7 @@ import java.util.function.*;
  * @param <V> Value type
  * @author Ruslan Sennov
  */
-public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, Function1<K, Traversable<V>>, PartialFunction<K, Traversable<V>>, Serializable {
+public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K, Traversable<V>>, Serializable {
 
     long serialVersionUID = 1L;
 

--- a/vavr/src/main/java/io/vavr/collection/Seq.java
+++ b/vavr/src/main/java/io/vavr/collection/Seq.java
@@ -93,7 +93,7 @@ import java.util.function.*;
  * @param <T> Component type
  * @author Daniel Dietrich
  */
-public interface Seq<T> extends Traversable<T>, Function1<Integer, T>, Serializable {
+public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Serializable {
 
     long serialVersionUID = 1L;
 

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -887,6 +887,11 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         assertThat(of(1, 2, 3).isDefinedAt(2)).isTrue();
     }
 
+    @Test
+    public void shouldNotBeDefinedAtIndexOutOfBoundsWhenNonEmpty() {
+        assertThat(of(1, 2, 3).isDefinedAt(3)).isFalse();
+    }
+
     // -- isSequential()
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -860,6 +860,40 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         assertThat(of('a', 'b').intersperse(',')).isEqualTo(of('a', ',', 'b'));
     }
 
+    // -- isDefinedAt()
+
+    @Test
+    public void shouldNotBeDefinedAtNegativeIndexWhenEmpty() {
+        assertThat(empty().isDefinedAt(-1)).isFalse();
+    }
+
+    @Test
+    public void shouldNotBeDefinedAtNegativeIndexWhenNonEmpty() {
+        assertThat(of(1).isDefinedAt(-1)).isFalse();
+    }
+
+    @Test
+    public void shouldNotBeDefinedAtIndex0WhenEmpty() {
+        assertThat(empty().isDefinedAt(0)).isFalse();
+    }
+
+    @Test
+    public void shouldBeDefinedAtIndex0WhenNonEmpty() {
+        assertThat(of(1).isDefinedAt(0)).isTrue();
+    }
+
+    @Test
+    public void shouldBeDefinedAtLastIndexWhenNonEmpty() {
+        assertThat(of(1, 2, 3).isDefinedAt(2)).isTrue();
+    }
+
+    // -- isSequential()
+
+    @Test
+    public void shouldReturnTrueWhenIsSequentialCalled() {
+        assertThat(of(1, 2, 3).isSequential()).isTrue();
+    }
+
     // -- iterator(int)
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -1719,6 +1753,23 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         assertThat(of(1, 2, 3).splitAtInclusive(e -> e == 5)).isEqualTo(Tuple.of(of(1, 2, 3), empty()));
     }
 
+    // -- spliterator
+
+    @Test
+    public void shouldNotHaveSortedSpliterator() {
+        assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.SORTED)).isFalse();
+    }
+
+    @Test
+    public void shouldHaveOrderedSpliterator() {
+        assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.ORDERED)).isTrue();
+    }
+
+    @Test
+    public void shouldNotHaveDistinctSpliterator() {
+        assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.DISTINCT)).isFalse();
+    }
+
     // -- startsWith
 
     @Test
@@ -1952,45 +2003,6 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         assertThat(of(10, 20, 30).search(25, Integer::compareTo)).isEqualTo(-3);
     }
 
-    // -- IndexedSeq special cases
-
-    @Test
-    public void shouldTestIndexedSeqStartsWithNonIndexedSeq() {
-        assertThat(of(1, 3, 4).startsWith(Stream.of(1, 3))).isTrue();
-        assertThat(of(1, 2, 3, 4).startsWith(Stream.of(1, 2, 4))).isFalse();
-        assertThat(of(1, 2).startsWith(Stream.of(1, 2, 4))).isFalse();
-    }
-
-    @Test
-    public void shouldTestIndexedSeqEndsWithNonIndexedSeq() {
-        assertThat(of(1, 3, 4).endsWith(Stream.of(3, 4))).isTrue();
-        assertThat(of(1, 2, 3, 4).endsWith(Stream.of(2, 3, 5))).isFalse();
-    }
-
-    @Test
-    public void lift() {
-        final Function1<Integer, Option<String>> lifted = of("a", "b", "c").lift();
-        assertThat(lifted.apply(1).get()).isEqualTo("b");
-        assertThat(lifted.apply(-1).isEmpty()).isTrue();
-        assertThat(lifted.apply(3).isEmpty()).isTrue();
-    }
-
-    @Test
-    public void withDefaultValue() {
-        final Function1<Integer, String> withDef = of("a", "b", "c").withDefaultValue("z");
-        assertThat(withDef.apply(2)).isEqualTo("c");
-        assertThat(withDef.apply(-1)).isEqualTo("z");
-        assertThat(withDef.apply(3)).isEqualTo("z");
-    }
-
-    @Test
-    public void withDefault() {
-        final Function1<Integer, String> withDef = of("a", "b", "c").withDefault(Object::toString);
-        assertThat(withDef.apply(2)).isEqualTo("c");
-        assertThat(withDef.apply(-1)).isEqualTo("-1");
-        assertThat(withDef.apply(3)).isEqualTo("3");
-    }
-
     // -- transpose()
 
     @Test
@@ -2096,28 +2108,43 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         transpose(actual);
     }
 
-    // -- spliterator
+    // -- IndexedSeq special cases
 
     @Test
-    public void shouldNotHaveSortedSpliterator() {
-        assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.SORTED)).isFalse();
+    public void shouldTestIndexedSeqStartsWithNonIndexedSeq() {
+        assertThat(of(1, 3, 4).startsWith(Stream.of(1, 3))).isTrue();
+        assertThat(of(1, 2, 3, 4).startsWith(Stream.of(1, 2, 4))).isFalse();
+        assertThat(of(1, 2).startsWith(Stream.of(1, 2, 4))).isFalse();
     }
 
     @Test
-    public void shouldHaveOrderedSpliterator() {
-        assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.ORDERED)).isTrue();
+    public void shouldTestIndexedSeqEndsWithNonIndexedSeq() {
+        assertThat(of(1, 3, 4).endsWith(Stream.of(3, 4))).isTrue();
+        assertThat(of(1, 2, 3, 4).endsWith(Stream.of(2, 3, 5))).isFalse();
     }
 
     @Test
-    public void shouldNotHaveDistinctSpliterator() {
-        assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.DISTINCT)).isFalse();
+    public void lift() {
+        final Function1<Integer, Option<String>> lifted = of("a", "b", "c").lift();
+        assertThat(lifted.apply(1).get()).isEqualTo("b");
+        assertThat(lifted.apply(-1).isEmpty()).isTrue();
+        assertThat(lifted.apply(3).isEmpty()).isTrue();
     }
 
-    // -- isSequential()
+    @Test
+    public void withDefaultValue() {
+        final Function1<Integer, String> withDef = of("a", "b", "c").withDefaultValue("z");
+        assertThat(withDef.apply(2)).isEqualTo("c");
+        assertThat(withDef.apply(-1)).isEqualTo("z");
+        assertThat(withDef.apply(3)).isEqualTo("z");
+    }
 
     @Test
-    public void shouldReturnTrueWhenIsSequentialCalled() {
-        assertThat(of(1, 2, 3).isSequential()).isTrue();
+    public void withDefault() {
+        final Function1<Integer, String> withDef = of("a", "b", "c").withDefault(Object::toString);
+        assertThat(withDef.apply(2)).isEqualTo("c");
+        assertThat(withDef.apply(-1)).isEqualTo("-1");
+        assertThat(withDef.apply(3)).isEqualTo("3");
     }
 
 }

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -6,10 +6,7 @@
  */
 package io.vavr.collection;
 
-import io.vavr.Tuple;
-import io.vavr.AbstractValueTest;
-import io.vavr.PartialFunction;
-import io.vavr.Tuple2;
+import io.vavr.*;
 import io.vavr.control.Option;
 import org.junit.Test;
 
@@ -21,8 +18,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
-import static io.vavr.API.$;
-import static io.vavr.API.Case;
+import static io.vavr.API.*;
 import static java.lang.System.lineSeparator;
 import static java.util.Arrays.asList;
 import static java.util.Comparator.comparingInt;
@@ -34,6 +30,10 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     protected final boolean isTraversableAgain() {
         return empty().isTraversableAgain();
+    }
+
+    protected final boolean isOrdered() {
+        return empty().isOrdered();
     }
 
     protected abstract <T> Collector<T, ArrayList<T>, ? extends Traversable<T>> collector();
@@ -275,6 +275,29 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
                 Case($(i -> i % 2 == 1), String::valueOf)
         );
         assertThat(actual).isEqualTo(of("1", "3"));
+    }
+
+    @Test
+    public void shouldCollectUsingMap() {
+        final Map<Integer, String> map = Map(1, "one", 3, "three");
+        final Traversable<String> actual = of(1, 2, 3, 4).collect(map);
+        assertThat(actual).isEqualTo(of("one", "three"));
+    }
+
+    @Test
+    public void shouldCollectUsingMultimap() {
+        if (!isOrdered()) {
+            final Multimap<Integer, String> map = HashMultimap.withSeq().of(1, "one", 1, "un", 3, "three", 3, "trois");
+            final Traversable<Traversable<String>> actual = of(1, 2, 3, 4).collect(map);
+            assertThat(actual).isEqualTo(of(List("one", "un"), List("three", "trois")));
+        }
+    }
+
+    @Test
+    public void shouldCollectUsingSeq() {
+        final Seq<String> map = List("one", "two", "three", "four");
+        final Traversable<String> actual = of(0, 2).collect(map);
+        assertThat(actual).isEqualTo(of("one", "three"));
     }
 
     // -- contains
@@ -893,13 +916,6 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
     @Test
     public void shouldRecognizeNonNil() {
         assertThat(of(1).isEmpty()).isFalse();
-    }
-
-    // -- isTraversableAgain
-
-    @Test
-    public void shouldReturnSomethingOnIsTraversableAgain() {
-        empty().isTraversableAgain();
     }
 
     // -- iterator

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -21,6 +21,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
 import static java.lang.System.lineSeparator;
 import static java.util.Arrays.asList;
 import static java.util.Comparator.comparingInt;
@@ -253,6 +255,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
     @Test
     public void shouldCollectUsingPartialFunction() {
         final PartialFunction<Integer, String> pf = new PartialFunction<Integer, String>() {
+            private static final long serialVersionUID = 1L;
             @Override
             public String apply(Integer i) {
                 return String.valueOf(i);
@@ -263,6 +266,14 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
             }
         };
         final Traversable<String> actual = of(1, 2, 3).collect(pf);
+        assertThat(actual).isEqualTo(of("1", "3"));
+    }
+
+    @Test
+    public void shouldCollectUsingCase() {
+        final Traversable<String> actual = of(1, 2, 3).collect(
+                Case($(i -> i % 2 == 1), String::valueOf)
+        );
         assertThat(actual).isEqualTo(of("1", "3"));
     }
 

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -284,6 +284,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         assertThat(actual).isEqualTo(of("one", "three"));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void shouldCollectUsingMultimap() {
         if (!isOrdered()) {

--- a/vavr/src/test/java/io/vavr/collection/IntMap.java
+++ b/vavr/src/test/java/io/vavr/collection/IntMap.java
@@ -81,6 +81,7 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
     public <R> Seq<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         Objects.requireNonNull(partialFunction, "partialFunction is null");
         final PartialFunction<Tuple2<Integer, T>, R> pf = new PartialFunction<Tuple2<Integer, T>, R>() {
+            private static final long serialVersionUID = 1L;
             @Override
             public R apply(Tuple2<Integer, T> entry) {
                 return partialFunction.apply(entry._2);

--- a/vavr/src/test/java/io/vavr/collection/IntMultimap.java
+++ b/vavr/src/test/java/io/vavr/collection/IntMultimap.java
@@ -82,6 +82,7 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
     public <R> Seq<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         Objects.requireNonNull(partialFunction, "partialFunction is null");
         final PartialFunction<Tuple2<Integer, T>, R> pf = new PartialFunction<Tuple2<Integer, T>, R>() {
+            private static final long serialVersionUID = 1L;
             @Override
             public R apply(Tuple2<Integer, T> entry) {
                 return partialFunction.apply(entry._2);

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -513,6 +513,13 @@ public class StreamTest extends AbstractLinearSeqTest {
         assertThat(Stream.continually(1).extend(i -> i + 1).take(6)).isEqualTo(of(1, 1, 1, 1, 1, 1));
     }
 
+    // -- isDefinedAt
+
+    @Test
+    public void shouldBeDefinedAtNonNegativeIndexWhenInfinitelyLong() {
+        assertThat(Stream.continually(1).isDefinedAt(1)).isTrue();
+    }
+
     // -- isLazy
 
     @Override


### PR DESCRIPTION
Follow-up of #2002 

Now Seq also extends PartialFunction.

**There will be another follow-up:** API.Pattern* should not extend PartialFunction. For example the type system currently does not allow us to use Patterns in conjunction with `Traversable.collect(PartialFunction)`.