### PR TITLE
Simplified numeric Traversable methods.

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/Comparators.java
+++ b/vavr/src/main/java/io/vavr/collection/Comparators.java
@@ -45,7 +45,6 @@ final class Comparators {
     static <U> Comparator<U> naturalComparator() {
         return NaturalComparator.instance();
     }
-
 }
 
 final class NaturalComparator<T> implements Comparator<T>, Serializable {
@@ -66,6 +65,17 @@ final class NaturalComparator<T> implements Comparator<T>, Serializable {
     @Override
     public int compare(T o1, T o2) {
         return ((Comparable<T>) o1).compareTo(o2);
+    }
+
+    /** @see Comparator#equals(Object) */
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof NaturalComparator;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/RedBlackTree.java
+++ b/vavr/src/main/java/io/vavr/collection/RedBlackTree.java
@@ -48,30 +48,15 @@ import static io.vavr.collection.RedBlackTree.Color.RED;
  */
 interface RedBlackTree<T> extends Iterable<T> {
 
-    static <T extends Comparable<? super T>> RedBlackTree<T> empty() {
-        return new Empty<>(Comparators.naturalComparator());
-    }
-
     static <T> RedBlackTree<T> empty(Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
         return new Empty<>(comparator);
-    }
-
-    static <T extends Comparable<? super T>> RedBlackTree<T> of(T value) {
-        return of(Comparators.naturalComparator(), value);
     }
 
     static <T> RedBlackTree<T> of(Comparator<? super T> comparator, T value) {
         Objects.requireNonNull(comparator, "comparator is null");
         final Empty<T> empty = new Empty<>(comparator);
         return new Node<>(BLACK, 1, empty, value, empty, empty);
-    }
-
-    @SuppressWarnings("varargs")
-    @SafeVarargs
-    static <T extends Comparable<? super T>> RedBlackTree<T> of(T... values) {
-        Objects.requireNonNull(values, "values is null");
-        return of(Comparators.<T> naturalComparator(), values);
     }
 
     @SafeVarargs
@@ -83,11 +68,6 @@ interface RedBlackTree<T> extends Iterable<T> {
             tree = tree.insert(value);
         }
         return tree;
-    }
-
-    static <T extends Comparable<? super T>> RedBlackTree<T> ofAll(Iterable<? extends T> values) {
-        Objects.requireNonNull(values, "values is null");
-        return ofAll(Comparators.naturalComparator(), values);
     }
 
     @SuppressWarnings("unchecked")

--- a/vavr/src/main/java/io/vavr/collection/TreeMap.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeMap.java
@@ -1573,6 +1573,16 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
                 return Comparators.naturalComparator();
             }
 
+            @Override
+            public boolean equals(Object obj) {
+                return obj instanceof Natural;
+            }
+
+            @Override
+            public int hashCode() {
+                return 1;
+            }
+
             /**
              * Instance control for object serialization.
              *

--- a/vavr/src/main/java/io/vavr/collection/TreeSet.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeSet.java
@@ -81,7 +81,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     }
 
     public static <T extends Comparable<? super T>> TreeSet<T> empty() {
-        return new TreeSet<>(RedBlackTree.<T> empty());
+        return empty(Comparators.naturalComparator());
     }
 
     public static <T> TreeSet<T> empty(Comparator<? super T> comparator) {
@@ -106,7 +106,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     }
 
     public static <T extends Comparable<? super T>> TreeSet<T> of(T value) {
-        return new TreeSet<>(RedBlackTree.of(value));
+        return of(Comparators.naturalComparator(), value);
     }
 
     public static <T> TreeSet<T> of(Comparator<? super T> comparator, T value) {
@@ -117,8 +117,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     @SuppressWarnings("varargs")
     @SafeVarargs
     public static <T extends Comparable<? super T>> TreeSet<T> of(T... values) {
-        Objects.requireNonNull(values, "values is null");
-        return new TreeSet<>(RedBlackTree.of(values));
+        return TreeSet.<T> of(Comparators.naturalComparator(), values);
     }
 
     @SuppressWarnings("varargs")
@@ -195,12 +194,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
 
     @SuppressWarnings("unchecked")
     public static <T extends Comparable<? super T>> TreeSet<T> ofAll(Iterable<? extends T> values) {
-        Objects.requireNonNull(values, "values is null");
-        if (values instanceof TreeSet) {
-            return (TreeSet<T>) values;
-        } else {
-            return values.iterator().hasNext() ? new TreeSet<>(RedBlackTree.ofAll(values)) : empty();
-        }
+        return ofAll(Comparators.naturalComparator(), values);
     }
 
     @SuppressWarnings("unchecked")
@@ -210,9 +204,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
         if (values instanceof TreeSet && ((TreeSet) values).comparator() == comparator) {
             return (TreeSet<T>) values;
         } else {
-            return values.iterator().hasNext()
-                   ? new TreeSet<>(RedBlackTree.ofAll(comparator, values))
-                   : (TreeSet<T>) empty();
+            return values.iterator().hasNext() ? new TreeSet<>(RedBlackTree.ofAll(comparator, values)) : (TreeSet<T>) empty();
         }
     }
 
@@ -765,16 +757,6 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     @Override
     public <U> TreeSet<U> map(Function<? super T, ? extends U> mapper) {
         return map(Comparators.naturalComparator(), mapper);
-    }
-
-    @Override
-    public Option<T> max() {
-        return tree.max();
-    }
-
-    @Override
-    public Option<T> min() {
-        return tree.min();
     }
 
     /**

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -256,6 +256,38 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         assertThat(of(BigDecimal.ZERO, BigDecimal.ONE).average().get()).isEqualTo(.5);
     }
 
+    @Test
+    public void shouldComputeAvergageAndCompensateErrors() {
+        // Kahan's summation algorithm (used by DoubleStream.average()) returns 0.0 (false)
+        // Neumaier's modification of Kahan's algorithm returns 0.75 (correct)
+        assertThat(of(1.0, +10e100, 2.0, -10e100).average().get()).isEqualTo(0.75);
+    }
+
+    @Test
+    public void shouldCalculateAverageOfDoublesContainingNaN() {
+        assertThat(of(1.0, Double.NaN, 2.0).average().get()).isEqualTo(Double.NaN);
+    }
+
+    @Test
+    public void shouldCalculateAverageOfFloatsContainingNaN() {
+        assertThat(of(1.0f, Float.NaN, 2.0f).average().get()).isEqualTo(Float.NaN);
+    }
+
+    @Test
+    public void shouldCalculateAverageOfDoubleAndFloat() {
+        assertThat(this.<Number> of(1.0, 1.0f).average().get()).isEqualTo(1.0);
+    }
+
+    @Test
+    public void shouldCalculateAverageOfDoublePositiveAndNegativeInfinity() {
+        assertThat(of(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY).average().get()).isEqualTo(Double.NaN);
+    }
+
+    @Test
+    public void shouldCalculateAverageOfFloatPositiveAndNegativeInfinity() {
+        assertThat(of(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY).average().get()).isEqualTo(Float.NaN);
+    }
+
     // -- collect
 
     @Test
@@ -1157,6 +1189,31 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         of(1, null).max();
     }
 
+    @Test
+    public void shouldCalculateMaxOfDoublesContainingNaN() {
+        assertThat(of(1.0, Double.NaN, 2.0).max().get()).isEqualTo(Double.NaN);
+    }
+
+    @Test
+    public void shouldCalculateMaxOfFloatsContainingNaN() {
+        assertThat(of(1.0f, Float.NaN, 2.0f).max().get()).isEqualTo(Float.NaN);
+    }
+
+    @Test
+    public void shouldThrowClassCastExceptionWhenTryingToCalculateMaxOfDoubleAndFloat() {
+        assertThatThrownBy(() -> this.<Number> of(1.0, 1.0f).max()).isInstanceOf(ClassCastException.class);
+    }
+
+    @Test
+    public void shouldCalculateMaxOfDoublePositiveAndNegativeInfinity() {
+        assertThat(of(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY).max().get()).isEqualTo(Double.POSITIVE_INFINITY);
+    }
+
+    @Test
+    public void shouldCalculateMaxOfFloatPositiveAndNegativeInfinity() {
+        assertThat(of(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY).max().get()).isEqualTo(Float.POSITIVE_INFINITY);
+    }
+
     // -- maxBy(Comparator)
 
     @Test(expected = NullPointerException.class)
@@ -1284,6 +1341,34 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
     @Test(expected = NullPointerException.class)
     public void shouldThrowNPEWhenMinOfIntAndNull() {
         of(1, null).min();
+    }
+
+    @Test
+    public void shouldCalculateMinOfDoublesContainingNaN() {
+        assertThat(of(1.0, Double.NaN, 2.0).min().get()).isEqualTo(Double.NaN);
+    }
+
+    @Test
+    public void shouldCalculateMinOfFloatsContainingNaN() {
+
+        System.out.println(TreeSet.of(1.0f, Float.NaN, 2.0f));
+
+        assertThat(of(1.0f, Float.NaN, 2.0f).min().get()).isEqualTo(Float.NaN);
+    }
+
+    @Test
+    public void shouldThrowClassCastExceptionWhenTryingToCalculateMinOfDoubleAndFloat() {
+        assertThatThrownBy(() -> this.<Number> of(1.0, 1.0f).min()).isInstanceOf(ClassCastException.class);
+    }
+
+    @Test
+    public void shouldCalculateMinOfDoublePositiveAndNegativeInfinity() {
+        assertThat(of(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY).min().get()).isEqualTo(Double.NEGATIVE_INFINITY);
+    }
+
+    @Test
+    public void shouldCalculateMinOfFloatPositiveAndNegativeInfinity() {
+        assertThat(of(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY).min().get()).isEqualTo(Double.NEGATIVE_INFINITY);
     }
 
     // -- minBy(Comparator)
@@ -1456,12 +1541,12 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldComputeProductOfBigInteger() {
-        assertThat(of(BigInteger.ZERO, BigInteger.ONE).product()).isEqualTo(0L);
+        assertThat(of(BigInteger.ZERO, BigInteger.ONE).product()).isEqualTo(BigInteger.ZERO);
     }
 
     @Test
     public void shouldComputeProductOfBigDecimal() {
-        assertThat(of(BigDecimal.ZERO, BigDecimal.ONE).product()).isEqualTo(0.0);
+        assertThat(of(BigDecimal.ZERO, BigDecimal.ONE).product()).isEqualTo(BigDecimal.ZERO);
     }
 
     // -- reduceOption
@@ -2050,12 +2135,12 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
 
     @Test
     public void shouldComputeSumOfBigInteger() {
-        assertThat(of(BigInteger.ZERO, BigInteger.ONE).sum()).isEqualTo(1L);
+        assertThat(of(BigInteger.ZERO, BigInteger.ONE).sum()).isEqualTo(BigInteger.ONE);
     }
 
     @Test
     public void shouldComputeSumOfBigDecimal() {
-        assertThat(of(BigDecimal.ZERO, BigDecimal.ONE).sum()).isEqualTo(1.0);
+        assertThat(of(BigDecimal.ZERO, BigDecimal.ONE).sum()).isEqualTo(BigDecimal.ONE);
     }
 
     // -- take

--- a/vavr/src/test/java/io/vavr/collection/PriorityQueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/PriorityQueueTest.java
@@ -20,6 +20,7 @@
 package io.vavr.collection;
 
 import io.vavr.Tuple;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -328,4 +329,14 @@ public class PriorityQueueTest extends AbstractTraversableTest {
             assertThat(oldQueue.peek()).isEqualTo(newQueue.head());
         }
     }
+
+    // -- ignored tests
+
+    @Override
+    @Test
+    @Ignore
+    public void shouldCalculateAverageOfDoubleAndFloat() {
+        // it is not possible to create a PriorityQueue containing unrelated types
+    }
+
 }

--- a/vavr/src/test/java/io/vavr/collection/RedBlackTreeTest.java
+++ b/vavr/src/test/java/io/vavr/collection/RedBlackTreeTest.java
@@ -27,13 +27,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RedBlackTreeTest {
 
+    private static <T> RedBlackTree<T> empty() {
+        return RedBlackTree.empty(Comparators.naturalComparator());
+    }
+
+    private static <T> RedBlackTree<T> of(T value) {
+        return RedBlackTree.of(Comparators.naturalComparator(), value);
+    }
+
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    private static <T> RedBlackTree<T> of(T... values) {
+        return RedBlackTree.<T> of(Comparators.naturalComparator(), values);
+    }
+
     // Rudimentary tests
 
     // empty tree
 
     @Test
     public void shouldCreateEmptyTree() {
-        final RedBlackTree<Integer> tree = RedBlackTree.empty();
+        final RedBlackTree<Integer> tree = empty();
         assertThat(tree.isEmpty()).isTrue();
         assertThat(tree.size()).isEqualTo(0);
         assertThat(tree.color()).isEqualTo(RedBlackTree.Color.BLACK);
@@ -41,46 +55,46 @@ public class RedBlackTreeTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void shouldFailLeftOfEmpty() {
-        RedBlackTree.empty().left();
+        empty().left();
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void shouldFailRightOfEmpty() {
-        RedBlackTree.empty().right();
+        empty().right();
     }
 
     @Test(expected = NoSuchElementException.class)
     public void shouldFailValueOfEmpty() {
-        RedBlackTree.empty().value();
+        empty().value();
     }
 
     // isEmpty
 
     @Test
     public void shouldRecognizeEmptyTree() {
-        assertThat(RedBlackTree.empty().isEmpty()).isTrue();
+        assertThat(empty().isEmpty()).isTrue();
     }
 
     @Test
     public void shouldRecognizeNonEmptyTree() {
-        assertThat(RedBlackTree.of(1).isEmpty()).isFalse();
+        assertThat(of(1).isEmpty()).isFalse();
     }
 
     // contains
 
     @Test
     public void shouldRecognizeContainedElement() {
-        assertThat(RedBlackTree.of(1, 2, 3).contains(2)).isTrue();
+        assertThat(of(1, 2, 3).contains(2)).isTrue();
     }
 
     @Test
     public void shouldRecognizeNonContainedElementOfEmptyTree() {
-        assertThat(RedBlackTree.<Integer> empty().contains(1)).isFalse();
+        assertThat(RedBlackTreeTest.<Integer> empty().contains(1)).isFalse();
     }
 
     @Test
     public void shouldRecognizeNonContainedElementOfNonEmptyTree() {
-        assertThat(RedBlackTree.of(1, 2, 3).contains(0)).isFalse();
+        assertThat(of(1, 2, 3).contains(0)).isFalse();
     }
 
     // insert
@@ -88,7 +102,7 @@ public class RedBlackTreeTest {
     @Test
     public void shouldInsert_2_1_4_5_9_3_6_7() {
 
-        RedBlackTree<Integer> tree = RedBlackTree.empty();
+        RedBlackTree<Integer> tree = empty();
         assertThat(tree.toString()).isEqualTo("()");
         assertThat(tree.size()).isEqualTo(0);
 
@@ -127,26 +141,26 @@ public class RedBlackTreeTest {
 
     @Test
     public void shouldInsertNullIntoEmptyTreeBecauseComparatorNotCalled() {
-        final RedBlackTree<Integer> actual = RedBlackTree.<Integer> empty().insert(null);
-        final RedBlackTree<Integer> expected = RedBlackTree.of((Integer) null);
+        final RedBlackTree<Integer> actual = RedBlackTreeTest.<Integer> empty().insert(null);
+        final RedBlackTree<Integer> expected = of((Integer) null);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldNotInsertNullTwoTimesIntoEmptyTreeBecauseComparatorCalled() {
-        RedBlackTree.<Integer> empty().insert(null).insert(null);
+        RedBlackTreeTest.<Integer> empty().insert(null).insert(null);
     }
 
     @Test
     public void shouldInsertNonNullIntoEmptyTree() {
-        final RedBlackTree<Integer> actual = RedBlackTree.<Integer> empty().insert(2);
-        final RedBlackTree<Integer> expected = RedBlackTree.of(2);
+        final RedBlackTree<Integer> actual = RedBlackTreeTest.<Integer> empty().insert(2);
+        final RedBlackTree<Integer> expected = of(2);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldReturnTheSameInstanceWhenInsertingAnAlreadyContainedELement() {
-        final RedBlackTree<Integer> testee = RedBlackTree.of(1, 2, 3);
+        final RedBlackTree<Integer> testee = of(1, 2, 3);
         final RedBlackTree<Integer> actual = testee.insert(2);
         assertThat(actual).isEqualTo(testee);
     }
@@ -155,7 +169,7 @@ public class RedBlackTreeTest {
 
     @Test
     public void shouldDelete_2_from_2_1_4_5_9_3_6_7() {
-        final RedBlackTree<Integer> testee = RedBlackTree.of(2, 1, 4, 5, 9, 3, 6, 7);
+        final RedBlackTree<Integer> testee = of(2, 1, 4, 5, 9, 3, 6, 7);
         final RedBlackTree<Integer> actual = testee.delete(2);
         assertThat(actual.toString()).isEqualTo("(B:4 (B:3 R:1) (R:6 B:5 (B:9 R:7)))");
         assertThat(actual.size()).isEqualTo(7);
@@ -165,26 +179,26 @@ public class RedBlackTreeTest {
 
     @Test
     public void shouldSubtractEmptyFromNonEmpty() {
-        final RedBlackTree<Integer> t1 = RedBlackTree.of(3, 5);
-        final RedBlackTree<Integer> t2 = RedBlackTree.empty();
+        final RedBlackTree<Integer> t1 = of(3, 5);
+        final RedBlackTree<Integer> t2 = empty();
         final RedBlackTree<Integer> actual = t1.difference(t2);
         assertThat(actual).isEqualTo(t1);
     }
 
     @Test
     public void shouldSubtractNonEmptyFromEmpty() {
-        final RedBlackTree<Integer> t1 = RedBlackTree.empty();
-        final RedBlackTree<Integer> t2 = RedBlackTree.of(5, 7);
+        final RedBlackTree<Integer> t1 = empty();
+        final RedBlackTree<Integer> t2 = of(5, 7);
         final RedBlackTree<Integer> actual = t1.difference(t2);
         assertThat(actual).isEqualTo(t1);
     }
 
     @Test
     public void shouldSubtractNonEmptyFromNonEmpty() {
-        final RedBlackTree<Integer> t1 = RedBlackTree.of(3, 5);
-        final RedBlackTree<Integer> t2 = RedBlackTree.of(5, 7);
+        final RedBlackTree<Integer> t1 = of(3, 5);
+        final RedBlackTree<Integer> t2 = of(5, 7);
         final RedBlackTree<Integer> actual = t1.difference(t2);
-        final RedBlackTree<Integer> expected = RedBlackTree.of(3);
+        final RedBlackTree<Integer> expected = of(3);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -192,28 +206,28 @@ public class RedBlackTreeTest {
 
     @Test
     public void shouldIntersectOnNonEmptyGivenEmpty() {
-        final RedBlackTree<Integer> t1 = RedBlackTree.of(3, 5);
-        final RedBlackTree<Integer> t2 = RedBlackTree.empty();
+        final RedBlackTree<Integer> t1 = of(3, 5);
+        final RedBlackTree<Integer> t2 = empty();
         final RedBlackTree<Integer> actual = t1.intersection(t2);
-        final RedBlackTree<Integer> expected = RedBlackTree.empty();
+        final RedBlackTree<Integer> expected = empty();
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldIntersectOnEmptyGivenNonEmpty() {
-        final RedBlackTree<Integer> t1 = RedBlackTree.empty();
-        final RedBlackTree<Integer> t2 = RedBlackTree.of(5, 7);
+        final RedBlackTree<Integer> t1 = empty();
+        final RedBlackTree<Integer> t2 = of(5, 7);
         final RedBlackTree<Integer> actual = t1.intersection(t2);
-        final RedBlackTree<Integer> expected = RedBlackTree.empty();
+        final RedBlackTree<Integer> expected = empty();
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldIntersectOnNonEmptyGivenNonEmpty() {
-        final RedBlackTree<Integer> t1 = RedBlackTree.of(3, 5);
-        final RedBlackTree<Integer> t2 = RedBlackTree.of(5, 7);
+        final RedBlackTree<Integer> t1 = of(3, 5);
+        final RedBlackTree<Integer> t2 = of(5, 7);
         final RedBlackTree<Integer> actual = t1.intersection(t2);
-        final RedBlackTree<Integer> expected = RedBlackTree.of(5);
+        final RedBlackTree<Integer> expected = of(5);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -225,10 +239,10 @@ public class RedBlackTreeTest {
         // - different values
         // - similar to each other left children
         // - and unlike each other right children
-        final RedBlackTree<Integer> t1 = RedBlackTree.of(1, 2, 3, 4, 5, 6, 7, 8, 60, 66, 67);
-        final RedBlackTree<Integer> t2 = RedBlackTree.of(1, 2, 3, 10, 11, 12, 13, 14, 60, 76, 77);
+        final RedBlackTree<Integer> t1 = of(1, 2, 3, 4, 5, 6, 7, 8, 60, 66, 67);
+        final RedBlackTree<Integer> t2 = of(1, 2, 3, 10, 11, 12, 13, 14, 60, 76, 77);
         final RedBlackTree<Integer> actual = t1.intersection(t2);
-        final RedBlackTree<Integer> expected = RedBlackTree.of(1, 2, 3, 60);
+        final RedBlackTree<Integer> expected = of(1, 2, 3, 60);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -240,10 +254,10 @@ public class RedBlackTreeTest {
         // - different values
         // - unlike each other left children
         // - and similar to each other right children
-        final RedBlackTree<Integer> t1 = RedBlackTree.of(1, 2, 3, 4, 40, 61, 62, 63, 64, 65);
-        final RedBlackTree<Integer> t2 = RedBlackTree.of(2, 7, 8, 9, 50, 61, 62, 63, 64, 65);
+        final RedBlackTree<Integer> t1 = of(1, 2, 3, 4, 40, 61, 62, 63, 64, 65);
+        final RedBlackTree<Integer> t2 = of(2, 7, 8, 9, 50, 61, 62, 63, 64, 65);
         final RedBlackTree<Integer> actual = t1.intersection(t2);
-        final RedBlackTree<Integer> expected = RedBlackTree.of(2, 61, 62, 63, 64, 65);
+        final RedBlackTree<Integer> expected = of(2, 61, 62, 63, 64, 65);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -251,8 +265,8 @@ public class RedBlackTreeTest {
     public void shouldIntersectOnNonEmptyGivenNonEmptyBalancedHeightRight() {
         // Node::mergeEQ && isRed(n1.right)
         //
-        final RedBlackTree<Integer> t1 = RedBlackTree.of(-10, -20, -30, -40, -50, 1, 10, 20, 30);
-        final RedBlackTree<Integer> t2 = RedBlackTree.of(-10, -20, -30, -40, -50, 2, 10, 20, 30);
+        final RedBlackTree<Integer> t1 = of(-10, -20, -30, -40, -50, 1, 10, 20, 30);
+        final RedBlackTree<Integer> t2 = of(-10, -20, -30, -40, -50, 2, 10, 20, 30);
         assertThat(t1.intersection(t2)).isEqualTo(t1.delete(1));
     }
 
@@ -260,37 +274,37 @@ public class RedBlackTreeTest {
 
     @Test
     public void shouldUnionOnNonEmptyGivenEmpty() {
-        final RedBlackTree<Integer> t1 = RedBlackTree.of(3, 5);
-        final RedBlackTree<Integer> t2 = RedBlackTree.empty();
+        final RedBlackTree<Integer> t1 = of(3, 5);
+        final RedBlackTree<Integer> t2 = empty();
         final RedBlackTree<Integer> actual = t1.union(t2);
-        final RedBlackTree<Integer> expected = RedBlackTree.of(3, 5);
+        final RedBlackTree<Integer> expected = of(3, 5);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldUnionOnEmptyGivenNonEmpty() {
-        final RedBlackTree<Integer> t1 = RedBlackTree.empty();
-        final RedBlackTree<Integer> t2 = RedBlackTree.of(5, 7);
+        final RedBlackTree<Integer> t1 = empty();
+        final RedBlackTree<Integer> t2 = of(5, 7);
         final RedBlackTree<Integer> actual = t1.union(t2);
-        final RedBlackTree<Integer> expected = RedBlackTree.of(5, 7);
+        final RedBlackTree<Integer> expected = of(5, 7);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldUnionOnNonEmptyGivenNonEmpty() {
-        final RedBlackTree<Integer> t1 = RedBlackTree.of(3, 5);
-        final RedBlackTree<Integer> t2 = RedBlackTree.of(5, 7);
+        final RedBlackTree<Integer> t1 = of(3, 5);
+        final RedBlackTree<Integer> t2 = of(5, 7);
         final RedBlackTree<Integer> actual = t1.union(t2);
-        final RedBlackTree<Integer> expected = RedBlackTree.of(3, 5, 7);
+        final RedBlackTree<Integer> expected = of(3, 5, 7);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldComputeUnionAndEqualTreesOfDifferentShapeButSameElements() {
-        final RedBlackTree<Integer> t1 = RedBlackTree.of(-1, -1, 0, 1);
-        final RedBlackTree<Integer> t2 = RedBlackTree.of(-2, -1, 0, 1);
+        final RedBlackTree<Integer> t1 = of(-1, -1, 0, 1);
+        final RedBlackTree<Integer> t2 = of(-2, -1, 0, 1);
         final RedBlackTree<Integer> actual = t1.union(t2);
-        final RedBlackTree<Integer> expected = RedBlackTree.of(-2, -1, 0, 1);
+        final RedBlackTree<Integer> expected = of(-2, -1, 0, 1);
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -298,12 +312,12 @@ public class RedBlackTreeTest {
 
     @Test
     public void shouldIterateEmptyTree() {
-        assertThat(RedBlackTree.empty().iterator().hasNext()).isFalse();
+        assertThat(empty().iterator().hasNext()).isFalse();
     }
 
     @Test
     public void shouldIterateNonEmptyTree() {
-        final RedBlackTree<Integer> testee = RedBlackTree.of(7, 1, 6, 2, 5, 3, 4);
+        final RedBlackTree<Integer> testee = of(7, 1, 6, 2, 5, 3, 4);
         final List<Integer> actual = testee.iterator().toList();
         assertThat(actual.toString()).isEqualTo("List(1, 2, 3, 4, 5, 6, 7)");
     }

--- a/vavr/src/test/java/io/vavr/collection/TreeSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/TreeSetTest.java
@@ -374,6 +374,15 @@ public class TreeSetTest extends AbstractSortedSetTest {
         return (i1, i2) -> Integer.compare(i2, i1);
     }
 
+    // -- ignored tests
+
+    @Override
+    @Test
+    @Ignore
+    public void shouldCalculateAverageOfDoubleAndFloat() {
+        // it is not possible to create a TreeSet containing unrelated types
+    }
+
     @Override
     @Test
     @Ignore


### PR DESCRIPTION
* Fixed: Traversable.min() is NaN if element type is Float/Double and the traversable contains NaN
* min() and max() now are computed according to the natural comparator, especially when the collection is inherently sorted by an underlying comparator
* Implemented Neumaier's modification of the Kahan summation algorithm