### PR TITLE
*.fill & *.tabulate refactoring

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -243,7 +243,7 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
      */
     public static <T> Array<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return io.vavr.collection.Collections.tabulate(n, f, empty(), Array::of);
+        return ofAll(Iterator.tabulate(n, f));
     }
 
     /**
@@ -257,7 +257,7 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
      */
     public static <T> Array<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
-        return io.vavr.collection.Collections.fill(n, s, empty(), Array::of);
+        return ofAll(Iterator.fill(n, s));
     }
 
     public static Array<Character> range(char from, char toExclusive) {

--- a/vavr/src/main/java/io/vavr/collection/BitSet.java
+++ b/vavr/src/main/java/io/vavr/collection/BitSet.java
@@ -82,12 +82,12 @@ public interface BitSet<T> extends SortedSet<T> {
 
         public BitSet<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
             Objects.requireNonNull(f, "f is null");
-            return empty().addAll(Collections.tabulate(n, f));
+            return empty().addAll(Iterator.tabulate(n, f));
         }
 
         public BitSet<T> fill(int n, Supplier<? extends T> s) {
             Objects.requireNonNull(s, "s is null");
-            return empty().addAll(Collections.fill(n, s));
+            return empty().addAll(Iterator.fill(n, s));
         }
     }
 

--- a/vavr/src/main/java/io/vavr/collection/Collections.java
+++ b/vavr/src/main/java/io/vavr/collection/Collections.java
@@ -152,18 +152,6 @@ final class Collections {
         }
     }
 
-    static <T> Iterator<T> fill(int n, Supplier<? extends T> supplier) {
-        Objects.requireNonNull(supplier, "supplier is null");
-        return tabulate(n, ignored -> supplier.get());
-    }
-
-    static <C extends Traversable<T>, T> C fill(int n, Supplier<? extends T> s, C empty, Function<T[], C> of) {
-        Objects.requireNonNull(s, "s is null");
-        Objects.requireNonNull(empty, "empty is null");
-        Objects.requireNonNull(of, "of is null");
-        return tabulate(n, anything -> s.get(), empty, of);
-    }
-
     static <T, C, R extends Iterable<T>> Map<C, R> groupBy(Traversable<T> source, Function<? super T, ? extends C> classifier, Function<? super Iterable<T>, R> mapper) {
         Objects.requireNonNull(classifier, "classifier is null");
         Objects.requireNonNull(mapper, "mapper is null");
@@ -332,44 +320,6 @@ final class Collections {
             throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + "), length = " + length);
         } else if (beginIndex > endIndex) {
             throw new IllegalArgumentException("subSequence(" + beginIndex + ", " + endIndex + ")");
-        }
-    }
-
-    static <T> Iterator<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
-        Objects.requireNonNull(f, "f is null");
-        if (n <= 0) {
-            return Iterator.empty();
-        } else {
-            return new AbstractIterator<T>() {
-
-                int i = 0;
-
-                @Override
-                public boolean hasNext() {
-                    return i < n;
-                }
-
-                @Override
-                protected T getNext() {
-                    return f.apply(i++);
-                }
-            };
-        }
-    }
-
-    static <C extends Traversable<T>, T> C tabulate(int n, Function<? super Integer, ? extends T> f, C empty, Function<T[], C> of) {
-        Objects.requireNonNull(f, "f is null");
-        Objects.requireNonNull(empty, "empty is null");
-        Objects.requireNonNull(of, "of is null");
-        if (n <= 0) {
-            return empty;
-        } else {
-            @SuppressWarnings("unchecked")
-            final T[] elements = (T[]) new Object[n];
-            for (int i = 0; i < n; i++) {
-                elements[i] = f.apply(i);
-            }
-            return of.apply(elements);
         }
     }
 

--- a/vavr/src/main/java/io/vavr/collection/HashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMap.java
@@ -411,7 +411,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> HashMap<K, V> tabulate(int n, Function<? super Integer, ? extends Tuple2<? extends K, ? extends V>> f) {
         Objects.requireNonNull(f, "f is null");
-        return ofEntries(Collections.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V>>) f));
+        return ofEntries(Iterator.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V>>) f));
     }
 
     /**
@@ -427,7 +427,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> HashMap<K, V> fill(int n, Supplier<? extends Tuple2<? extends K, ? extends V>> s) {
         Objects.requireNonNull(s, "s is null");
-        return ofEntries(Collections.fill(n, (Supplier<? extends Tuple2<K, V>>) s));
+        return ofEntries(Iterator.fill(n, (Supplier<? extends Tuple2<K, V>>) s));
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/HashMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMultimap.java
@@ -177,7 +177,7 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         @SuppressWarnings("unchecked")
         public <K, V2 extends V> HashMultimap<K, V2> tabulate(int n, Function<? super Integer, ? extends Tuple2<? extends K, ? extends V2>> f) {
             Objects.requireNonNull(f, "f is null");
-            return ofEntries(Collections.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V2>>) f));
+            return ofEntries(Iterator.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V2>>) f));
         }
 
         /**
@@ -193,7 +193,7 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         @SuppressWarnings("unchecked")
         public <K, V2 extends V> HashMultimap<K, V2> fill(int n, Supplier<? extends Tuple2<? extends K, ? extends V2>> s) {
             Objects.requireNonNull(s, "s is null");
-            return ofEntries(Collections.fill(n, (Supplier<? extends Tuple2<K, V2>>) s));
+            return ofEntries(Iterator.fill(n, (Supplier<? extends Tuple2<K, V2>>) s));
         }
 
         /**

--- a/vavr/src/main/java/io/vavr/collection/HashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/HashSet.java
@@ -115,7 +115,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
      */
     public static <T> HashSet<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return Collections.tabulate(n, f, HashSet.empty(), HashSet::of);
+        return ofAll(Iterator.tabulate(n, f));
     }
 
     /**
@@ -129,7 +129,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
      */
     public static <T> HashSet<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
-        return Collections.fill(n, s, HashSet.empty(), HashSet::of);
+        return ofAll(Iterator.fill(n, s));
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/Iterator.java
+++ b/vavr/src/main/java/io/vavr/collection/Iterator.java
@@ -424,7 +424,24 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
      */
     static <T> Iterator<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return io.vavr.collection.Collections.tabulate(n, f);
+        if (n <= 0) {
+            return Iterator.empty();
+        } else {
+            return new AbstractIterator<T>() {
+
+                int i = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return i < n;
+                }
+
+                @Override
+                protected T getNext() {
+                    return f.apply(i++);
+                }
+            };
+        }
     }
 
     /**
@@ -438,7 +455,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
      */
     static <T> Iterator<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
-        return io.vavr.collection.Collections.fill(n, s);
+        return tabulate(n, ignored -> s.get());
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -434,7 +434,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> LinkedHashMap<K, V> tabulate(int n, Function<? super Integer, ? extends Tuple2<? extends K, ? extends V>> f) {
         Objects.requireNonNull(f, "f is null");
-        return ofEntries(Collections.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V>>) f));
+        return ofEntries(Iterator.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V>>) f));
     }
 
     /**
@@ -450,7 +450,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> LinkedHashMap<K, V> fill(int n, Supplier<? extends Tuple2<? extends K, ? extends V>> s) {
         Objects.requireNonNull(s, "s is null");
-        return ofEntries(Collections.fill(n, (Supplier<? extends Tuple2<K, V>>) s));
+        return ofEntries(Iterator.fill(n, (Supplier<? extends Tuple2<K, V>>) s));
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMultimap.java
@@ -177,7 +177,7 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         @SuppressWarnings("unchecked")
         public <K, V2 extends V> LinkedHashMultimap<K, V2> tabulate(int n, Function<? super Integer, ? extends Tuple2<? extends K, ? extends V2>> f) {
             Objects.requireNonNull(f, "f is null");
-            return ofEntries(Collections.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V2>>) f));
+            return ofEntries(Iterator.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V2>>) f));
         }
 
         /**
@@ -193,7 +193,7 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         @SuppressWarnings("unchecked")
         public <K, V2 extends V> LinkedHashMultimap<K, V2> fill(int n, Supplier<? extends Tuple2<? extends K, ? extends V2>> s) {
             Objects.requireNonNull(s, "s is null");
-            return ofEntries(Collections.fill(n, (Supplier<? extends Tuple2<K, V2>>) s));
+            return ofEntries(Iterator.fill(n, (Supplier<? extends Tuple2<K, V2>>) s));
         }
 
         /**

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -119,7 +119,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
      */
     public static <T> LinkedHashSet<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return Collections.tabulate(n, f, LinkedHashSet.empty(), LinkedHashSet::of);
+        return ofAll(Iterator.tabulate(n, f));
     }
 
     /**
@@ -133,7 +133,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
      */
     public static <T> LinkedHashSet<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
-        return Collections.fill(n, s, LinkedHashSet.empty(), LinkedHashSet::of);
+        return ofAll(Iterator.fill(n, s));
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -382,7 +382,7 @@ public interface List<T> extends LinearSeq<T> {
      */
     static <T> List<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return Collections.tabulate(n, f, empty(), List::of);
+        return ofAll(Iterator.tabulate(n, f));
     }
 
     /**
@@ -396,7 +396,7 @@ public interface List<T> extends LinearSeq<T> {
      */
     static <T> List<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
-        return Collections.fill(n, s, empty(), List::of);
+        return ofAll(Iterator.fill(n, s));
     }
 
     static List<Character> range(char from, char toExclusive) {

--- a/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
+++ b/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
@@ -250,7 +250,7 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
     public static <T> PriorityQueue<T> tabulate(int size, Function<? super Integer, ? extends T> function) {
         Objects.requireNonNull(function, "function is null");
         final Comparator<? super T> comparator = Comparators.naturalComparator();
-        return io.vavr.collection.Collections.tabulate(size, function, empty(comparator), values -> ofAll(comparator, io.vavr.collection.List.of(values)));
+        return ofAll(comparator, Iterator.tabulate(size, function));
     }
 
     /**
@@ -267,7 +267,7 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
     public static <T> PriorityQueue<T> fill(int size, Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         final Comparator<? super T> comparator = Comparators.naturalComparator();
-        return io.vavr.collection.Collections.fill(size, supplier, empty(comparator), values -> ofAll(comparator, io.vavr.collection.List.of(values)));
+        return ofAll(comparator, Iterator.fill(size, supplier));
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -278,7 +278,7 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
      */
     public static <T> Queue<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return io.vavr.collection.Collections.tabulate(n, f, empty(), Queue::of);
+        return ofAll(Iterator.tabulate(n, f));
     }
 
     /**
@@ -292,7 +292,7 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
      */
     public static <T> Queue<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
-        return io.vavr.collection.Collections.fill(n, s, empty(), Queue::of);
+        return ofAll(Iterator.fill(n, s));
     }
 
     public static Queue<Character> range(char from, char toExclusive) {

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -314,7 +314,7 @@ public interface Stream<T> extends LinearSeq<T> {
      */
     static <T> Stream<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return Stream.ofAll(io.vavr.collection.Collections.tabulate(n, f));
+        return ofAll(Iterator.tabulate(n, f));
     }
 
     /**
@@ -328,7 +328,7 @@ public interface Stream<T> extends LinearSeq<T> {
      */
     static <T> Stream<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
-        return Stream.ofAll(io.vavr.collection.Collections.fill(n, s));
+        return ofAll(Iterator.fill(n, s));
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/Tree.java
+++ b/vavr/src/main/java/io/vavr/collection/Tree.java
@@ -175,7 +175,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      */
     static <T> Tree<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return io.vavr.collection.Collections.tabulate(n, f, empty(), Tree::of);
+        return ofAll(Iterator.tabulate(n, f));
     }
 
     /**
@@ -189,7 +189,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      */
     static <T> Tree<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
-        return io.vavr.collection.Collections.fill(n, s, empty(), Tree::of);
+        return ofAll(Iterator.fill(n, s));
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/TreeMap.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeMap.java
@@ -773,7 +773,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
      */
     public static <K, V> TreeMap<K, V> tabulate(Comparator<? super K> keyComparator, int n, Function<? super Integer, ? extends Tuple2<? extends K, ? extends V>> f) {
         Objects.requireNonNull(f, "f is null");
-        return createTreeMap(EntryComparator.of(keyComparator), Collections.tabulate(n, f));
+        return createTreeMap(EntryComparator.of(keyComparator), Iterator.tabulate(n, f));
     }
 
     /**
@@ -790,7 +790,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
      */
     public static <K extends Comparable<? super K>, V> TreeMap<K, V> tabulate(int n, Function<? super Integer, ? extends Tuple2<? extends K, ? extends V>> f) {
         Objects.requireNonNull(f, "f is null");
-        return createTreeMap(EntryComparator.natural(), Collections.tabulate(n, f));
+        return createTreeMap(EntryComparator.natural(), Iterator.tabulate(n, f));
     }
 
     /**
@@ -807,7 +807,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> TreeMap<K, V> fill(Comparator<? super K> keyComparator, int n, Supplier<? extends Tuple2<? extends K, ? extends V>> s) {
         Objects.requireNonNull(s, "s is null");
-        return createTreeMap(EntryComparator.of(keyComparator), Collections.fill(n, s));
+        return createTreeMap(EntryComparator.of(keyComparator), Iterator.fill(n, s));
     }
 
     /**
@@ -823,7 +823,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
      */
     public static <K extends Comparable<? super K>, V> TreeMap<K, V> fill(int n, Supplier<? extends Tuple2<? extends K, ? extends V>> s) {
         Objects.requireNonNull(s, "s is null");
-        return createTreeMap(EntryComparator.natural(), Collections.fill(n, s));
+        return createTreeMap(EntryComparator.natural(), Iterator.fill(n, s));
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/TreeMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeMultimap.java
@@ -310,7 +310,7 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         public <K, V2 extends V> TreeMultimap<K, V2> tabulate(Comparator<? super K> keyComparator, int n, Function<? super Integer, ? extends Tuple2<? extends K, ? extends V2>> f) {
             Objects.requireNonNull(keyComparator, "keyComparator is null");
             Objects.requireNonNull(f, "f is null");
-            return ofEntries(keyComparator, Collections.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V2>>) f));
+            return ofEntries(keyComparator, Iterator.tabulate(n, (Function<? super Integer, ? extends Tuple2<K, V2>>) f));
         }
 
         /**
@@ -344,7 +344,7 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         public <K, V2 extends V> TreeMultimap<K, V2> fill(Comparator<? super K> keyComparator, int n, Supplier<? extends Tuple2<? extends K, ? extends V2>> s) {
             Objects.requireNonNull(keyComparator, "keyComparator is null");
             Objects.requireNonNull(s, "s is null");
-            return ofEntries(keyComparator, Collections.fill(n, (Supplier<? extends Tuple2<K, V2>>) s));
+            return ofEntries(keyComparator, Iterator.fill(n, (Supplier<? extends Tuple2<K, V2>>) s));
         }
 
         /**

--- a/vavr/src/main/java/io/vavr/collection/TreeSet.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeSet.java
@@ -130,7 +130,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     public static <T> TreeSet<T> tabulate(Comparator<? super T> comparator, int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(comparator, "comparator is null");
         Objects.requireNonNull(f, "f is null");
-        return Collections.tabulate(n, f, TreeSet.empty(comparator), values -> of(comparator, values));
+        return ofAll(comparator, Iterator.tabulate(n, f));
     }
 
     /**
@@ -162,7 +162,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     public static <T> TreeSet<T> fill(Comparator<? super T> comparator, int n, Supplier<? extends T> s) {
         Objects.requireNonNull(comparator, "comparator is null");
         Objects.requireNonNull(s, "s is null");
-        return Collections.fill(n, s, TreeSet.empty(comparator), values -> of(comparator, values));
+        return ofAll(comparator, Iterator.fill(n, s));
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -126,7 +126,7 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
      */
     public static <T> Vector<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
-        return io.vavr.collection.Collections.tabulate(n, f, empty(), Vector::of);
+        return ofAll(Iterator.tabulate(n, f));
     }
 
     /**
@@ -140,7 +140,7 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
      */
     public static <T> Vector<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
-        return io.vavr.collection.Collections.fill(n, s, empty(), Vector::of);
+        return ofAll(Iterator.fill(n, s));
     }
 
     /**


### PR DESCRIPTION
Now all methods uses `Iterator.tabulate` which is moved from `Collections`