### PR TITLE
Hardens Future.await(), adds Future.await(timeout, timeunit)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,9 +302,10 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.version}</version>
                     <configuration>
-                        <parallel>all</parallel>
-                        <threadCount>4</threadCount>
-                        <reuseForks>true</reuseForks>
+                        <!-- ForkJoinPool configuration for io.vavr.concurrent.Future -->
+                        <argLine>-Djava.util.concurrent.ForkJoinPool.common.parallelism=4</argLine>
+                        <!-- parallel tests could lead to deadlocks because of limited common thread pool parallelism -->
+                        <parallel>none</parallel>
                     </configuration>
                 </plugin>
             </plugins>

--- a/vavr/src/main/java/io/vavr/concurrent/Future.java
+++ b/vavr/src/main/java/io/vavr/concurrent/Future.java
@@ -29,10 +29,7 @@ import io.vavr.collection.List;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.*;
 
@@ -587,10 +584,27 @@ public interface Future<T> extends Value<T> {
 
     /**
      * Blocks the current Thread until this Future completed or returns immediately if this Future is already completed.
+     * <p>
+     * In the case the current thread was interrupted while waiting, a failed {@code Future} is returned containing
+     * the corresponding {@link InterruptedException}.
      *
      * @return this {@code Future} instance
      */
     Future<T> await();
+
+    /**
+     * Blocks the current Thread until this Future completed or returns immediately if this Future is already completed.
+     * <p>
+     * In the case the current thread was interrupted while waiting, a failed {@code Future} is returned containing
+     * the corresponding {@link InterruptedException}.
+     * <p>
+     * If the deadline wasn't met, a failed {@code Future} is returned containing a {@link TimeoutException}.
+     *
+     * @return this {@code Future} instance
+     * @throws IllegalArgumentException if {@code timeout} is negative
+     * @throws NullPointerException if {@code unit} is null
+     */
+    Future<T> await(long timeout, TimeUnit unit);
 
     /**
      * Cancels the Future. A running thread is interrupted.

--- a/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
+++ b/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
@@ -25,8 +25,8 @@ import io.vavr.control.Try;
 import io.vavr.control.Option;
 
 import java.util.Objects;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.*;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 
 /**
@@ -95,6 +95,13 @@ final class FutureImpl<T> implements Future<T> {
     private Queue<Consumer<? super Try<T>>> actions = Queue.empty();
 
     /**
+     * The queue of waiters is filled when calling await() before the Future is completed or cancelled.
+     * Otherwise waiters = null.
+     */
+    @GuardedBy("lock")
+    private Queue<Thread> waiters = Queue.empty();
+
+    /**
      * Once a computation is started via run(), job is defined and used to control the lifecycle of the computation.
      * <p>
      * The {@code java.util.concurrent.Future} is not intended to store the result of the computation, it is stored in
@@ -116,19 +123,68 @@ final class FutureImpl<T> implements Future<T> {
     @Override
     public Future<T> await() {
         if (!isCompleted()) {
-            final Object monitor = new Object();
-            onComplete(ignored -> {
-                synchronized (monitor) {
-                    monitor.notify();
-                }
-            });
-            synchronized (monitor) {
-                if (!isCompleted()) {
-                    Try.run(monitor::wait);
-                }
-            }
+            _await(-1L, -1L, null);
         }
         return this;
+    }
+
+    @Override
+    public Future<T> await(long timeout, TimeUnit unit) {
+        final long now = System.nanoTime();
+        Objects.requireNonNull(unit, "unit is null");
+        if (timeout < 0) {
+            throw new IllegalArgumentException("negative timeout");
+        }
+        if (!isCompleted()) {
+            _await(now, timeout, unit);
+        }
+        return this;
+    }
+
+    // time unit: nanos
+    private void _await(long start, long timeout, TimeUnit unit) {
+        try {
+            ForkJoinPool.managedBlock(new ForkJoinPool.ManagedBlocker() {
+                @Override
+                public boolean block() throws InterruptedException {
+                    try {
+                        final Thread thread = Thread.currentThread();
+                        final boolean park;
+                        synchronized (lock) {
+                            if (park = !isCompleted()) {
+                                waiters = waiters.enqueue(thread);
+                            }
+                        }
+                        // If this Future is complete (and the Thread unparked), the next park() call will not block.
+                        if (park) {
+                            if (timeout != -1L) {
+                                final long duration = unit.toNanos(timeout);
+                                final long delta = System.nanoTime() - start;
+                                final long remaining = duration - delta;
+                                LockSupport.parkNanos(Math.max(remaining, 0L));
+                                if (System.nanoTime() - start > duration) {
+                                    throw new TimeoutException("timeout after " + timeout + " " + unit);
+                                }
+                            } else {
+                                LockSupport.park();
+                            }
+                            if (thread.isInterrupted()) {
+                                throw new InterruptedException();
+                            }
+                        }
+                    } catch(Throwable x) {
+                        tryComplete(Try.failure(x));
+                    }
+                    return true;
+                }
+                @Override
+                public boolean isReleasable() {
+                    return isCompleted();
+                }
+            });
+        } catch (Throwable x) {
+            tryComplete(Try.failure(x));
+        }
     }
 
     @Override
@@ -248,16 +304,27 @@ final class FutureImpl<T> implements Future<T> {
     private void complete(Try<? extends T> value) {
         Objects.requireNonNull(value, "value is null");
         final Queue<Consumer<? super Try<T>>> actions;
+        final Queue<Thread> waiters;
         // it is essential to make the completed state public *before* performing the actions
         synchronized (lock) {
             if (isCompleted()) {
-                throw new IllegalStateException("The Future is completed.");
+                actions = null;
+                waiters = null;
+            } else {
+                // the job isn't set to null, see isCancelled()
+                actions = this.actions;
+                waiters = this.waiters;
+                this.value = Option.some(Try.narrow(value));
+                this.actions = null;
+                this.waiters = null;
             }
-            actions = this.actions;
-            this.value = Option.some(Try.narrow(value));
-            this.actions = null;
         }
-        actions.forEach(this::perform);
+        if (waiters != null) {
+            waiters.forEach(LockSupport::unpark);
+        }
+        if (actions != null) {
+            actions.forEach(this::perform);
+        }
     }
 
     private void perform(Consumer<? super Try<T>> action) {


### PR DESCRIPTION
Fixes #1963
Fixes #1871 (it is `future.await(timeout, timeunit).get()` instead of `future.get(timeout, timeunit)`)