### PR TITLE
Implement Traversable#reject

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/AbstractMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/AbstractMultimap.java
@@ -254,9 +254,21 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
     }
 
     @Override
+    public M reject(Predicate<? super Tuple2<K, V>> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     public M filter(BiPredicate<? super K, ? super V> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filter(t -> predicate.test(t._1, t._2));
+    }
+
+    @Override
+    public M reject(BiPredicate<? super K, ? super V> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(t -> predicate.test(t._1, t._2));
     }
 
     @Override
@@ -266,27 +278,42 @@ abstract class AbstractMultimap<K, V, M extends Multimap<K, V>> implements Multi
     }
 
     @Override
+    public M rejectKeys(Predicate<? super K> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(t -> predicate.test(t._1));
+    }
+
+    @Override
     public M filterValues(Predicate<? super V> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filter(t -> predicate.test(t._2));
     }
 
     @Override
+    public M rejectValues(Predicate<? super V> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(t -> predicate.test(t._2));
+    }
+
+    @Override
+    @Deprecated
     public M removeAll(BiPredicate<? super K, ? super V> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate.negate());
+        return reject(predicate);
     }
 
     @Override
+    @Deprecated
     public M removeKeys(Predicate<? super K> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return filterKeys(predicate.negate());
+        return rejectKeys(predicate);
     }
 
     @Override
+    @Deprecated
     public M removeValues(Predicate<? super V> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return filterValues(predicate.negate());
+        return rejectValues(predicate);
     }
 
     @SuppressWarnings("unchecked")

--- a/vavr/src/main/java/io/vavr/collection/AbstractQueue.java
+++ b/vavr/src/main/java/io/vavr/collection/AbstractQueue.java
@@ -164,9 +164,16 @@ abstract class AbstractQueue<T, Q extends AbstractQueue<T, Q>> implements Traver
         return Collections.removeAll((Q) this, elements);
     }
 
-    @SuppressWarnings("unchecked")
+    @Deprecated
     public Q removeAll(Predicate<? super T> predicate) {
-        return Collections.removeAll((Q) this, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(predicate);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Q reject(Predicate<? super T> predicate) {
+        return Collections.reject((Q) this, predicate);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -796,7 +796,7 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     @Override
     public Array<T> reject(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate.negate());
+        return Collections.reject(this, predicate);
     }
 
     @Override
@@ -1104,8 +1104,10 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    @Deprecated
     public Array<T> removeAll(Predicate<? super T> predicate) {
-        return io.vavr.collection.Collections.removeAll(this, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(predicate);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -794,6 +794,12 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    public Array<T> reject(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     public <U> Array<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {

--- a/vavr/src/main/java/io/vavr/collection/BitSet.java
+++ b/vavr/src/main/java/io/vavr/collection/BitSet.java
@@ -389,6 +389,9 @@ public interface BitSet<T> extends SortedSet<T> {
     BitSet<T> filter(Predicate<? super T> predicate);
 
     @Override
+    BitSet<T> reject(Predicate<? super T> predicate);
+
+    @Override
     default <U> SortedSet<U> flatMap(Comparator<? super U> comparator, Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return TreeSet.ofAll(comparator, iterator().flatMap(mapper));
@@ -820,6 +823,13 @@ interface BitSetModule {
         public BitSet<T> filter(Predicate<? super T> predicate) {
             Objects.requireNonNull(predicate, "predicate is null");
             final BitSet<T> bitSet = createFromAll(iterator().filter(predicate));
+            return (bitSet.length() == length()) ? this : bitSet;
+        }
+
+        @Override
+        public BitSet<T> reject(Predicate<? super T> predicate) {
+            Objects.requireNonNull(predicate, "predicate is null");
+            final BitSet<T> bitSet = createFromAll(iterator().reject(predicate));
             return (bitSet.length() == length()) ? this : bitSet;
         }
 

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -530,7 +530,7 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     @Override
     public CharSeq reject(Predicate<? super Character> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate.negate());
+        return Collections.reject(this, predicate);
     }
 
     @Override
@@ -854,8 +854,10 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
+    @Deprecated
     public CharSeq removeAll(Predicate<? super Character> predicate) {
-        return io.vavr.collection.Collections.removeAll(this, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(predicate);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -528,6 +528,12 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
+    public CharSeq reject(Predicate<? super Character> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     public <U> IndexedSeq<U> flatMap(Function<? super Character, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {

--- a/vavr/src/main/java/io/vavr/collection/Collections.java
+++ b/vavr/src/main/java/io/vavr/collection/Collections.java
@@ -273,7 +273,7 @@ final class Collections {
     }
 
     @SuppressWarnings("unchecked")
-    static <C extends Traversable<T>, T> C removeAll(C source, Predicate<? super T> predicate) {
+    static <C extends Traversable<T>, T> C reject(C source, Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (source.isEmpty()) {
             return source;

--- a/vavr/src/main/java/io/vavr/collection/HashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMap.java
@@ -565,8 +565,18 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
+    public HashMap<K, V> reject(BiPredicate<? super K, ? super V> predicate) {
+        return Maps.reject(this, this::createFromEntries, predicate);
+    }
+
+    @Override
     public HashMap<K, V> filter(Predicate<? super Tuple2<K, V>> predicate) {
         return Maps.filter(this, this::createFromEntries, predicate);
+    }
+
+    @Override
+    public HashMap<K, V> reject(Predicate<? super Tuple2<K, V>> predicate) {
+        return Maps.reject(this, this::createFromEntries, predicate);
     }
 
     @Override
@@ -575,8 +585,18 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
+    public HashMap<K, V> rejectKeys(Predicate<? super K> predicate) {
+        return Maps.rejectKeys(this, this::createFromEntries, predicate);
+    }
+
+    @Override
     public HashMap<K, V> filterValues(Predicate<? super V> predicate) {
         return Maps.filterValues(this, this::createFromEntries, predicate);
+    }
+
+    @Override
+    public HashMap<K, V> rejectValues(Predicate<? super V> predicate) {
+        return Maps.rejectValues(this, this::createFromEntries, predicate);
     }
 
     @Override
@@ -755,8 +775,10 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
+    @Deprecated
     public HashMap<K, V> removeAll(BiPredicate<? super K, ? super V> predicate) {
-        return Maps.removeAll(this, this::createFromEntries, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(predicate);
     }
 
     @Override
@@ -777,13 +799,17 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
+    @Deprecated
     public HashMap<K, V> removeKeys(Predicate<? super K> predicate) {
-        return Maps.removeKeys(this, this::createFromEntries, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return rejectKeys(predicate);
     }
 
     @Override
+    @Deprecated
     public HashMap<K, V> removeValues(Predicate<? super V> predicate) {
-        return Maps.removeValues(this, this::createFromEntries, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return rejectValues(predicate);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/HashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/HashSet.java
@@ -581,6 +581,12 @@ public final class HashSet<T> implements Set<T>, Serializable {
     }
 
     @Override
+    public HashSet<T> reject(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     public <U> HashSet<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {

--- a/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
@@ -137,6 +137,9 @@ public interface IndexedSeq<T> extends Seq<T> {
     IndexedSeq<T> filter(Predicate<? super T> predicate);
 
     @Override
+    IndexedSeq<T> reject(Predicate<? super T> predicate);
+
+    @Override
     <U> IndexedSeq<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
@@ -256,6 +256,7 @@ public interface IndexedSeq<T> extends Seq<T> {
     IndexedSeq<T> removeAll(Iterable<? extends T> elements);
 
     @Override
+    @Deprecated
     IndexedSeq<T> removeAll(Predicate<? super T> predicate);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Iterator.java
+++ b/vavr/src/main/java/io/vavr/collection/Iterator.java
@@ -1454,6 +1454,12 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     }
 
     @Override
+    default Iterator<T> reject(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     default Option<T> findLast(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         T last = null;

--- a/vavr/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/LinearSeq.java
@@ -237,6 +237,7 @@ public interface LinearSeq<T> extends Seq<T> {
     LinearSeq<T> removeAll(Iterable<? extends T> elements);
 
     @Override
+    @Deprecated
     LinearSeq<T> removeAll(Predicate<? super T> predicate);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/LinearSeq.java
@@ -113,6 +113,9 @@ public interface LinearSeq<T> extends Seq<T> {
     LinearSeq<T> filter(Predicate<? super T> predicate);
 
     @Override
+    LinearSeq<T> reject(Predicate<? super T> predicate);
+
+    @Override
     <U> LinearSeq<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -589,8 +589,18 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
+    public LinkedHashMap<K, V> reject(BiPredicate<? super K, ? super V> predicate) {
+        return Maps.reject(this, this::createFromEntries, predicate);
+    }
+
+    @Override
     public LinkedHashMap<K, V> filter(Predicate<? super Tuple2<K, V>> predicate) {
         return Maps.filter(this, this::createFromEntries, predicate);
+    }
+
+    @Override
+    public LinkedHashMap<K, V> reject(Predicate<? super Tuple2<K, V>> predicate) {
+        return Maps.reject(this, this::createFromEntries, predicate);
     }
 
     @Override
@@ -599,8 +609,18 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
+    public LinkedHashMap<K, V> rejectKeys(Predicate<? super K> predicate) {
+        return Maps.rejectKeys(this, this::createFromEntries, predicate);
+    }
+
+    @Override
     public LinkedHashMap<K, V> filterValues(Predicate<? super V> predicate) {
         return Maps.filterValues(this, this::createFromEntries, predicate);
+    }
+
+    @Override
+    public LinkedHashMap<K, V> rejectValues(Predicate<? super V> predicate) {
+        return Maps.rejectValues(this, this::createFromEntries, predicate);
     }
 
     @Override
@@ -794,8 +814,10 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
+    @Deprecated
     public LinkedHashMap<K, V> removeAll(BiPredicate<? super K, ? super V> predicate) {
-        return Maps.removeAll(this, this::createFromEntries, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(predicate);
     }
 
     @Override
@@ -808,13 +830,17 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     @Override
+    @Deprecated
     public LinkedHashMap<K, V> removeKeys(Predicate<? super K> predicate) {
-        return Maps.removeKeys(this, this::createFromEntries, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return rejectKeys(predicate);
     }
 
     @Override
+    @Deprecated
     public LinkedHashMap<K, V> removeValues(Predicate<? super V> predicate) {
-        return Maps.removeValues(this, this::createFromEntries, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return rejectValues(predicate);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -582,6 +582,12 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
     }
 
     @Override
+    public LinkedHashSet<T> reject(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     public <U> LinkedHashSet<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -870,6 +870,12 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
+    default List<T> reject(Predicate<? super T> predicate){
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     default <U> List<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         List<U> list = empty();

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -872,7 +872,7 @@ public interface List<T> extends LinearSeq<T> {
     @Override
     default List<T> reject(Predicate<? super T> predicate){
         Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate.negate());
+        return Collections.reject(this, predicate);
     }
 
     @Override
@@ -1312,8 +1312,10 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
+    @Deprecated
     default List<T> removeAll(Predicate<? super T> predicate) {
-        return Collections.removeAll(this, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(predicate);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Map.java
+++ b/vavr/src/main/java/io/vavr/collection/Map.java
@@ -58,11 +58,11 @@ import java.util.function.*;
  * <li>{@link #filter(BiPredicate)}</li>
  * <li>{@link #filterKeys(Predicate)}</li>
  * <li>{@link #filterValues(Predicate)}</li>
+ * <li>{@link #reject(BiPredicate)}</li>
+ * <li>{@link #rejectKeys(Predicate)}</li>
+ * <li>{@link #rejectValues(Predicate)}</li>
  * <li>{@link #remove(Object)}</li>
- * <li>{@link #removeAll(BiPredicate)}</li>
  * <li>{@link #removeAll(Iterable)}</li>
- * <li>{@link #removeKeys(Predicate)}</li>
- * <li>{@link #removeValues(Predicate)}</li>
  * </ul>
  *
  * Iteration:
@@ -218,6 +218,15 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
     Map<K, V> filter(BiPredicate<? super K, ? super V> predicate);
 
     /**
+     * Returns a new Map consisting of all elements which do not satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test elements
+     * @return a new Map
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Map<K, V> reject(BiPredicate<? super K, ? super V> predicate);
+
+    /**
      * Returns a new Map consisting of all elements with keys which satisfy the given predicate.
      *
      * @param predicate the predicate used to test keys of elements
@@ -227,6 +236,15 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
     Map<K, V> filterKeys(Predicate<? super K> predicate);
 
     /**
+     * Returns a new Map consisting of all elements with keys which do not satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test keys of elements
+     * @return a new Map
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Map<K, V> rejectKeys(Predicate<? super K> predicate);
+
+    /**
      * Returns a new Map consisting of all elements with values which satisfy the given predicate.
      *
      * @param predicate the predicate used to test values of elements
@@ -234,6 +252,15 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
      * @throws NullPointerException if {@code predicate} is null
      */
     Map<K, V> filterValues(Predicate<? super V> predicate);
+
+    /**
+     * Returns a new Map consisting of all elements with values which do not satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test values of elements
+     * @return a new Map
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Map<K, V> rejectValues(Predicate<? super V> predicate);
 
     /**
      * FlatMaps this {@code Map} to a new {@code Map} with different component type.
@@ -495,10 +522,12 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
     /**
      * Returns a new Map consisting of all elements which do not satisfy the given predicate.
      *
+     * @deprecated Please use {@link #reject(BiPredicate)}
      * @param predicate the predicate used to test elements
      * @return a new Map
      * @throws NullPointerException if {@code predicate} is null
      */
+    @Deprecated
     Map<K, V> removeAll(BiPredicate<? super K, ? super V> predicate);
 
     /**
@@ -513,19 +542,23 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
     /**
      * Returns a new Map consisting of all elements with keys which do not satisfy the given predicate.
      *
+     * @deprecated Please use {@link #rejectKeys(Predicate)}
      * @param predicate the predicate used to test keys of elements
      * @return a new Map
      * @throws NullPointerException if {@code predicate} is null
      */
+    @Deprecated
     Map<K, V> removeKeys(Predicate<? super K> predicate);
 
     /**
      * Returns a new Map consisting of all elements with values which do not satisfy the given predicate.
      *
+     * @deprecated Please use {@link #rejectValues(Predicate)}
      * @param predicate the predicate used to test values of elements
      * @return a new Map
      * @throws NullPointerException if {@code predicate} is null
      */
+    @Deprecated
     Map<K, V> removeValues(Predicate<? super V> predicate);
 
     @Override
@@ -678,6 +711,9 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
 
     @Override
     Map<K, V> filter(Predicate<? super Tuple2<K, V>> predicate);
+
+    @Override
+    Map<K, V> reject(Predicate<? super Tuple2<K, V>> predicate);
 
     @Override
     <C> Map<C, ? extends Map<K, V>> groupBy(Function<? super Tuple2<K, V>, ? extends C> classifier);

--- a/vavr/src/main/java/io/vavr/collection/Maps.java
+++ b/vavr/src/main/java/io/vavr/collection/Maps.java
@@ -245,19 +245,25 @@ final class Maps {
         }
     }
 
-    static <K, V, M extends Map<K, V>> M removeAll(M map, OfEntries<K, V, M> ofEntries,
+    static <K, V, M extends Map<K, V>> M reject(M map, OfEntries<K, V, M> ofEntries,
+            Predicate<? super Tuple2<K, V>> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(map, ofEntries, predicate.negate());
+    }
+
+    static <K, V, M extends Map<K, V>> M reject(M map, OfEntries<K, V, M> ofEntries,
             BiPredicate<? super K, ? super V> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filter(map, ofEntries, predicate.negate());
     }
 
-    static <K, V, M extends Map<K, V>> M removeKeys(M map, OfEntries<K, V, M> ofEntries,
+    static <K, V, M extends Map<K, V>> M rejectKeys(M map, OfEntries<K, V, M> ofEntries,
             Predicate<? super K> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filterKeys(map, ofEntries, predicate.negate());
     }
 
-    static <K, V, M extends Map<K, V>> M removeValues(M map, OfEntries<K, V, M> ofEntries,
+    static <K, V, M extends Map<K, V>> M rejectValues(M map, OfEntries<K, V, M> ofEntries,
             Predicate<? super V> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filterValues(map, ofEntries, predicate.negate());

--- a/vavr/src/main/java/io/vavr/collection/Multimap.java
+++ b/vavr/src/main/java/io/vavr/collection/Multimap.java
@@ -56,12 +56,12 @@ import java.util.function.*;
  * <li>{@link #filter(BiPredicate)}</li>
  * <li>{@link #filterKeys(Predicate)}</li>
  * <li>{@link #filterValues(Predicate)}</li>
+ * <li>{@link #reject(BiPredicate)}</li>
+ * <li>{@link #rejectKeys(Predicate)}</li>
+ * <li>{@link #rejectValues(Predicate)}</li>
  * <li>{@link #remove(Object)}</li>
  * <li>{@link #remove(Object, Object)}</li>
- * <li>{@link #removeAll(BiPredicate)}</li>
  * <li>{@link #removeAll(Iterable)}</li>
- * <li>{@link #removeKeys(Predicate)}</li>
- * <li>{@link #removeValues(Predicate)}</li>
  * </ul>
  *
  * Iteration:
@@ -218,6 +218,15 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
     Multimap<K, V> filter(BiPredicate<? super K, ? super V> predicate);
 
     /**
+     * Returns a new Multimap consisting of all elements which do not satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test elements
+     * @return a new Multimap
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Multimap<K, V> reject(BiPredicate<? super K, ? super V> predicate);
+
+    /**
      * Returns a new Multimap consisting of all elements with keys which satisfy the given predicate.
      *
      * @param predicate the predicate used to test keys of elements
@@ -227,6 +236,15 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
     Multimap<K, V> filterKeys(Predicate<? super K> predicate);
 
     /**
+     * Returns a new Multimap consisting of all elements with keys which do not satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test keys of elements
+     * @return a new Multimap
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Multimap<K, V> rejectKeys(Predicate<? super K> predicate);
+
+    /**
      * Returns a new Multimap consisting of all elements with values which satisfy the given predicate.
      *
      * @param predicate the predicate used to test values of elements
@@ -234,6 +252,15 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
      * @throws NullPointerException if {@code predicate} is null
      */
     Multimap<K, V> filterValues(Predicate<? super V> predicate);
+
+    /**
+     * Returns a new Multimap consisting of all elements with values which do not satisfy the given predicate.
+     *
+     * @param predicate the predicate used to test values of elements
+     * @return a new Multimap
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Multimap<K, V> rejectValues(Predicate<? super V> predicate);
 
     /**
      * FlatMaps this {@code Multimap} to a new {@code Multimap} with different component type.
@@ -439,10 +466,12 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
     /**
      * Returns a new Multimap consisting of all elements which do not satisfy the given predicate.
      *
+     * @deprecated Please use {@link #reject(BiPredicate)}
      * @param predicate the predicate used to test elements
      * @return a new Multimap
      * @throws NullPointerException if {@code predicate} is null
      */
+    @Deprecated
     Multimap<K, V> removeAll(BiPredicate<? super K, ? super V> predicate);
 
     /**
@@ -457,19 +486,23 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
     /**
      * Returns a new Multimap consisting of all elements with keys which do not satisfy the given predicate.
      *
+     * @deprecated Please use {@link #rejectKeys(Predicate)}
      * @param predicate the predicate used to test keys of elements
      * @return a new Multimap
      * @throws NullPointerException if {@code predicate} is null
      */
+    @Deprecated
     Multimap<K, V> removeKeys(Predicate<? super K> predicate);
 
     /**
      * Returns a new Multimap consisting of all elements with values which do not satisfy the given predicate.
      *
+     * @deprecated Please use {@link #rejectValues(Predicate)}
      * @param predicate the predicate used to test values of elements
      * @return a new Multimap
      * @throws NullPointerException if {@code predicate} is null
      */
+    @Deprecated
     Multimap<K, V> removeValues(Predicate<? super V> predicate);
 
     @Override
@@ -585,6 +618,9 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
 
     @Override
     Multimap<K, V> filter(Predicate<? super Tuple2<K, V>> predicate);
+
+    @Override
+    Multimap<K, V> reject(Predicate<? super Tuple2<K, V>> predicate);
 
     /**
      * Flat-maps this entries to a sequence of values.

--- a/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
+++ b/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
@@ -354,12 +354,6 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
     }
 
     @Override
-    public PriorityQueue<T> reject(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate.negate());
-    }
-
-    @Override
     public <U> PriorityQueue<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         return flatMap(Comparators.naturalComparator(), mapper);
     }

--- a/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
+++ b/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
@@ -354,6 +354,12 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
     }
 
     @Override
+    public PriorityQueue<T> reject(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     public <U> PriorityQueue<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         return flatMap(Comparators.naturalComparator(), mapper);
     }

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -779,12 +779,6 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
-    public Queue<T> reject(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate.negate());
-    }
-
-    @Override
     public <U> Queue<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -779,6 +779,12 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
+    public Queue<T> reject(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     public <U> Queue<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {

--- a/vavr/src/main/java/io/vavr/collection/Seq.java
+++ b/vavr/src/main/java/io/vavr/collection/Seq.java
@@ -776,10 +776,12 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
     /**
      * Returns a new Seq consisting of all elements which do not satisfy the given predicate.
      *
+     * @deprecated Please use {@link #reject(Predicate)}
      * @param predicate the predicate used to test elements
      * @return a new Seq
      * @throws NullPointerException if {@code predicate} is null
      */
+    @Deprecated
     Seq<T> removeAll(Predicate<? super T> predicate);
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/Seq.java
+++ b/vavr/src/main/java/io/vavr/collection/Seq.java
@@ -1119,6 +1119,9 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
     Seq<T> filter(Predicate<? super T> predicate);
 
     @Override
+    Seq<T> reject(Predicate<? super T> predicate);
+
+    @Override
     <U> Seq<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Set.java
+++ b/vavr/src/main/java/io/vavr/collection/Set.java
@@ -217,6 +217,9 @@ public interface Set<T> extends Traversable<T>, Function1<T, Boolean>, Serializa
     Set<T> filter(Predicate<? super T> predicate);
 
     @Override
+    Set<T> reject(Predicate<? super T> predicate);
+
+    @Override
     <U> Set<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/SortedMap.java
+++ b/vavr/src/main/java/io/vavr/collection/SortedMap.java
@@ -130,21 +130,36 @@ public interface SortedMap<K, V> extends Map<K, V>, Ordered<K> {
     SortedMap<K, V> filter(Predicate<? super Tuple2<K, V>> predicate);
 
     @Override
+    SortedMap<K, V> reject(Predicate<? super Tuple2<K, V>> predicate);
+
+    @Override
     SortedMap<K, V> filter(BiPredicate<? super K, ? super V> predicate);
+
+    @Override
+    SortedMap<K, V> reject(BiPredicate<? super K, ? super V> predicate);
 
     @Override
     SortedMap<K, V> filterKeys(Predicate<? super K> predicate);
 
     @Override
+    SortedMap<K, V> rejectKeys(Predicate<? super K> predicate);
+
+    @Override
     SortedMap<K, V> filterValues(Predicate<? super V> predicate);
 
     @Override
+    SortedMap<K, V> rejectValues(Predicate<? super V> predicate);
+
+    @Override
+    @Deprecated
     SortedMap<K, V> removeAll(BiPredicate<? super K, ? super V> predicate);
 
     @Override
+    @Deprecated
     SortedMap<K, V> removeKeys(Predicate<? super K> predicate);
 
     @Override
+    @Deprecated
     SortedMap<K, V> removeValues(Predicate<? super V> predicate);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/SortedMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/SortedMultimap.java
@@ -56,10 +56,19 @@ public interface SortedMultimap<K, V> extends Multimap<K, V>, Ordered<K> {
     SortedMultimap<K, V> filter(BiPredicate<? super K, ? super V> predicate);
 
     @Override
+    SortedMultimap<K, V> reject(BiPredicate<? super K, ? super V> predicate);
+
+    @Override
     SortedMultimap<K, V> filterKeys(Predicate<? super K> predicate);
 
     @Override
+    SortedMultimap<K, V> rejectKeys(Predicate<? super K> predicate);
+
+    @Override
     SortedMultimap<K, V> filterValues(Predicate<? super V> predicate);
+
+    @Override
+    SortedMultimap<K, V> rejectValues(Predicate<? super V> predicate);
 
     @Override
     SortedSet<K> keySet();
@@ -83,15 +92,18 @@ public interface SortedMultimap<K, V> extends Multimap<K, V>, Ordered<K> {
     SortedMultimap<K, V> remove(K key, V value);
 
     @Override
+    @Deprecated
     SortedMultimap<K, V> removeAll(BiPredicate<? super K, ? super V> predicate);
 
     @Override
     SortedMultimap<K, V> removeAll(Iterable<? extends K> keys);
 
     @Override
+    @Deprecated
     SortedMultimap<K, V> removeKeys(Predicate<? super K> predicate);
 
     @Override
+    @Deprecated
     SortedMultimap<K, V> removeValues(Predicate<? super V> predicate);
 
     @Override
@@ -120,6 +132,9 @@ public interface SortedMultimap<K, V> extends Multimap<K, V>, Ordered<K> {
 
     @Override
     SortedMultimap<K, V> filter(Predicate<? super Tuple2<K, V>> predicate);
+
+    @Override
+    SortedMultimap<K, V> reject(Predicate<? super Tuple2<K, V>> predicate);
 
     @Override
     <C> Map<C, ? extends SortedMultimap<K, V>> groupBy(Function<? super Tuple2<K, V>, ? extends C> classifier);

--- a/vavr/src/main/java/io/vavr/collection/SortedSet.java
+++ b/vavr/src/main/java/io/vavr/collection/SortedSet.java
@@ -124,6 +124,9 @@ public interface SortedSet<T> extends Set<T>, Ordered<T> {
     SortedSet<T> filter(Predicate<? super T> predicate);
 
     @Override
+    SortedSet<T> reject(Predicate<? super T> predicate);
+
+    @Override
     <U> SortedSet<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -1027,7 +1027,7 @@ public interface Stream<T> extends LinearSeq<T> {
     @Override
     default Stream<T> reject(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate.negate());
+        return Collections.reject(this, predicate);
     }
 
     @Override
@@ -1360,8 +1360,10 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
+    @Deprecated
     default Stream<T> removeAll(Predicate<? super T> predicate) {
-        return io.vavr.collection.Collections.removeAll(this, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(predicate);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -1025,6 +1025,12 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
+    default Stream<T> reject(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     default <U> Stream<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? Empty.instance() : Stream.ofAll(new Iterator<U>() {

--- a/vavr/src/main/java/io/vavr/collection/Traversable.java
+++ b/vavr/src/main/java/io/vavr/collection/Traversable.java
@@ -105,6 +105,7 @@ import java.util.stream.DoubleStream;
  * <li>{@link #dropUntil(Predicate)}</li>
  * <li>{@link #dropWhile(Predicate)}</li>
  * <li>{@link #filter(Predicate)}</li>
+ * <li>{@link #reject(Predicate)}</li>
  * <li>{@link #find(Predicate)}</li>
  * <li>{@link #findLast(Predicate)}</li>
  * <li>{@link #groupBy(Function)}</li>
@@ -427,6 +428,15 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
      * @throws NullPointerException if {@code predicate} is null
      */
     Traversable<T> filter(Predicate<? super T> predicate);
+
+    /**
+     * Returns a new traversable consisting of all elements which do not satisfy the given predicate.
+     *
+     * @param predicate A predicate
+     * @return a new traversable
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    Traversable<T> reject(Predicate<? super T> predicate);
 
     /**
      * Returns the first element of this which satisfies the given predicate.

--- a/vavr/src/main/java/io/vavr/collection/Tree.java
+++ b/vavr/src/main/java/io/vavr/collection/Tree.java
@@ -539,6 +539,16 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
+    default Seq<T> reject(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        if (isEmpty()) {
+            return Stream.empty();
+        } else {
+            return values().reject(predicate);
+        }
+    }
+
+    @Override
     default <U> Tree<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? Empty.instance() : TreeModule.flatMap((Node<T>) this, mapper);

--- a/vavr/src/main/java/io/vavr/collection/TreeMap.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeMap.java
@@ -992,8 +992,18 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
     }
 
     @Override
+    public TreeMap<K, V> reject(BiPredicate<? super K, ? super V> predicate) {
+        return Maps.reject(this, this::createFromEntries, predicate);
+    }
+
+    @Override
     public TreeMap<K, V> filter(Predicate<? super Tuple2<K, V>> predicate) {
         return Maps.filter(this, this::createFromEntries, predicate);
+    }
+
+    @Override
+    public TreeMap<K, V> reject(Predicate<? super Tuple2<K, V>> predicate) {
+        return Maps.reject(this, this::createFromEntries, predicate);
     }
 
     @Override
@@ -1002,8 +1012,18 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
     }
 
     @Override
+    public TreeMap<K, V> rejectKeys(Predicate<? super K> predicate) {
+        return Maps.rejectKeys(this, this::createFromEntries, predicate);
+    }
+
+    @Override
     public TreeMap<K, V> filterValues(Predicate<? super V> predicate) {
         return Maps.filterValues(this, this::createFromEntries, predicate);
+    }
+
+    @Override
+    public TreeMap<K, V> rejectValues(Predicate<? super V> predicate) {
+        return Maps.rejectValues(this, this::createFromEntries, predicate);
     }
 
     @Override
@@ -1207,8 +1227,10 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
     }
 
     @Override
+    @Deprecated
     public TreeMap<K, V> removeAll(BiPredicate<? super K, ? super V> predicate) {
-        return Maps.removeAll(this, this::createFromEntries, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(predicate);
     }
 
     @Override
@@ -1229,13 +1251,17 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
     }
 
     @Override
+    @Deprecated
     public TreeMap<K, V> removeKeys(Predicate<? super K> predicate) {
-        return Maps.removeKeys(this, this::createFromEntries, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return rejectKeys(predicate);
     }
 
     @Override
+    @Deprecated
     public TreeMap<K, V> removeValues(Predicate<? super V> predicate) {
-        return Maps.removeValues(this, this::createFromEntries, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return rejectValues(predicate);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/TreeSet.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeSet.java
@@ -634,6 +634,12 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     }
 
     @Override
+    public TreeSet<T> reject(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     public <U> TreeSet<U> flatMap(Comparator<? super U> comparator,
             Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -708,7 +708,7 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     @Override
     public Vector<T> reject(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return filter(predicate.negate());
+        return Collections.reject(this, predicate);
     }
 
     @Override
@@ -986,8 +986,10 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    @Deprecated
     public Vector<T> removeAll(Predicate<? super T> predicate) {
-        return io.vavr.collection.Collections.removeAll(this, predicate);
+        Objects.requireNonNull(predicate, "predicate is null");
+        return reject(predicate);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -706,6 +706,12 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    public Vector<T> reject(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filter(predicate.negate());
+    }
+
+    @Override
     public <U> Vector<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         final Iterator<? extends U> results = iterator().flatMap(mapper);

--- a/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
@@ -1153,8 +1153,34 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(dst).isEqualTo(emptyIntString().put(0, "0").put(1, "1").put(2, "2").put(3, "3").put(4, "4").put(5, "5").put(6, "6").put(7, "7").put(8, "8").put(9, "9"));
     }
 
+    // -- reject
+
+    @Test
+    public void shouldBiRejectWork() throws Exception {
+        final Map<Integer, String> src = mapTabulate(20, n -> Tuple.of(n, Integer.toHexString(n)));
+        final Pattern isDigits = Pattern.compile("^\\d+$");
+        final Map<Integer, String> dst = src.reject((k, v) -> k % 2 == 0 && isDigits.matcher(v).matches());
+        assertThat(dst).isEqualTo(emptyIntString().put(1, "1").put(3, "3").put(5, "5").put(7, "7").put(9, "9").put(10, "a").put(11, "b").put(12, "c").put(13, "d").put(14, "e").put(15, "f").put(17, "11").put(19, "13"));
+    }
+
+    @Test
+    public void shouldKeyRejectWork() throws Exception {
+        final Map<Integer, String> src = mapTabulate(20, n -> Tuple.of(n, Integer.toHexString(n)));
+        final Map<Integer, String> dst = src.rejectKeys(k -> k % 2 == 0);
+        assertThat(dst).isEqualTo(emptyIntString().put(1, "1").put(3, "3").put(5, "5").put(7, "7").put(9, "9").put(11, "b").put(13, "d").put(15, "f").put(17, "11").put(19, "13"));
+    }
+
+    @Test
+    public void shouldValueRejectWork() throws Exception {
+        final Map<Integer, String> src = mapTabulate(15, n -> Tuple.of(n, Integer.toHexString(n)));
+        final Pattern isDigits = Pattern.compile("^\\d+$");
+        final Map<Integer, String> dst = src.rejectValues(v -> isDigits.matcher(v).matches());
+        assertThat(dst).isEqualTo(emptyIntString().put(10, "a").put(11, "b").put(12, "c").put(13, "d").put(14, "e"));
+    }
+
     // -- remove by filter
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldBiRemoveWork() throws Exception {
         final Map<Integer, String> src = mapTabulate(20, n -> Tuple.of(n, Integer.toHexString(n)));
@@ -1163,6 +1189,7 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(dst).isEqualTo(emptyIntString().put(1, "1").put(3, "3").put(5, "5").put(7, "7").put(9, "9").put(10, "a").put(11, "b").put(12, "c").put(13, "d").put(14, "e").put(15, "f").put(17, "11").put(19, "13"));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldKeyRemoveWork() throws Exception {
         final Map<Integer, String> src = mapTabulate(20, n -> Tuple.of(n, Integer.toHexString(n)));
@@ -1170,6 +1197,7 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(dst).isEqualTo(emptyIntString().put(1, "1").put(3, "3").put(5, "5").put(7, "7").put(9, "9").put(11, "b").put(13, "d").put(15, "f").put(17, "11").put(19, "13"));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldValueRemoveWork() throws Exception {
         final Map<Integer, String> src = mapTabulate(20, n -> Tuple.of(n, Integer.toHexString(n)));

--- a/vavr/src/test/java/io/vavr/collection/AbstractMultimapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractMultimapTest.java
@@ -471,6 +471,34 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
         assertThat(dst).isEqualTo(emptyIntString().put(0, "0").put(0, "5").put(1, "1").put(1, "6").put(2, "2").put(2, "7").put(3, "3").put(3, "8").put(4, "4").put(4, "9"));
     }
 
+    // -- reject
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldBiRejectWork() throws Exception {
+        final Multimap<Integer, String> src = mapTabulate(20, n -> Tuple.of(n % 10, Integer.toHexString(n)));
+        final Pattern isDigits = Pattern.compile("^\\d+$");
+        final Multimap<Integer, String> dst = src.reject((k, v) -> k % 2 == 0 && isDigits.matcher(v).matches());
+        assertThat(dst).isEqualTo(emptyIntString().put(0, "a").put(1, "1").put(1, "b").put(2, "c").put(3, "3").put(3, "d").put(4, "e").put(5, "5").put(5, "f").put(7, "7").put(7, "11").put(9, "9").put(9, "13"));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldKeyRejectWork() throws Exception {
+        final Multimap<Integer, String> src = mapTabulate(20, n -> Tuple.of(n % 10, Integer.toHexString(n)));
+        final Multimap<Integer, String> dst = src.rejectKeys(k -> k % 2 == 0);
+        assertThat(dst).isEqualTo(emptyIntString().put(1, "1").put(1, "b").put(3, "3").put(3, "d").put(5, "5").put(5, "f").put(7, "7").put(7, "11").put(9, "9").put(9, "13"));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldValueRejectWork() throws Exception {
+        final Multimap<Integer, String> src = mapTabulate(20, n -> Tuple.of(n % 10, Integer.toHexString(n)));
+        final Pattern isDigits = Pattern.compile("^\\d+$");
+        final Multimap<Integer, String> dst = src.rejectValues(v -> isDigits.matcher(v).matches());
+        assertThat(dst).isEqualTo(emptyIntString().put(0, "a").put(1, "b").put(2, "c").put(3, "d").put(4, "e").put(5, "f"));
+    }
+
     // -- flatMap
 
     @SuppressWarnings("unchecked")
@@ -759,6 +787,7 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
 
     // -- remove by filter
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldBiRemoveWork() throws Exception {
         final Multimap<Integer, String> src = mapTabulate(20, n -> Tuple.of(n % 10, Integer.toHexString(n)));
@@ -767,6 +796,7 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
         assertThat(dst).isEqualTo(emptyIntString().put(0, "a").put(1, "1").put(1, "b").put(2, "c").put(3, "3").put(3, "d").put(4, "e").put(5, "5").put(5, "f").put(7, "7").put(7, "11").put(9, "9").put(9, "13"));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldKeyRemoveWork() throws Exception {
         final Multimap<Integer, String> src = mapTabulate(20, n -> Tuple.of(n % 10, Integer.toHexString(n)));
@@ -774,6 +804,7 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
         assertThat(dst).isEqualTo(emptyIntString().put(1, "1").put(1, "b").put(3, "3").put(3, "d").put(5, "5").put(5, "f").put(7, "7").put(7, "11").put(9, "9").put(9, "13"));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldValueRemoveWork() throws Exception {
         final Multimap<Integer, String> src = mapTabulate(20, n -> Tuple.of(n % 10, Integer.toHexString(n)));

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -1344,6 +1344,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     // -- removeAll(Predicate)
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveExistingElements() {
         assertThat(of(1, 2, 3).removeAll(i -> i == 1)).isEqualTo(of(2, 3));
@@ -1358,6 +1359,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveNonExistingElements() {
         if (useIsEqualToInsteadOfIsSameAs()) {
@@ -1369,21 +1371,25 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveAllElementsByPredicateFromNil() {
         assertThat(empty().removeAll(o -> true)).isEmpty();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveAllExistingElements() {
         assertThat(of(1, 2, 3, 4, 5, 6).removeAll(ignored -> true)).isEmpty();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveAllMatchedElementsFromNonNil() {
         assertThat(of(1, 2, 3, 4, 5, 6).removeAll(i -> i % 2 == 0)).isEqualTo(of(1, 3, 5));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -721,6 +721,38 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         assertThat(empty.filter(v -> true)).isSameAs(empty);
     }
 
+    // -- reject
+
+    @Test
+    public void shouldRejectExistingElements() {
+        assertThat(of(1, 2, 3).reject(i -> i == 1)).isEqualTo(of(2, 3));
+        assertThat(of(1, 2, 3).reject(i -> i == 2)).isEqualTo(of(1, 3));
+        assertThat(of(1, 2, 3).reject(i -> i == 3)).isEqualTo(of(1, 2));
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(of(1, 2, 3).reject(ignore -> false)).isEqualTo(of(1, 2, 3));
+        } else {
+            final Traversable<Integer> t = of(1, 2, 3);
+            assertThat(t.reject(ignore -> false)).isSameAs(t);
+        }
+    }
+
+    @Test
+    public void shouldRejectNonExistingElements() {
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(this.<Integer> empty().reject(i -> i == 0)).isEqualTo(empty());
+            assertThat(of(1, 2, 3).reject(i -> i > 0)).isEqualTo(empty());
+        } else {
+            assertThat(this.<Integer> empty().reject(i -> i == 0)).isSameAs(empty());
+            assertThat(of(1, 2, 3).reject(i -> i > 0)).isSameAs(empty());
+        }
+    }
+
+    @Test
+    public void shouldReturnSameInstanceWhenRejectingEmptyTraversable() {
+        final Traversable<?> empty = empty();
+        assertThat(empty.reject(v -> true)).isSameAs(empty);
+    }
+
     // -- find
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -2900,17 +2900,20 @@ public class CharSeqTest {
 
     // -- removeAll(Predicate)
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveAllElementsByPredicateFromNil() {
         assertThat(CharSeq.empty().removeAll(Character::isDigit)).isSameAs(CharSeq.empty());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveAllMatchedElementsFromNonNil() {
         assertThat(CharSeq.of('1', '2', '3', 'a', 'b', 'c').removeAll(Character::isDigit))
                 .isEqualTo(CharSeq.of('a', 'b', 'c'));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
         final CharSeq t = CharSeq.of('a', 'b', 'c');

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -791,6 +791,24 @@ public class CharSeqTest {
         assertThat(t.filter(i -> true)).isSameAs(t);
     }
     
+    // -- reject
+
+    @Test
+    public void shouldRejectEmptyTraversable() {
+        assertThat(CharSeq.empty().reject(ignored -> true)).isSameAs(CharSeq.empty());
+    }
+
+    @Test
+    public void shouldRejectNonEmptyTraversable() {
+        assertThat(CharSeq.of('1', '2', '3', '4').reject(i -> i == '2' || i == '4')).isEqualTo(CharSeq.of('1', '3'));
+    }
+
+    @Test
+    public void shouldRejectNonEmptyTraversableNoneMatch() {
+        final CharSeq t = CharSeq.of('1', '2', '3', '4');
+        assertThat(t.reject(i -> false)).isSameAs(t);
+    }
+
     // -- find
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/IntMap.java
+++ b/vavr/src/test/java/io/vavr/collection/IntMap.java
@@ -150,6 +150,11 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
+    public IntMap<T> reject(Predicate<? super T> predicate) {
+        return unit(original.reject(p -> predicate.test(p._2)));
+    }
+
+    @Override
     public <U> Seq<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         return original.flatMap(e -> mapper.apply(e._2));
     }

--- a/vavr/src/test/java/io/vavr/collection/IntMultimap.java
+++ b/vavr/src/test/java/io/vavr/collection/IntMultimap.java
@@ -151,6 +151,11 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
+    public IntMultimap<T> reject(Predicate<? super T> predicate) {
+        return unit(original.reject(p -> predicate.test(p._2)));
+    }
+
+    @Override
     public <U> Seq<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         return original.flatMap(e -> mapper.apply(e._2));
     }

--- a/vavr/src/test/java/io/vavr/collection/IteratorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/IteratorTest.java
@@ -515,6 +515,7 @@ public class IteratorTest extends AbstractTraversableTest {
         multipleHasNext(() -> Iterator.of(1, 2, 3, 4).dropUntil(e -> e == 3));
         multipleHasNext(() -> Iterator.of(1, 2, 3, 4).dropWhile(e -> e == 1));
         multipleHasNext(() -> Iterator.of(1, 2, 3, 4).filter(e -> e > 1));
+        multipleHasNext(() -> Iterator.of(1, 2, 3, 4).reject(e -> e <= 1));
         multipleHasNext(() -> Iterator.of(1, 2, 3, 4).flatMap(e -> Iterator.of(e, e + 1)));
         multipleHasNext(() -> Iterator.of(1, 2, 3, 4).grouped(2));
         multipleHasNext(() -> Iterator.of(1, 2, 3, 4).intersperse(-1));

--- a/vavr/src/test/java/io/vavr/collection/TreeTest.java
+++ b/vavr/src/test/java/io/vavr/collection/TreeTest.java
@@ -850,6 +850,15 @@ public class TreeTest extends AbstractTraversableTest {
         // TODO: remove this overridden method with #1826
     }
 
+    // -- reject
+
+    @Ignore
+    @Override
+    @Test
+    public void shouldReturnSameInstanceWhenRejectingEmptyTraversable() {
+        // TODO: remove this overridden method with #1826
+    }
+
     // -- take
 
     @Ignore


### PR DESCRIPTION
Fix #2156.

P.S.
A also replace `Map#removeAll`, `Map#removeKeys` and `Map#removeValues` with `reject*` variant. With deprecation of course.