### PR TITLE
Implements unlift operator for total functions returning an Option result

### DIFF
--- a/vavr/src/main/java/io/vavr/PartialFunction.java
+++ b/vavr/src/main/java/io/vavr/PartialFunction.java
@@ -37,6 +37,30 @@ import io.vavr.control.Option;
 public interface PartialFunction<T, R> extends Function1<T, R> {
 
     /**
+     * Unlifts a {@code totalFunction} that returns an {@code Option} result into a partial function.
+     * The total function should be side effect free because it might be invoked twice: when checking if the
+     * unlifted partial function is defined at a value and when applying the partial function to a value.
+     *
+     * @param totalFunction the function returning an {@code Option} result.
+     * @param <T> type of the function input, called <em>domain</em> of the function
+     * @param <R> type of the function output, called <em>codomain</em> of the function
+     * @return a partial function that is not necessarily defined for all input values of type T.
+     */
+    static <T, R> PartialFunction<T, R> unlift(Function1<T, Option<R>> totalFunction) {
+        return new PartialFunction<T, R>() {
+            @Override
+            public R apply(T t) {
+                return totalFunction.apply(t).get();
+            }
+
+            @Override
+            public boolean isDefinedAt(T value) {
+                return totalFunction.apply(value).isDefined();
+            }
+        };
+    }
+
+    /**
      * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
      */
     long serialVersionUID = 1L;

--- a/vavr/src/main/java/io/vavr/PartialFunction.java
+++ b/vavr/src/main/java/io/vavr/PartialFunction.java
@@ -51,7 +51,7 @@ public interface PartialFunction<T, R> extends Function1<T, R> {
      * @param <R> type of the function output, called <em>codomain</em> of the function
      * @return a partial function that is not necessarily defined for all input values of type T.
      */
-    static <T, R> PartialFunction<T, R> unlift(Function1<T, Option<R>> totalFunction) {
+    static <T, R> PartialFunction<T, R> unlift(Function1<? super T, ? extends Option<? extends R>> totalFunction) {
         return new PartialFunction<T, R>() {
 
             private static final long serialVersionUID = 1L;

--- a/vavr/src/main/java/io/vavr/PartialFunction.java
+++ b/vavr/src/main/java/io/vavr/PartialFunction.java
@@ -37,6 +37,11 @@ import io.vavr.control.Option;
 public interface PartialFunction<T, R> extends Function1<T, R> {
 
     /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    /**
      * Unlifts a {@code totalFunction} that returns an {@code Option} result into a partial function.
      * The total function should be side effect free because it might be invoked twice: when checking if the
      * unlifted partial function is defined at a value and when applying the partial function to a value.
@@ -59,11 +64,6 @@ public interface PartialFunction<T, R> extends Function1<T, R> {
             }
         };
     }
-
-    /**
-     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
-     */
-    long serialVersionUID = 1L;
 
     /**
      * Applies this function to the given argument and returns the result.

--- a/vavr/src/main/java/io/vavr/PartialFunction.java
+++ b/vavr/src/main/java/io/vavr/PartialFunction.java
@@ -53,6 +53,9 @@ public interface PartialFunction<T, R> extends Function1<T, R> {
      */
     static <T, R> PartialFunction<T, R> unlift(Function1<T, Option<R>> totalFunction) {
         return new PartialFunction<T, R>() {
+
+            private static final long serialVersionUID = 1L;
+
             @Override
             public R apply(T t) {
                 return totalFunction.apply(t).get();

--- a/vavr/src/test/java/io/vavr/PartialFunctionTest.java
+++ b/vavr/src/test/java/io/vavr/PartialFunctionTest.java
@@ -24,6 +24,8 @@ import io.vavr.collection.List;
 import io.vavr.control.Option;
 import org.junit.Test;
 
+import java.util.function.Predicate;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PartialFunctionTest {
@@ -42,9 +44,10 @@ public class PartialFunctionTest {
 
     @Test
     public void shouldUnliftTotalFunctionReturningAnOption() {
-        final Function1<Integer, Option<String>> totalFunction = n -> n % 2 == 0 ? Option.some("even") : Option.none();
+        final Predicate<Number> isEven = n -> n.intValue() % 2 == 0;
+        final Function1<Number, Option<String>> totalFunction = n -> isEven.test(n) ? Option.some("even") : Option.none();
 
-        final PartialFunction<Integer, String> partialFunction = PartialFunction.unlift(totalFunction);
+        final PartialFunction<Integer, CharSequence> partialFunction = PartialFunction.unlift(totalFunction);
 
         assertThat(partialFunction.isDefinedAt(1)).isFalse();
         assertThat(partialFunction.isDefinedAt(2)).isTrue();

--- a/vavr/src/test/java/io/vavr/PartialFunctionTest.java
+++ b/vavr/src/test/java/io/vavr/PartialFunctionTest.java
@@ -20,6 +20,7 @@
 package io.vavr;
 
 import io.vavr.collection.HashMap;
+import io.vavr.collection.List;
 import io.vavr.control.Option;
 import org.junit.Test;
 
@@ -37,6 +38,26 @@ public class PartialFunctionTest {
     public void shouldReturnNone() {
         Option<String> oneToOne = HashMap.<Integer, String>empty().lift().apply(1);
         assertThat(oneToOne).isEqualTo(Option.none());
+    }
+
+    @Test
+    public void shouldUnliftTotalFunctionReturningAnOption() {
+        final Function1<Integer, Option<String>> totalFunction = n -> n % 2 == 0 ? Option.some("even") : Option.none();
+
+        final PartialFunction<Integer, String> partialFunction = PartialFunction.unlift(totalFunction);
+
+        assertThat(partialFunction.isDefinedAt(1)).isFalse();
+        assertThat(partialFunction.isDefinedAt(2)).isTrue();
+        assertThat(partialFunction.apply(2)).isEqualTo("even");
+    }
+
+    @Test
+    public void shouldCollectSomeValuesAndIgnoreNone() {
+        final List<Integer> evenNumbers = List.range(0, 10)
+          .map(n -> n % 2 == 0 ? Option.some(n) : Option.<Integer>none())
+          .collect(PartialFunction.unlift(Function1.identity()));
+
+        assertThat(evenNumbers).containsExactly(0, 2, 4, 6, 8);
     }
 
 }


### PR DESCRIPTION
This pull request adds the static method `<T, R> PartialFunction<T, R> unlift(Function1<T, Option<R>> totalFunction)` to the interface `PartialFunction`. This method unlifts a total function returning an Option result into a partial function. The partial function is defined at a value if and only if the given total function doesn't return None at this value.

An example use case of this method is the following:
```
Seq<Option<T>> maybeValues = ...
Seq<T> values = maybeValues.collect(PartialFunction.unlift(Function1.identity()))
```
In Scala, one would use Pattern Matching: `maybeValues.collect { case Some(x) => x }`.