### PR TITLE
Add Capsule's Set into benchmarks

### DIFF
--- a/vavr-benchmark/pom.xml
+++ b/vavr-benchmark/pom.xml
@@ -51,6 +51,11 @@
             <version>8.0.0</version>
         </dependency>
         <dependency>
+            <groupId>io.usethesource</groupId>
+            <artifactId>capsule</artifactId>
+            <version>0.6.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <version>0.7.1</version>
@@ -101,4 +106,10 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>useTheSource</id>
+            <url>http://nexus.usethesource.io/content/repositories/public/</url>
+        </repository>
+    </repositories>
 </project>

--- a/vavr-benchmark/src/test/java/io/vavr/collection/HashSetBenchmark.java
+++ b/vavr-benchmark/src/test/java/io/vavr/collection/HashSetBenchmark.java
@@ -53,6 +53,7 @@ public class HashSetBenchmark {
 
         scala.collection.immutable.Set<Integer> scalaPersistent;
         org.pcollections.PSet<Integer> pcollectionsPersistent;
+        io.usethesource.capsule.Set.Immutable<Integer> capsulePersistent;
         io.vavr.collection.Set<Integer> vavrPersistent;
 
         @Setup
@@ -65,6 +66,7 @@ public class HashSetBenchmark {
 
             scalaPersistent = create(v -> (scala.collection.immutable.Set<Integer>) scala.collection.immutable.HashSet$.MODULE$.apply(asScalaBuffer(v)), SET.toJavaList(), SET.size(), v -> SET.forAll(v::contains));
             pcollectionsPersistent = create(org.pcollections.HashTreePSet::from, SET.toJavaList(), SET.size(), v -> SET.forAll(v::contains));
+            capsulePersistent = create(io.usethesource.capsule.util.collection.AbstractSpecialisedImmutableSet::setOf, SET.toJavaSet(), SET.size(), v -> SET.forAll(v::contains));
             vavrPersistent = create(io.vavr.collection.HashSet::ofAll, SET, SET.size(), v -> SET.forAll(v::contains));
         }
     }
@@ -85,6 +87,16 @@ public class HashSetBenchmark {
             scala.collection.immutable.HashSet<Integer> values = new scala.collection.immutable.HashSet<>();
             for (Integer element : ELEMENTS) {
                 values = values.$plus(element);
+            }
+            assert SET.forAll(values::contains);
+            return values;
+        }
+
+        @Benchmark
+        public Object capsule_persistent() {
+            io.usethesource.capsule.Set.Immutable<Integer> values = io.usethesource.capsule.core.PersistentTrieSet.of();
+            for (Integer element : ELEMENTS) {
+                values = values.__insert(element);
             }
             assert SET.forAll(values::contains);
             return values;
@@ -117,6 +129,16 @@ public class HashSetBenchmark {
         public int pcollections_persistent() {
             int aggregate = 0;
             for (final java.util.Iterator<Integer> iterator = pcollectionsPersistent.iterator(); iterator.hasNext(); ) {
+                aggregate ^= iterator.next();
+            }
+            assert aggregate == EXPECTED_AGGREGATE;
+            return aggregate;
+        }
+
+        @Benchmark
+        public int capsule_persistent() {
+            int aggregate = 0;
+            for (final java.util.Iterator<Integer> iterator = capsulePersistent.iterator(); iterator.hasNext(); ) {
                 aggregate ^= iterator.next();
             }
             assert aggregate == EXPECTED_AGGREGATE;


### PR DESCRIPTION
Ref #2053 

[Capsule](https://github.com/usethesource/capsule), as I see, contains only `Map` and `Set` implementations.
But Vavr doesn't contains benchmarks for `Map` yet.