### PR TITLE
add Either.toValidation

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Either.java
+++ b/vavr/src/main/java/io/vavr/control/Either.java
@@ -403,6 +403,15 @@ public interface Either<L, R> extends Value<R>, Serializable {
         return this;
     }
 
+    /**
+     * Returns this as {@code Validation}.
+     *
+     * @return {@code Validation.valid(get())} if this is right, otherwise {@code Validation.invalid(getLeft())}.
+     */
+    default Validation<L, R> toValidation() {
+        return isRight() ? Validation.valid(get()) : Validation.invalid(getLeft());
+    }
+
     // -- Object.*
 
     @Override

--- a/vavr/src/test/java/io/vavr/control/EitherTest.java
+++ b/vavr/src/test/java/io/vavr/control/EitherTest.java
@@ -278,6 +278,22 @@ public class EitherTest extends AbstractValueTest {
         assertThat(Either.right(1)).isEqualTo(Either.right(1));
     }
 
+    // -- toValidation
+
+    @Test
+    public void shouldConvertToValidValidation() {
+        final Validation<?, Integer> validation = Either.right(42).toValidation();
+        assertThat(validation.isValid()).isTrue();
+        assertThat(validation.get()).isEqualTo(42);
+    }
+
+    @Test
+    public void shouldConvertToInvalidValidation() {
+        final Validation<String, ?> validation = Either.left("vavr").toValidation();
+        assertThat(validation.isInvalid()).isTrue();
+        assertThat(validation.getError()).isEqualTo("vavr");
+    }
+
     // hashCode
 
     @Test


### PR DESCRIPTION
a colleague was looking for `Either.toValidation` today at work. There are two overloads from `Value`, but they take a value or a callback for the invalid value, which makes sense since that comes from `Value`. But obviously `Either` already has that.
And we have `Validation.toEither` so there's some symmetry here. I did notice though while preparing this PR that we do already have `Validation.fromEither`... So there is some duplication here... So maybe we shouldn't add this new way of doing this.

But as I said if you already have two overloads for `toValidation`, you could be forgiven for forgetting to check for `Validation.fromEither`... So there's something to say about having both or maybe even for adding this one and deprecating `Validation.fromEither`..
Just thinking out loud.. your call obviously!