### PR TITLE
Added flexibility to build maven modules separately

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,6 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
 * Update version properties: `mvn versions:update-properties`
 * Check for new plugin version: `mvn versions:display-plugin-updates`
 
-Note: The maven build currently needs to be started from the vavr root dir
-      because the code generators write to hard-coded relative directories.
-
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -84,7 +81,7 @@ Note: The maven build currently needs to be started from the vavr root dir
         <maven.source.version>3.0.1</maven.source.version>
         <maven.exec.version>1.5.0</maven.exec.version>
         <maven.gwt.plugin>1.0-rc-6</maven.gwt.plugin>
-        <scala.maven.version>3.2.2</scala.maven.version>
+        <scala.maven.version>3.3.1</scala.maven.version>
         <scala.version>2.11.7</scala.version>
     </properties>
     <dependencyManagement>
@@ -191,6 +188,7 @@ Note: The maven build currently needs to be started from the vavr root dir
                                 <goal>script</goal>
                             </goals>
                             <configuration>
+                                <includeScopes>plugin</includeScopes>
                                 <scriptFile>${project.basedir}/generator/Generator.scala</scriptFile>
                             </configuration>
                         </execution>

--- a/vavr-test/generator/Generator.scala
+++ b/vavr-test/generator/Generator.scala
@@ -25,8 +25,8 @@ import JavaGenerator._
 import scala.language.implicitConversions
 
 val N = 8
-val TARGET_MAIN = "vavr-test/src-gen/main/java"
-val TARGET_TEST = "vavr-test/src-gen/test/java"
+val TARGET_MAIN = s"${project.getBasedir()}/src-gen/main/java"
+val TARGET_TEST = s"${project.getBasedir()}/src-gen/test/java"
 val CHARSET = java.nio.charset.StandardCharsets.UTF_8
 
 /**

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -27,8 +27,8 @@ import scala.language.implicitConversions
 
 val N = 8
 val VARARGS = 10
-val TARGET_MAIN = "vavr/src-gen/main/java"
-val TARGET_TEST = "vavr/src-gen/test/java"
+val TARGET_MAIN = s"${project.getBasedir()}/src-gen/main/java"
+val TARGET_TEST = s"${project.getBasedir()}/src-gen/test/java"
 val CHARSET = java.nio.charset.StandardCharsets.UTF_8
 
 /**


### PR DESCRIPTION
Looks like scala maven plugin has a way to pass project related information to the script. https://davidb.github.io/scala-maven-plugin/example_script.html

When script is executed in scope PLUGIN the plugin injects a variable `project` with type [MavenProject](https://maven.apache.org/ref/3.0.5/apidocs/org/apache/maven/project/MavenProject.html).

PROS:
 * can speedup development by building only module under change
 * can run parallel builds on CI

CONS: 
 * IDE does not recognize `project` variable and marks it as compilation error 
 * cannot run script without maven (limits debugging)