### PR TITLE
Updated Scala version used by scala-maven-plugin...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
         <maven.exec.version>1.5.0</maven.exec.version>
         <maven.gwt.plugin>1.0-rc-6</maven.gwt.plugin>
         <scala.maven.version>3.3.1</scala.maven.version>
-        <scala.version>2.12.4</scala.version>
-        <scala.compat.version>2.12</scala.compat.version>
+        <scala.version>2.10.6</scala.version>
+        <scala.compat.version>2.10</scala.compat.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,8 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
         <maven.exec.version>1.5.0</maven.exec.version>
         <maven.gwt.plugin>1.0-rc-6</maven.gwt.plugin>
         <scala.maven.version>3.3.1</scala.maven.version>
-        <scala.version>2.12.2</scala.version>
+        <scala.version>2.12.4</scala.version>
+        <scala.compat.version>2.12</scala.compat.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -181,6 +182,7 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
                     <version>${scala.maven.version}</version>
                     <configuration>
                         <scalaVersion>${scala.version}</scalaVersion>
+                        <scalaCompatVersion>${scala.compat.version}</scalaCompatVersion>
                         <failOnMultipleScalaVersions>true</failOnMultipleScalaVersions>
                     </configuration>
                     <executions>


### PR DESCRIPTION
... & added Scala compatibility hint.

Fixes #2141 

---
Tested on 

* [x] Mac (locally)
* [x] Linux (travis-ci)
* [x] Windows

Could someone please checkout 👉🏼 [my branch](https://github.com/danieldietrich/javaslang/tree/scala-version) 👈🏼  and test it on a **Windows** machine?
(or on your boxes, @szarnekow, @tmtron, @yegor256, because you had issues with the build...)

There is the risk that it will still not work for _some_ users, depending on the build environment. In that case we will downgrade the Scala version from 2.12.4 to 2.10.6.