### PR TITLE
Use maven the enforcer plugin to require maven 3.0.5+.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,6 @@ Note: The maven build currently needs to be started from the vavr root dir
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.0.5</maven>
-    </prerequisites>
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
@@ -70,6 +67,7 @@ Note: The maven build currently needs to be started from the vavr root dir
         <jmh.version>1.18</jmh.version>
         <junit.version>4.12</junit.version>
         <gwt.version>2.8.0</gwt.version>
+        <maven.enforcer.version>1.4.1</maven.enforcer.version>
         <maven.build-helper.version>1.12</maven.build-helper.version>
         <maven.bundle.version>3.2.0</maven.bundle.version>
         <maven.clean.version>3.0.0</maven.clean.version>
@@ -110,6 +108,26 @@ Note: The maven build currently needs to be started from the vavr root dir
     </dependencyManagement>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven.enforcer.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.0.5</version>
+                                </requireMavenVersion>
+                            </rules> 
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>

--- a/vavr-benchmark/pom.xml
+++ b/vavr-benchmark/pom.xml
@@ -1,9 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.0.5</maven>
-    </prerequisites>
     <parent>
         <groupId>io.vavr</groupId>
         <artifactId>vavr-parent</artifactId>

--- a/vavr-match/pom.xml
+++ b/vavr-match/pom.xml
@@ -1,8 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.0.5</maven>
-    </prerequisites>
     <parent>
         <groupId>io.vavr</groupId>
         <artifactId>vavr-parent</artifactId>

--- a/vavr-test/pom.xml
+++ b/vavr-test/pom.xml
@@ -1,8 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.0.5</maven>
-    </prerequisites>
     <parent>
         <groupId>io.vavr</groupId>
         <artifactId>vavr-parent</artifactId>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -1,8 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.0.5</maven>
-    </prerequisites>
     <parent>
         <groupId>io.vavr</groupId>
         <artifactId>vavr-parent</artifactId>


### PR DESCRIPTION
This fixes a maven warning concerning use of prerequisites by a non maven plugin project.