### PR TITLE
Add Seq.takeRightUntil and Seq.takeRightWhile

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/AbstractQueue.java
+++ b/vavr/src/main/java/io/vavr/collection/AbstractQueue.java
@@ -98,6 +98,15 @@ abstract class AbstractQueue<T, Q extends AbstractQueue<T, Q>> implements Traver
         return isEmpty() ? Option.none() : Option.some(peek());
     }
 
+    @Override
+    public Q dropUntil(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return dropWhile(predicate.negate());
+    }
+
+    @Override
+    public abstract Q dropWhile(Predicate<? super T> predicate);
+
     /**
      * Dual of {@linkplain #tail()}, returning all elements except the last.
      *

--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -1307,6 +1307,17 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    public Array<T> takeUntil(Predicate<? super T> predicate) {
+        return io.vavr.collection.Collections.takeUntil(this, predicate);
+    }
+
+    @Override
+    public Array<T> takeWhile(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return takeUntil(predicate.negate());
+    }
+
+    @Override
     public Array<T> takeRight(int n) {
         if (n >= length()) {
             return this;
@@ -1320,21 +1331,14 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
-    public Array<T> takeUntil(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return takeWhile(predicate.negate());
+    public Array<T> takeRightUntil(Predicate<? super T> predicate) {
+        return io.vavr.collection.Collections.takeRightUntil(this, predicate);
     }
 
     @Override
-    public Array<T> takeWhile(Predicate<? super T> predicate) {
+    public Array<T> takeRightWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        for (int i = 0; i < delegate.length; i++) {
-            final T value = get(i);
-            if (!predicate.test(value)) {
-                return take(i);
-            }
-        }
-        return this;
+        return takeRightUntil(predicate.negate());
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -1017,6 +1017,17 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
+    public CharSeq takeUntil(Predicate<? super Character> predicate) {
+        return io.vavr.collection.Collections.takeUntil(this, predicate);
+    }
+
+    @Override
+    public CharSeq takeWhile(Predicate<? super Character> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return takeUntil(predicate.negate());
+    }
+
+    @Override
     public CharSeq takeRight(int n) {
         if (n <= 0) {
             return EMPTY;
@@ -1028,23 +1039,14 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
-    public CharSeq takeUntil(Predicate<? super Character> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return takeWhile(predicate.negate());
+    public CharSeq takeRightUntil(Predicate<? super Character> predicate) {
+        return io.vavr.collection.Collections.takeRightUntil(this, predicate);
     }
 
     @Override
-    public CharSeq takeWhile(Predicate<? super Character> predicate) {
+    public CharSeq takeRightWhile(Predicate<? super Character> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        final StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < length(); i++) {
-            final char c = get(i);
-            if (!predicate.test(c)) {
-                break;
-            }
-            sb.append(c);
-        }
-        return sb.length() == length() ? this : sb.length() == 0 ? EMPTY : of(sb);
+        return takeRightUntil(predicate.negate());
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/Collections.java
+++ b/vavr/src/main/java/io/vavr/collection/Collections.java
@@ -70,7 +70,7 @@ final class Collections {
     // because of O(N) complexity of get() and infinite loop in size()
     // see https://github.com/vavr-io/vavr/issues/2007
     @SuppressWarnings("unchecked")
-    static <T, S extends Seq<T>> S dropUntil(S seq, Predicate<? super T> predicate) {
+    static <T, S extends IndexedSeq<T>> S dropUntil(S seq, Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         for (int i = 0; i < seq.length(); i++) {
             if (predicate.test(seq.get(i))) {
@@ -371,6 +371,34 @@ final class Collections {
             }
             return of.apply(elements);
         }
+    }
+
+    // DEV-NOTE: Use this method for non-infinite and direct-access collection only
+    // because of O(N) complexity of get() and infinite loop in size()
+    // see https://github.com/vavr-io/vavr/issues/2007
+    @SuppressWarnings("unchecked")
+    static <T, S extends IndexedSeq<T>> S takeRightUntil(S seq, Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        for (int i = seq.length() - 1; i >= 0; i--) {
+            if (predicate.test(seq.get(i))) {
+                return (S) seq.drop(i + 1);
+            }
+        }
+        return seq;
+    }
+
+    // DEV-NOTE: Use this method for non-infinite and direct-access collection only
+    // because of O(N) complexity of get() and infinite loop in size()
+    // see https://github.com/vavr-io/vavr/issues/2007
+    @SuppressWarnings("unchecked")
+    static <T, S extends IndexedSeq<T>> S takeUntil(S seq, Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        for (int i = 0; i < seq.length(); i++) {
+            if (predicate.test(seq.get(i))) {
+                return (S) seq.take(i);
+            }
+        }
+        return seq;
     }
 
     static <T, U extends Seq<T>, V extends Seq<U>> V transpose(V matrix, Function<Iterable<U>, V> rowFactory, Function<T[], U> columnFactory) {

--- a/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
@@ -366,13 +366,19 @@ public interface IndexedSeq<T> extends Seq<T> {
     IndexedSeq<T> take(int n);
 
     @Override
-    IndexedSeq<T> takeRight(int n);
-
-    @Override
     IndexedSeq<T> takeUntil(Predicate<? super T> predicate);
 
     @Override
     IndexedSeq<T> takeWhile(Predicate<? super T> predicate);
+
+    @Override
+    IndexedSeq<T> takeRight(int n);
+
+    @Override
+    IndexedSeq<T> takeRightUntil(Predicate<? super T> predicate);
+
+    @Override
+    IndexedSeq<T> takeRightWhile(Predicate<? super T> predicate);
 
     @Override
     <T1, T2> Tuple2<? extends IndexedSeq<T1>, ? extends IndexedSeq<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);

--- a/vavr/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/LinearSeq.java
@@ -307,13 +307,19 @@ public interface LinearSeq<T> extends Seq<T> {
     LinearSeq<T> take(int n);
 
     @Override
-    LinearSeq<T> takeRight(int n);
-
-    @Override
     LinearSeq<T> takeUntil(Predicate<? super T> predicate);
 
     @Override
     LinearSeq<T> takeWhile(Predicate<? super T> predicate);
+
+    @Override
+    LinearSeq<T> takeRight(int n);
+
+    @Override
+    LinearSeq<T> takeRightUntil(Predicate<? super T> predicate);
+
+    @Override
+    LinearSeq<T> takeRightWhile(Predicate<? super T> predicate);
 
     @Override
     <T1, T2> Tuple2<? extends LinearSeq<T1>, ? extends LinearSeq<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -1524,17 +1524,6 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> takeRight(int n) {
-        if (n <= 0) {
-            return empty();
-        }
-        if (n >= length()) {
-            return this;
-        }
-        return reverse().take(n).reverse();
-    }
-
-    @Override
     default List<T> takeUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return takeWhile(predicate.negate());
@@ -1548,6 +1537,29 @@ public interface List<T> extends LinearSeq<T> {
             result = result.prepend(list.head());
         }
         return result.length() == length() ? this : result.reverse();
+    }
+
+    @Override
+    default List<T> takeRight(int n) {
+        if (n <= 0) {
+            return empty();
+        }
+        if (n >= length()) {
+            return this;
+        }
+        return reverse().take(n).reverse();
+    }
+
+    @Override
+    default List<T> takeRightUntil(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return takeRightWhile(predicate.negate());
+    }
+
+    @Override
+    default List<T> takeRightWhile(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reverse().takeWhile(predicate).reverse();
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
+++ b/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
@@ -321,12 +321,6 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
     }
 
     @Override
-    public PriorityQueue<T> dropUntil(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return dropWhile(predicate.negate());
-    }
-
-    @Override
     public PriorityQueue<T> dropWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         PriorityQueue<T> result = this;

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -722,11 +722,6 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
-    public Queue<T> dropUntil(Predicate<? super T> predicate) {
-        return dropWhile(predicate.negate());
-    }
-
-    @Override
     public Queue<T> dropWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         final List<T> dropped = toList().dropWhile(predicate);
@@ -1213,6 +1208,13 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
+    public Queue<T> takeUntil(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        final io.vavr.collection.List<T> taken = toList().takeUntil(predicate);
+        return taken.length() == length() ? this : ofAll(taken);
+    }
+
+    @Override
     public Queue<T> takeRight(int n) {
         if (n <= 0) {
             return empty();
@@ -1231,10 +1233,16 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
-    public Queue<T> takeUntil(Predicate<? super T> predicate) {
+    public Queue<T> takeRightUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        final io.vavr.collection.List<T> taken = toList().takeUntil(predicate);
+        final io.vavr.collection.List<T> taken = toList().takeRightUntil(predicate);
         return taken.length() == length() ? this : ofAll(taken);
+    }
+
+    @Override
+    public Queue<T> takeRightWhile(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return takeRightUntil(predicate.negate());
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/Seq.java
+++ b/vavr/src/main/java/io/vavr/collection/Seq.java
@@ -1081,7 +1081,7 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
      * Drops elements until the predicate holds for the current element, starting from the end.
      *
      * @param predicate A condition tested subsequently for this elements, starting from the end.
-     * @return a new instance consisting of all elements starting from the last one which does satisfy the given
+     * @return a new instance consisting of all elements until and including the last one which does satisfy the given
      * predicate.
      * @throws NullPointerException if {@code predicate} is null
      */
@@ -1094,7 +1094,7 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
      * It is intended to be used with method references, which cannot be negated directly.
      *
      * @param predicate A condition tested subsequently for this elements, starting from the end.
-     * @return a new instance consisting of all elements starting from the last one which does not satisfy the
+     * @return a new instance consisting of all elements until and including the last one which does not satisfy the
      * given predicate.
      * @throws NullPointerException if {@code predicate} is null
      */
@@ -1179,13 +1179,34 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
     Seq<T> take(int n);
 
     @Override
-    Seq<T> takeRight(int n);
-
-    @Override
     Seq<T> takeUntil(Predicate<? super T> predicate);
 
     @Override
     Seq<T> takeWhile(Predicate<? super T> predicate);
+
+    @Override
+    Seq<T> takeRight(int n);
+
+    /**
+     * Takes elements until the predicate holds for the current element, starting from the end.
+     *
+     * @param predicate A condition tested subsequently for this elements, starting from the end.
+     * @return a new instance consisting of all elements after the last one which does satisfy the given predicate.
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Seq<T> takeRightUntil(Predicate<? super T> predicate);
+
+    /**
+     * Takes elements while the predicate holds for the current element, starting from the end.
+     * <p>
+     * Note: This is essentially the same as {@code takeRightUntil(predicate.negate())}.
+     * It is intended to be used with method references, which cannot be negated directly.
+     *
+     * @param predicate A condition tested subsequently for this elements, starting from the end.
+     * @return a new instance consisting of all elements after the last one which does not satisfy the given predicate.
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Seq<T> takeRightWhile(Predicate<? super T> predicate);
 
     @Override
     <T1, T2> Tuple2<? extends Seq<T1>, ? extends Seq<T2>> unzip(Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper);

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -1535,17 +1535,6 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> takeRight(int n) {
-        Stream<T> right = this;
-        Stream<T> remaining = drop(n);
-        while (!remaining.isEmpty()) {
-            right = right.tail();
-            remaining = remaining.tail();
-        }
-        return right;
-    }
-
-    @Override
     default Stream<T> takeUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return takeWhile(predicate.negate());
@@ -1564,6 +1553,29 @@ public interface Stream<T> extends LinearSeq<T> {
                 return Empty.instance();
             }
         }
+    }
+
+    @Override
+    default Stream<T> takeRight(int n) {
+        Stream<T> right = this;
+        Stream<T> remaining = drop(n);
+        while (!remaining.isEmpty()) {
+            right = right.tail();
+            remaining = remaining.tail();
+        }
+        return right;
+    }
+
+    @Override
+    default Stream<T> takeRightUntil(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reverse().takeUntil(predicate).reverse();
+    }
+
+    @Override
+    default Stream<T> takeRightWhile(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return takeRightUntil(predicate.negate());
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/Traversable.java
+++ b/vavr/src/main/java/io/vavr/collection/Traversable.java
@@ -1369,7 +1369,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * In the case of {@code n < 0} the empty instance is returned, in the case of {@code n > length()} this is returned.
      *
      * @param n The number of elements to take.
-     * @return A new instance consisting the first n elements of this or all elements, if this has less than n elements.
+     * @return A new instance consisting of the first n elements of this or all elements, if this has less than n elements.
      */
     Traversable<T> take(int n);
 
@@ -1382,7 +1382,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * In the case of {@code n < 0} the empty instance is returned, in the case of {@code n > length()} this is returned.
      *
      * @param n The number of elements to take.
-     * @return A new instance consisting the first n elements of this or all elements, if this has less than n elements.
+     * @return A new instance consisting of the last n elements of this or all elements, if this has less than n elements.
      */
     Traversable<T> takeRight(int n);
 
@@ -1393,7 +1393,8 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * method references, which cannot be negated directly.
      *
      * @param predicate A condition tested subsequently for this elements.
-     * @return a new instance consisting of all elements until the first which does satisfy the given predicate.
+     * @return a new instance consisting of all elements before the first one which does satisfy the given
+     * predicate.
      * @throws NullPointerException if {@code predicate} is null
      */
     Traversable<T> takeUntil(Predicate<? super T> predicate);
@@ -1402,7 +1403,8 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * Takes elements while the predicate holds for the current element.
      *
      * @param predicate A condition tested subsequently for the contained elements.
-     * @return a new instance consisting of all elements until the first which does not satisfy the given predicate.
+     * @return a new instance consisting of all elements before the first one which does not satisfy the
+     * given predicate.
      * @throws NullPointerException if {@code predicate} is null
      */
     Traversable<T> takeWhile(Predicate<? super T> predicate);

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -1144,26 +1144,30 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
-    public Vector<T> takeRight(int n) {
-        return drop(length() - n);
-    }
-
-    @Override
     public Vector<T> takeUntil(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return takeWhile(predicate.negate());
+        return io.vavr.collection.Collections.takeUntil(this, predicate);
     }
 
     @Override
     public Vector<T> takeWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        for (int i = 0; i < length(); i++) {
-            final T value = get(i);
-            if (!predicate.test(value)) {
-                return take(i);
-            }
-        }
-        return this;
+        return takeUntil(predicate.negate());
+    }
+
+    @Override
+    public Vector<T> takeRight(int n) {
+        return drop(length() - n);
+    }
+
+    @Override
+    public Vector<T> takeRightUntil(Predicate<? super T> predicate) {
+        return io.vavr.collection.Collections.takeRightUntil(this, predicate);
+    }
+
+    @Override
+    public Vector<T> takeRightWhile(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return takeRightUntil(predicate.negate());
     }
 
     /**

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -1497,6 +1497,50 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         assertThat(shuffled.indexOf(4)).isEqualTo(-1);
     }
 
+    // -- takeRightUntil
+
+    @Test
+    public void shouldTakeRightUntilNoneOnNil() {
+        assertThat(empty().takeRightUntil(x -> true)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldTakeRightUntilAllOnFalseCondition() {
+        assertThat(of(1, 2, 3).takeRightUntil(x -> false)).isEqualTo(of(1, 2, 3));
+    }
+
+    @Test
+    public void shouldTakeRightUntilAllOnTrueCondition() {
+        assertThat(of(1, 2, 3).takeRightUntil(x -> true)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldTakeRightUntilAsExpected() {
+        assertThat(of(2, 3, 4, 6).takeRightUntil(x -> x % 2 != 0)).isEqualTo(of(4, 6));
+    }
+
+    // -- takeRightWhile
+
+    @Test
+    public void shouldTakeRightWhileNoneOnNil() {
+        assertThat(empty().takeRightWhile(x -> true)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldTakeRightWhileAllOnFalseCondition() {
+        assertThat(of(1, 2, 3).takeRightWhile(x -> false)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldTakeRightWhileAllOnTrueCondition() {
+        assertThat(of(1, 2, 3).takeRightWhile(x -> true)).isEqualTo(of(1, 2, 3));
+    }
+
+    @Test
+    public void shouldTakeRightWhileAsExpected() {
+        assertThat(of(2, 3, 4, 6).takeRightWhile(x -> x % 2 == 0)).isEqualTo(of(4, 6));
+    }
+
     // -- update
 
     @Test(expected = IndexOutOfBoundsException.class)

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -605,29 +605,6 @@ public class CharSeqTest {
         assertThat(CharSeq.of('1', '2', '3').drop('4')).isSameAs(CharSeq.empty());
     }
 
-    // -- dropRight
-
-    @Test
-    public void shouldDropRightNoneOnNil() {
-        assertThat(CharSeq.empty().dropRight(1)).isSameAs(CharSeq.empty());
-    }
-
-    @Test
-    public void shouldDropRightNoneIfCountIsNegative() {
-        final CharSeq t = CharSeq.of('1', '2', '3');
-        assertThat(t.dropRight(-1)).isSameAs(t);
-    }
-
-    @Test
-    public void shouldDropRightAsExpectedIfCountIsLessThanSize() {
-        assertThat(CharSeq.of('1', '2', '3').dropRight(2)).isEqualTo(CharSeq.of('1'));
-    }
-
-    @Test
-    public void shouldDropRightAllIfCountExceedsSize() {
-        assertThat(CharSeq.of('1', '2', '3').dropRight(4)).isSameAs(CharSeq.empty());
-    }
-
     // -- dropUntil
 
     @Test
@@ -671,6 +648,29 @@ public class CharSeqTest {
     @Test
     public void shouldDropWhileCorrect() {
         assertThat(CharSeq.of('1', '2', '3').dropWhile(i -> i == '1')).isEqualTo(CharSeq.of('2', '3'));
+    }
+
+    // -- dropRight
+
+    @Test
+    public void shouldDropRightNoneOnNil() {
+        assertThat(CharSeq.empty().dropRight(1)).isSameAs(CharSeq.empty());
+    }
+
+    @Test
+    public void shouldDropRightNoneIfCountIsNegative() {
+        final CharSeq t = CharSeq.of('1', '2', '3');
+        assertThat(t.dropRight(-1)).isSameAs(t);
+    }
+
+    @Test
+    public void shouldDropRightAsExpectedIfCountIsLessThanSize() {
+        assertThat(CharSeq.of('1', '2', '3').dropRight(2)).isEqualTo(CharSeq.of('1'));
+    }
+
+    @Test
+    public void shouldDropRightAllIfCountExceedsSize() {
+        assertThat(CharSeq.of('1', '2', '3').dropRight(4)).isSameAs(CharSeq.empty());
     }
 
     // -- dropRightUntil
@@ -1756,27 +1756,27 @@ public class CharSeqTest {
         assertThat(t.take(4)).isSameAs(t);
     }
 
-    // -- takeRight
+    // -- takeUntil
 
     @Test
-    public void shouldTakeRightNoneOnNil() {
-        assertThat(CharSeq.empty().takeRight(1)).isSameAs(CharSeq.empty());
+    public void shouldTakeUntilNoneOnNil() {
+        assertThat(CharSeq.empty().takeUntil(x -> true)).isSameAs(CharSeq.empty());
     }
 
     @Test
-    public void shouldTakeRightNoneIfCountIsNegative() {
-        assertThat(CharSeq.of('1', '2', '3').takeRight(-1)).isSameAs(CharSeq.empty());
-    }
-
-    @Test
-    public void shouldTakeRightAsExpectedIfCountIsLessThanSize() {
-        assertThat(CharSeq.of('1', '2', '3').takeRight(2)).isEqualTo(CharSeq.of('2', '3'));
-    }
-
-    @Test
-    public void shouldTakeRightAllIfCountExceedsSize() {
+    public void shouldTakeUntilAllOnFalseCondition() {
         final CharSeq t = CharSeq.of('1', '2', '3');
-        assertThat(t.takeRight(4)).isSameAs(t);
+        assertThat(t.takeUntil(x -> false)).isSameAs(t);
+    }
+
+    @Test
+    public void shouldTakeUntilAllOnTrueCondition() {
+        assertThat(CharSeq.of('1', '2', '3').takeUntil(x -> true)).isSameAs(CharSeq.empty());
+    }
+
+    @Test
+    public void shouldTakeUntilAsExpected() {
+        assertThat(CharSeq.of('2', '4', '5', '6').takeUntil(x -> x % 2 != 0)).isEqualTo(CharSeq.of('2', '4'));
     }
 
     // -- takeWhile
@@ -1802,27 +1802,73 @@ public class CharSeqTest {
         assertThat(CharSeq.of('2', '4', '5', '6').takeWhile(x -> x % 2 == 0)).isEqualTo(CharSeq.of('2', '4'));
     }
 
-    // -- takeUntil
+    // -- takeRight
 
     @Test
-    public void shouldTakeUntilNoneOnNil() {
-        assertThat(CharSeq.empty().takeUntil(x -> true)).isSameAs(CharSeq.empty());
+    public void shouldTakeRightNoneOnNil() {
+        assertThat(CharSeq.empty().takeRight(1)).isSameAs(CharSeq.empty());
     }
 
     @Test
-    public void shouldTakeUntilAllOnFalseCondition() {
+    public void shouldTakeRightNoneIfCountIsNegative() {
+        assertThat(CharSeq.of('1', '2', '3').takeRight(-1)).isSameAs(CharSeq.empty());
+    }
+
+    @Test
+    public void shouldTakeRightAsExpectedIfCountIsLessThanSize() {
+        assertThat(CharSeq.of('1', '2', '3').takeRight(2)).isEqualTo(CharSeq.of('2', '3'));
+    }
+
+    @Test
+    public void shouldTakeRightAllIfCountExceedsSize() {
         final CharSeq t = CharSeq.of('1', '2', '3');
-        assertThat(t.takeUntil(x -> false)).isSameAs(t);
+        assertThat(t.takeRight(4)).isSameAs(t);
+    }
+
+    // -- takeRightUntil
+
+    @Test
+    public void shouldTakeRightUntilNoneOnNil() {
+        assertThat(CharSeq.empty().takeRightUntil(x -> true)).isSameAs(CharSeq.empty());
     }
 
     @Test
-    public void shouldTakeUntilAllOnTrueCondition() {
-        assertThat(CharSeq.of('1', '2', '3').takeUntil(x -> true)).isSameAs(CharSeq.empty());
+    public void shouldTakeRightUntilAllOnFalseCondition() {
+        final CharSeq t = CharSeq.of('1', '2', '3');
+        assertThat(t.takeRightUntil(x -> false)).isSameAs(t);
     }
 
     @Test
-    public void shouldTakeUntilAsExpected() {
-        assertThat(CharSeq.of('2', '4', '5', '6').takeUntil(x -> x % 2 != 0)).isEqualTo(CharSeq.of('2', '4'));
+    public void shouldTakeRightUntilAllOnTrueCondition() {
+        assertThat(CharSeq.of('1', '2', '3').takeRightUntil(x -> true)).isSameAs(CharSeq.empty());
+    }
+
+    @Test
+    public void shouldTakeRightUntilAsExpected() {
+        assertThat(CharSeq.of('2', '3', '4', '6').takeRightUntil(x -> x % 2 != 0)).isEqualTo(CharSeq.of('4', '6'));
+    }
+
+    // -- takeRightWhile
+
+    @Test
+    public void shouldTakeRightWhileNoneOnNil() {
+        assertThat(CharSeq.empty().takeRightWhile(x -> true)).isSameAs(CharSeq.empty());
+    }
+
+    @Test
+    public void shouldTakeRightWhileAllOnFalseCondition() {
+        assertThat(CharSeq.of('1', '2', '3').takeRightWhile(x -> false)).isSameAs(CharSeq.empty());
+    }
+
+    @Test
+    public void shouldTakeRightWhileAllOnTrueCondition() {
+        final CharSeq t = CharSeq.of('1', '2', '3');
+        assertThat(t.takeRightWhile(x -> true)).isSameAs(t);
+    }
+
+    @Test
+    public void shouldTakeRightWhileAsExpected() {
+        assertThat(CharSeq.of('2', '3', '4', '6').takeRightWhile(x -> x % 2 == 0)).isEqualTo(CharSeq.of('4', '6'));
     }
 
     // -- tail


### PR DESCRIPTION
`takeRightUntil` and `takeRightWhile` were conspiciously missing from `Seq`, while `dropRightUntil` and `dropRightWhile` are there.

This pull request adds the missing methods with a standardized implementation for `IndexedSeq`, also fixes/improves some docstrings.