### PR TITLE
Eliminated method useIsEqualToInsteadOfIsSameAs() from AbstractSeqTes…

### DIFF
--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -21,8 +21,8 @@ package io.vavr.collection;
 
 import io.vavr.Function1;
 import io.vavr.Tuple;
-import io.vavr.Tuple2;
 import io.vavr.control.Option;
+import io.vavr.Tuple2;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -140,14 +140,14 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldAppendElementToNil() {
-        final Seq<Integer> actual = this.<Integer>empty().append(1);
+        final Seq<Integer> actual = this.<Integer> empty().append(1);
         final Seq<Integer> expected = of(1);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldAppendNullElementToNil() {
-        final Seq<Integer> actual = this.<Integer>empty().append(null);
+        final Seq<Integer> actual = this.<Integer> empty().append(null);
         final Seq<Integer> expected = this.of((Integer) null);
         assertThat(actual).isEqualTo(expected);
     }
@@ -180,7 +180,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldAppendAllNonNilToNil() {
-        final Seq<Integer> actual = this.<Integer>empty().appendAll(of(1, 2, 3));
+        final Seq<Integer> actual = this.<Integer> empty().appendAll(of(1, 2, 3));
         final Seq<Integer> expected = of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
@@ -262,9 +262,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldConvertAsJavaAndRethrowException() {
-        assertThatThrownBy(() -> of(1, 2, 3).asJavaMutable(list -> {
-            throw new RuntimeException("test");
-        }))
+        assertThatThrownBy(() -> of(1, 2, 3).asJavaMutable(list -> { throw new RuntimeException("test");}))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("test");
     }
@@ -287,9 +285,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldConvertAsJavaImmutableAndRethrowException() {
-        assertThatThrownBy(() -> of(1, 2, 3).asJava(list -> {
-            throw new RuntimeException("test");
-        }))
+        assertThatThrownBy(() -> of(1, 2, 3).asJava(list -> { throw new RuntimeException("test");}))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("test");
     }
@@ -751,7 +747,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldInsertIntoNil() {
-        final Seq<Integer> actual = this.<Integer>empty().insert(0, 1);
+        final Seq<Integer> actual = this.<Integer> empty().insert(0, 1);
         final Seq<Integer> expected = of(1);
         assertThat(actual).isEqualTo(expected);
     }
@@ -796,7 +792,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldInsertAllIntoNil() {
-        final Seq<Integer> actual = this.<Integer>empty().insertAll(0, of(1, 2, 3));
+        final Seq<Integer> actual = this.<Integer> empty().insertAll(0, of(1, 2, 3));
         final Seq<Integer> expected = of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
@@ -864,7 +860,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldIntersperseNil() {
-        assertThat(this.<Character>empty().intersperse(',')).isEmpty();
+        assertThat(this.<Character> empty().intersperse(',')).isEmpty();
     }
 
     @Test
@@ -1082,7 +1078,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldMapTransformedSeq() {
         final Function<Integer, Integer> mapper = o -> o + 1;
-        assertThat(this.<Integer>empty().map(mapper)).isEmpty();
+        assertThat(this.<Integer> empty().map(mapper)).isEmpty();
         assertThat(of(3, 1, 4, 1, 5).map(mapper)).isEqualTo(of(4, 2, 5, 2, 6));
         assertThat(of(3, 1, 4, 1, 5, 9, 2).sorted().distinct().drop(1).init().remove(5).map(mapper).tail()).isEqualTo(of(4, 5));
     }
@@ -1122,7 +1118,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldPrependElementToNil() {
-        final Seq<Integer> actual = this.<Integer>empty().prepend(1);
+        final Seq<Integer> actual = this.<Integer> empty().prepend(1);
         final Seq<Integer> expected = of(1);
         assertThat(actual).isEqualTo(expected);
     }
@@ -1143,7 +1139,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldPrependAllNilToNil() {
-        final Seq<Integer> actual = this.<Integer>empty().prependAll(empty());
+        final Seq<Integer> actual = this.<Integer> empty().prependAll(empty());
         final Seq<Integer> expected = empty();
         assertThat(actual).isEqualTo(expected);
     }
@@ -1157,7 +1153,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldPrependAllNonNilToNil() {
-        final Seq<Integer> actual = this.<Integer>empty().prependAll(of(1, 2, 3));
+        final Seq<Integer> actual = this.<Integer> empty().prependAll(of(1, 2, 3));
         final Seq<Integer> expected = of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
@@ -1221,7 +1217,11 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldRemoveNonExistingElement() {
         final Seq<Integer> t = of(1, 2, 3);
-        assertThat(t.remove(4)).isSameAs(t);
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(t.remove(4)).isEqualTo(t);
+        } else {
+            assertThat(t.remove(4)).isSameAs(t);
+        }
     }
 
     // -- removeFirst(Predicate)
@@ -1259,7 +1259,11 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldRemoveFirstElementByPredicateNonExisting() {
         final Seq<Integer> t = of(1, 2, 3);
-        assertThat(t.removeFirst(v -> v == 4)).isSameAs(t);
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(t.removeFirst(v -> v == 4)).isEqualTo(t);
+        } else {
+            assertThat(t.removeFirst(v -> v == 4)).isSameAs(t);
+        }
     }
 
     // -- removeLast(Predicate)
@@ -1297,9 +1301,12 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldRemoveLastElementByPredicateNonExisting() {
         final Seq<Integer> t = of(1, 2, 3);
-        assertThat(t.removeLast(v -> v == 4)).isSameAs(t);
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(t.removeLast(v -> v == 4)).isEqualTo(t);
+        } else {
+            assertThat(t.removeLast(v -> v == 4)).isSameAs(t);
+        }
     }
-
 
     // -- removeAll(Iterable)
 
@@ -1316,7 +1323,11 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldNotRemoveAllNonExistingElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);
-        assertThat(t.removeAll(of(4, 5))).isSameAs(t);
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(t.removeAll(of(4, 5))).isEqualTo(t);
+        } else {
+            assertThat(t.removeAll(of(4, 5))).isSameAs(t);
+        }
     }
 
     @Test
@@ -1335,14 +1346,27 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldRemoveExistingElements() {
-        final Seq<Integer> seq = of(1, 2, 3);
-        assertThat(seq.removeAll(ignore -> false)).isSameAs(seq);
+        assertThat(of(1, 2, 3).removeAll(i -> i == 1)).isEqualTo(of(2, 3));
+        assertThat(of(1, 2, 3).removeAll(i -> i == 2)).isEqualTo(of(1, 3));
+        assertThat(of(1, 2, 3).removeAll(i -> i == 3)).isEqualTo(of(1, 2));
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(of(1, 2, 3).removeAll(ignore -> true)).isEmpty();
+            assertThat(of(1, 2, 3).removeAll(ignore -> false)).isEqualTo(of(1, 2, 3));
+        } else {
+            final Seq<Integer> seq = of(1, 2, 3);
+            assertThat(seq.removeAll(ignore -> false)).isSameAs(seq);
+        }
     }
 
     @Test
     public void shouldRemoveNonExistingElements() {
-        assertThat(this.<Integer>empty().removeAll(i -> i == 0)).isEqualTo(empty());
-        assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isEqualTo(empty());
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(this.<Integer> empty().removeAll(i -> i == 0)).isEqualTo(empty());
+            assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isEqualTo(empty());
+        } else {
+            assertThat(this.<Integer> empty().removeAll(i -> i == 0)).isSameAs(empty());
+            assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isSameAs(empty());
+        }
     }
 
     @Test
@@ -1364,7 +1388,11 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);
         final Predicate<Integer> isTooBig = i -> i >= 4;
-        assertThat(t.removeAll(isTooBig)).isSameAs(t);
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(t.removeAll(isTooBig)).isEqualTo(t);
+        } else {
+            assertThat(t.removeAll(isTooBig)).isSameAs(t);
+        }
     }
 
     // -- removeAll(Object)
@@ -1382,7 +1410,11 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldNotRemoveAllNonObjectsElementsFromNonNil() {
         final Seq<Integer> seq = of(1, 2, 3);
-        assertThat(seq.removeAll(4)).isSameAs(seq);
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(seq.removeAll(4)).isEqualTo(seq);
+        } else {
+            assertThat(seq.removeAll(4)).isSameAs(seq);
+        }
     }
 
     @Test
@@ -1653,7 +1685,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldReturnNilWhenSliceFrom0To0OnNil() {
-        final Seq<Integer> actual = this.<Integer>empty().slice(0, 0);
+        final Seq<Integer> actual = this.<Integer> empty().slice(0, 0);
         assertThat(actual).isEmpty();
     }
 
@@ -1743,7 +1775,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldSortNilUsingComparator() {
-        assertThat(this.<Integer>empty().sorted((i, j) -> j - i)).isEmpty();
+        assertThat(this.<Integer> empty().sorted((i, j) -> j - i)).isEmpty();
     }
 
     @Test
@@ -1755,7 +1787,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldSortByNilUsingFunction() {
-        assertThat(this.<String>empty().sortBy(String::length)).isEmpty();
+        assertThat(this.<String> empty().sortBy(String::length)).isEmpty();
     }
 
     @Test
@@ -1781,7 +1813,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldSortByNilUsingComparatorAndFunction() {
-        assertThat(this.<String>empty().sortBy(String::length)).isEmpty();
+        assertThat(this.<String> empty().sortBy(String::length)).isEmpty();
     }
 
     @Test
@@ -1970,7 +2002,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldReturnNilWhenSubSequenceFrom0OnNil() {
-        final Seq<Integer> actual = this.<Integer>empty().subSequence(0);
+        final Seq<Integer> actual = this.<Integer> empty().subSequence(0);
         assertThat(actual).isEmpty();
     }
 
@@ -2023,7 +2055,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldReturnNilWhenSubSequenceFrom0To0OnNil() {
-        final Seq<Integer> actual = this.<Integer>empty().subSequence(0, 0);
+        final Seq<Integer> actual = this.<Integer> empty().subSequence(0, 0);
         assertThat(actual).isEmpty();
     }
 
@@ -2120,7 +2152,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldSearchNegatedInsertionPointMinusOneForAbsentElementsUsingComparator() {
-        assertThat(this.<Integer>empty().search(42, Integer::compareTo)).isEqualTo(-1);
+        assertThat(this.<Integer> empty().search(42, Integer::compareTo)).isEqualTo(-1);
         assertThat(of(10, 20, 30).search(25, Integer::compareTo)).isEqualTo(-3);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -1328,20 +1328,22 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     // -- removeAll(Predicate)
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveExistingElements() {
         final Seq<Integer> seq = of(1, 2, 3);
-        assertThat(seq.reject(i -> i == 1)).isEqualTo(of(2, 3));
-        assertThat(seq.reject(i -> i == 2)).isEqualTo(of(1, 3));
-        assertThat(seq.reject(i -> i == 3)).isEqualTo(of(1, 2));
-        assertThat(seq.reject(ignore -> true)).isEmpty();
-        assertThat(seq.reject(ignore -> false)).isSameAs(seq);
+        assertThat(seq.removeAll(i -> i == 1)).isEqualTo(of(2, 3));
+        assertThat(seq.removeAll(i -> i == 2)).isEqualTo(of(1, 3));
+        assertThat(seq.removeAll(i -> i == 3)).isEqualTo(of(1, 2));
+        assertThat(seq.removeAll(ignore -> true)).isEmpty();
+        assertThat(seq.removeAll(ignore -> false)).isSameAs(seq);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveNonExistingElements() {
-        assertThat(this.<Integer> empty().reject(i -> i == 0)).isSameAs(empty());
-        assertThat(of(1, 2, 3).reject(i -> i != 0)).isSameAs(empty());
+        assertThat(this.<Integer> empty().removeAll(i -> i == 0)).isSameAs(empty());
+        assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isSameAs(empty());
     }
 
     @SuppressWarnings("deprecation")
@@ -1362,11 +1364,12 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         assertThat(of(1, 2, 3, 4, 5, 6).removeAll(i -> i % 2 == 0)).isEqualTo(of(1, 3, 5));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);
         final Predicate<Integer> isTooBig = i -> i >= 4;
-        assertThat(t.reject(isTooBig)).isSameAs(t);
+        assertThat(t.removeAll(isTooBig)).isSameAs(t);
     }
 
     // -- removeAll(Object)

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -1328,22 +1328,20 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     // -- removeAll(Predicate)
 
-    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveExistingElements() {
         final Seq<Integer> seq = of(1, 2, 3);
-        assertThat(seq.removeAll(i -> i == 1)).isEqualTo(of(2, 3));
-        assertThat(seq.removeAll(i -> i == 2)).isEqualTo(of(1, 3));
-        assertThat(seq.removeAll(i -> i == 3)).isEqualTo(of(1, 2));
-        assertThat(seq.removeAll(ignore -> true)).isEmpty();
-        assertThat(seq.removeAll(ignore -> false)).isSameAs(seq);
+        assertThat(seq.reject(i -> i == 1)).isEqualTo(of(2, 3));
+        assertThat(seq.reject(i -> i == 2)).isEqualTo(of(1, 3));
+        assertThat(seq.reject(i -> i == 3)).isEqualTo(of(1, 2));
+        assertThat(seq.reject(ignore -> true)).isEmpty();
+        assertThat(seq.reject(ignore -> false)).isSameAs(seq);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void shouldRemoveNonExistingElements() {
-        assertThat(this.<Integer> empty().removeAll(i -> i == 0)).isSameAs(empty());
-        assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isSameAs(empty());
+        assertThat(this.<Integer> empty().reject(i -> i == 0)).isSameAs(empty());
+        assertThat(of(1, 2, 3).reject(i -> i != 0)).isSameAs(empty());
     }
 
     @SuppressWarnings("deprecation")

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -21,8 +21,8 @@ package io.vavr.collection;
 
 import io.vavr.Function1;
 import io.vavr.Tuple;
-import io.vavr.control.Option;
 import io.vavr.Tuple2;
+import io.vavr.control.Option;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -140,14 +140,14 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldAppendElementToNil() {
-        final Seq<Integer> actual = this.<Integer> empty().append(1);
+        final Seq<Integer> actual = this.<Integer>empty().append(1);
         final Seq<Integer> expected = of(1);
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldAppendNullElementToNil() {
-        final Seq<Integer> actual = this.<Integer> empty().append(null);
+        final Seq<Integer> actual = this.<Integer>empty().append(null);
         final Seq<Integer> expected = this.of((Integer) null);
         assertThat(actual).isEqualTo(expected);
     }
@@ -180,7 +180,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldAppendAllNonNilToNil() {
-        final Seq<Integer> actual = this.<Integer> empty().appendAll(of(1, 2, 3));
+        final Seq<Integer> actual = this.<Integer>empty().appendAll(of(1, 2, 3));
         final Seq<Integer> expected = of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
@@ -262,7 +262,9 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldConvertAsJavaAndRethrowException() {
-        assertThatThrownBy(() -> of(1, 2, 3).asJavaMutable(list -> { throw new RuntimeException("test");}))
+        assertThatThrownBy(() -> of(1, 2, 3).asJavaMutable(list -> {
+            throw new RuntimeException("test");
+        }))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("test");
     }
@@ -285,7 +287,9 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldConvertAsJavaImmutableAndRethrowException() {
-        assertThatThrownBy(() -> of(1, 2, 3).asJava(list -> { throw new RuntimeException("test");}))
+        assertThatThrownBy(() -> of(1, 2, 3).asJava(list -> {
+            throw new RuntimeException("test");
+        }))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("test");
     }
@@ -747,7 +751,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldInsertIntoNil() {
-        final Seq<Integer> actual = this.<Integer> empty().insert(0, 1);
+        final Seq<Integer> actual = this.<Integer>empty().insert(0, 1);
         final Seq<Integer> expected = of(1);
         assertThat(actual).isEqualTo(expected);
     }
@@ -792,7 +796,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldInsertAllIntoNil() {
-        final Seq<Integer> actual = this.<Integer> empty().insertAll(0, of(1, 2, 3));
+        final Seq<Integer> actual = this.<Integer>empty().insertAll(0, of(1, 2, 3));
         final Seq<Integer> expected = of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
@@ -860,7 +864,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldIntersperseNil() {
-        assertThat(this.<Character> empty().intersperse(',')).isEmpty();
+        assertThat(this.<Character>empty().intersperse(',')).isEmpty();
     }
 
     @Test
@@ -1078,7 +1082,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldMapTransformedSeq() {
         final Function<Integer, Integer> mapper = o -> o + 1;
-        assertThat(this.<Integer> empty().map(mapper)).isEmpty();
+        assertThat(this.<Integer>empty().map(mapper)).isEmpty();
         assertThat(of(3, 1, 4, 1, 5).map(mapper)).isEqualTo(of(4, 2, 5, 2, 6));
         assertThat(of(3, 1, 4, 1, 5, 9, 2).sorted().distinct().drop(1).init().remove(5).map(mapper).tail()).isEqualTo(of(4, 5));
     }
@@ -1118,7 +1122,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldPrependElementToNil() {
-        final Seq<Integer> actual = this.<Integer> empty().prepend(1);
+        final Seq<Integer> actual = this.<Integer>empty().prepend(1);
         final Seq<Integer> expected = of(1);
         assertThat(actual).isEqualTo(expected);
     }
@@ -1139,7 +1143,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldPrependAllNilToNil() {
-        final Seq<Integer> actual = this.<Integer> empty().prependAll(empty());
+        final Seq<Integer> actual = this.<Integer>empty().prependAll(empty());
         final Seq<Integer> expected = empty();
         assertThat(actual).isEqualTo(expected);
     }
@@ -1153,7 +1157,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldPrependAllNonNilToNil() {
-        final Seq<Integer> actual = this.<Integer> empty().prependAll(of(1, 2, 3));
+        final Seq<Integer> actual = this.<Integer>empty().prependAll(of(1, 2, 3));
         final Seq<Integer> expected = of(1, 2, 3);
         assertThat(actual).isEqualTo(expected);
     }
@@ -1217,11 +1221,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldRemoveNonExistingElement() {
         final Seq<Integer> t = of(1, 2, 3);
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(t.remove(4)).isEqualTo(t);
-        } else {
-            assertThat(t.remove(4)).isSameAs(t);
-        }
+        assertThat(t.remove(4)).isSameAs(t);
     }
 
     // -- removeFirst(Predicate)
@@ -1259,11 +1259,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldRemoveFirstElementByPredicateNonExisting() {
         final Seq<Integer> t = of(1, 2, 3);
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(t.removeFirst(v -> v == 4)).isEqualTo(t);
-        } else {
-            assertThat(t.removeFirst(v -> v == 4)).isSameAs(t);
-        }
+        assertThat(t.removeFirst(v -> v == 4)).isSameAs(t);
     }
 
     // -- removeLast(Predicate)
@@ -1301,12 +1297,9 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldRemoveLastElementByPredicateNonExisting() {
         final Seq<Integer> t = of(1, 2, 3);
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(t.removeLast(v -> v == 4)).isEqualTo(t);
-        } else {
-            assertThat(t.removeLast(v -> v == 4)).isSameAs(t);
-        }
+        assertThat(t.removeLast(v -> v == 4)).isSameAs(t);
     }
+
 
     // -- removeAll(Iterable)
 
@@ -1323,11 +1316,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldNotRemoveAllNonExistingElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(t.removeAll(of(4, 5))).isEqualTo(t);
-        } else {
-            assertThat(t.removeAll(of(4, 5))).isSameAs(t);
-        }
+        assertThat(t.removeAll(of(4, 5))).isSameAs(t);
     }
 
     @Test
@@ -1346,27 +1335,14 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldRemoveExistingElements() {
-        assertThat(of(1, 2, 3).removeAll(i -> i == 1)).isEqualTo(of(2, 3));
-        assertThat(of(1, 2, 3).removeAll(i -> i == 2)).isEqualTo(of(1, 3));
-        assertThat(of(1, 2, 3).removeAll(i -> i == 3)).isEqualTo(of(1, 2));
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(of(1, 2, 3).removeAll(ignore -> true)).isEmpty();
-            assertThat(of(1, 2, 3).removeAll(ignore -> false)).isEqualTo(of(1, 2, 3));
-        } else {
-            final Seq<Integer> seq = of(1, 2, 3);
-            assertThat(seq.removeAll(ignore -> false)).isSameAs(seq);
-        }
+        final Seq<Integer> seq = of(1, 2, 3);
+        assertThat(seq.removeAll(ignore -> false)).isSameAs(seq);
     }
 
     @Test
     public void shouldRemoveNonExistingElements() {
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(this.<Integer> empty().removeAll(i -> i == 0)).isEqualTo(empty());
-            assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isEqualTo(empty());
-        } else {
-            assertThat(this.<Integer> empty().removeAll(i -> i == 0)).isSameAs(empty());
-            assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isSameAs(empty());
-        }
+        assertThat(this.<Integer>empty().removeAll(i -> i == 0)).isEqualTo(empty());
+        assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isEqualTo(empty());
     }
 
     @Test
@@ -1388,11 +1364,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);
         final Predicate<Integer> isTooBig = i -> i >= 4;
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(t.removeAll(isTooBig)).isEqualTo(t);
-        } else {
-            assertThat(t.removeAll(isTooBig)).isSameAs(t);
-        }
+        assertThat(t.removeAll(isTooBig)).isSameAs(t);
     }
 
     // -- removeAll(Object)
@@ -1410,11 +1382,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldNotRemoveAllNonObjectsElementsFromNonNil() {
         final Seq<Integer> seq = of(1, 2, 3);
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(seq.removeAll(4)).isEqualTo(seq);
-        } else {
-            assertThat(seq.removeAll(4)).isSameAs(seq);
-        }
+        assertThat(seq.removeAll(4)).isSameAs(seq);
     }
 
     @Test
@@ -1605,7 +1573,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldReturnNilWhenSliceFrom0To0OnNil() {
-        final Seq<Integer> actual = this.<Integer> empty().slice(0, 0);
+        final Seq<Integer> actual = this.<Integer>empty().slice(0, 0);
         assertThat(actual).isEmpty();
     }
 
@@ -1695,7 +1663,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldSortNilUsingComparator() {
-        assertThat(this.<Integer> empty().sorted((i, j) -> j - i)).isEmpty();
+        assertThat(this.<Integer>empty().sorted((i, j) -> j - i)).isEmpty();
     }
 
     @Test
@@ -1707,7 +1675,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldSortByNilUsingFunction() {
-        assertThat(this.<String> empty().sortBy(String::length)).isEmpty();
+        assertThat(this.<String>empty().sortBy(String::length)).isEmpty();
     }
 
     @Test
@@ -1733,7 +1701,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldSortByNilUsingComparatorAndFunction() {
-        assertThat(this.<String> empty().sortBy(String::length)).isEmpty();
+        assertThat(this.<String>empty().sortBy(String::length)).isEmpty();
     }
 
     @Test
@@ -1922,7 +1890,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldReturnNilWhenSubSequenceFrom0OnNil() {
-        final Seq<Integer> actual = this.<Integer> empty().subSequence(0);
+        final Seq<Integer> actual = this.<Integer>empty().subSequence(0);
         assertThat(actual).isEmpty();
     }
 
@@ -1975,7 +1943,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldReturnNilWhenSubSequenceFrom0To0OnNil() {
-        final Seq<Integer> actual = this.<Integer> empty().subSequence(0, 0);
+        final Seq<Integer> actual = this.<Integer>empty().subSequence(0, 0);
         assertThat(actual).isEmpty();
     }
 
@@ -2072,7 +2040,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldSearchNegatedInsertionPointMinusOneForAbsentElementsUsingComparator() {
-        assertThat(this.<Integer> empty().search(42, Integer::compareTo)).isEqualTo(-1);
+        assertThat(this.<Integer>empty().search(42, Integer::compareTo)).isEqualTo(-1);
         assertThat(of(10, 20, 30).search(25, Integer::compareTo)).isEqualTo(-3);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -1362,12 +1362,11 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         assertThat(of(1, 2, 3, 4, 5, 6).removeAll(i -> i % 2 == 0)).isEqualTo(of(1, 3, 5));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);
         final Predicate<Integer> isTooBig = i -> i >= 4;
-        assertThat(t.removeAll(isTooBig)).isSameAs(t);
+        assertThat(t.reject(isTooBig)).isSameAs(t);
     }
 
     // -- removeAll(Object)

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -1217,11 +1217,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldRemoveNonExistingElement() {
         final Seq<Integer> t = of(1, 2, 3);
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(t.remove(4)).isEqualTo(t);
-        } else {
-            assertThat(t.remove(4)).isSameAs(t);
-        }
+        assertThat(t.remove(4)).isSameAs(t);
     }
 
     // -- removeFirst(Predicate)
@@ -1259,11 +1255,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldRemoveFirstElementByPredicateNonExisting() {
         final Seq<Integer> t = of(1, 2, 3);
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(t.removeFirst(v -> v == 4)).isEqualTo(t);
-        } else {
-            assertThat(t.removeFirst(v -> v == 4)).isSameAs(t);
-        }
+        assertThat(t.removeFirst(v -> v == 4)).isSameAs(t);
     }
 
     // -- removeLast(Predicate)
@@ -1301,11 +1293,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldRemoveLastElementByPredicateNonExisting() {
         final Seq<Integer> t = of(1, 2, 3);
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(t.removeLast(v -> v == 4)).isEqualTo(t);
-        } else {
-            assertThat(t.removeLast(v -> v == 4)).isSameAs(t);
-        }
+        assertThat(t.removeLast(v -> v == 4)).isSameAs(t);
     }
 
     // -- removeAll(Iterable)
@@ -1323,11 +1311,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldNotRemoveAllNonExistingElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(t.removeAll(of(4, 5))).isEqualTo(t);
-        } else {
-            assertThat(t.removeAll(of(4, 5))).isSameAs(t);
-        }
+        assertThat(t.removeAll(of(4, 5))).isSameAs(t);
     }
 
     @Test
@@ -1346,27 +1330,18 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     @Test
     public void shouldRemoveExistingElements() {
-        assertThat(of(1, 2, 3).removeAll(i -> i == 1)).isEqualTo(of(2, 3));
-        assertThat(of(1, 2, 3).removeAll(i -> i == 2)).isEqualTo(of(1, 3));
-        assertThat(of(1, 2, 3).removeAll(i -> i == 3)).isEqualTo(of(1, 2));
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(of(1, 2, 3).removeAll(ignore -> true)).isEmpty();
-            assertThat(of(1, 2, 3).removeAll(ignore -> false)).isEqualTo(of(1, 2, 3));
-        } else {
-            final Seq<Integer> seq = of(1, 2, 3);
-            assertThat(seq.removeAll(ignore -> false)).isSameAs(seq);
-        }
+        final Seq<Integer> seq = of(1, 2, 3);
+        assertThat(seq.removeAll(i -> i == 1)).isEqualTo(of(2, 3));
+        assertThat(seq.removeAll(i -> i == 2)).isEqualTo(of(1, 3));
+        assertThat(seq.removeAll(i -> i == 3)).isEqualTo(of(1, 2));
+        assertThat(seq.removeAll(ignore -> true)).isEmpty();
+        assertThat(seq.removeAll(ignore -> false)).isSameAs(seq);
     }
 
     @Test
     public void shouldRemoveNonExistingElements() {
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(this.<Integer> empty().removeAll(i -> i == 0)).isEqualTo(empty());
-            assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isEqualTo(empty());
-        } else {
-            assertThat(this.<Integer> empty().removeAll(i -> i == 0)).isSameAs(empty());
-            assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isSameAs(empty());
-        }
+        assertThat(this.<Integer> empty().removeAll(i -> i == 0)).isSameAs(empty());
+        assertThat(of(1, 2, 3).removeAll(i -> i != 0)).isSameAs(empty());
     }
 
     @Test
@@ -1388,11 +1363,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);
         final Predicate<Integer> isTooBig = i -> i >= 4;
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(t.removeAll(isTooBig)).isEqualTo(t);
-        } else {
-            assertThat(t.removeAll(isTooBig)).isSameAs(t);
-        }
+        assertThat(t.removeAll(isTooBig)).isSameAs(t);
     }
 
     // -- removeAll(Object)
@@ -1410,11 +1381,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldNotRemoveAllNonObjectsElementsFromNonNil() {
         final Seq<Integer> seq = of(1, 2, 3);
-        if (useIsEqualToInsteadOfIsSameAs()) {
-            assertThat(seq.removeAll(4)).isEqualTo(seq);
-        } else {
-            assertThat(seq.removeAll(4)).isSameAs(seq);
-        }
+        assertThat(seq.removeAll(4)).isSameAs(seq);
     }
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/ArrayTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ArrayTest.java
@@ -195,6 +195,7 @@ public class ArrayTest extends AbstractIndexedSeqTest {
         return 1;
     }
 
+    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return false;

--- a/vavr/src/test/java/io/vavr/collection/ArrayTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ArrayTest.java
@@ -195,7 +195,6 @@ public class ArrayTest extends AbstractIndexedSeqTest {
         return 1;
     }
 
-    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return false;

--- a/vavr/src/test/java/io/vavr/collection/HashSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/HashSetTest.java
@@ -396,6 +396,7 @@ public class HashSetTest extends AbstractSetTest {
         assertTrue(HashSet.of(1).equals(HashSet.of(1)));
     }
 
+    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return false;

--- a/vavr/src/test/java/io/vavr/collection/HashSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/HashSetTest.java
@@ -396,7 +396,6 @@ public class HashSetTest extends AbstractSetTest {
         assertTrue(HashSet.of(1).equals(HashSet.of(1)));
     }
 
-    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return false;

--- a/vavr/src/test/java/io/vavr/collection/ListTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ListTest.java
@@ -405,6 +405,7 @@ public class ListTest extends AbstractLinearSeqTest {
         }
     }
 
+    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return false;

--- a/vavr/src/test/java/io/vavr/collection/ListTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ListTest.java
@@ -405,7 +405,6 @@ public class ListTest extends AbstractLinearSeqTest {
         }
     }
 
-    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return false;

--- a/vavr/src/test/java/io/vavr/collection/QueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/QueueTest.java
@@ -200,6 +200,7 @@ public class QueueTest extends AbstractLinearSeqTest {
         return 1;
     }
 
+    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return false;

--- a/vavr/src/test/java/io/vavr/collection/QueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/QueueTest.java
@@ -200,7 +200,6 @@ public class QueueTest extends AbstractLinearSeqTest {
         return 1;
     }
 
-    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return false;

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -19,11 +19,7 @@
  */
 package io.vavr.collection;
 
-import io.vavr.CheckedFunction1;
-import io.vavr.CheckedFunction2;
-import io.vavr.Serializables;
-import io.vavr.Tuple2;
-import io.vavr.Value;
+import io.vavr.*;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
 import org.junit.Ignore;
@@ -39,7 +35,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 
 import static io.vavr.collection.Stream.concat;
-import static org.junit.Assert.assertNotSame;
 
 public class StreamTest extends AbstractLinearSeqTest {
 
@@ -203,71 +198,9 @@ public class StreamTest extends AbstractLinearSeqTest {
         return Stream.transpose((Stream<Stream<T>>) rows);
     }
 
-    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return true;
-    }
-
-    @Test
-    @Override
-    public void shouldRemoveNonExistingElement() {
-        final Seq<Integer> t = of(1, 2, 3);
-        assertThat(t.remove(4)).isEqualTo(t);
-        assertNotSame(t, t.remove(4));
-    }
-
-    @Test
-    @Override
-    public void shouldRemoveFirstElementByPredicateNonExisting() {
-        final Seq<Integer> t = of(1, 2, 3);
-        assertThat(t.removeFirst(v -> v == 4)).isEqualTo(t);
-        assertNotSame(t, t.removeFirst(v -> v == 4));
-    }
-
-    @Test
-    @Override
-    public void shouldRemoveLastElementByPredicateNonExisting() {
-        final Seq<Integer> t = of(1, 2, 3);
-        assertThat(t.removeLast(v -> v == 4)).isEqualTo(t);
-        assertNotSame(t, t.removeLast(v -> v == 4));
-    }
-
-    @Test
-    @Override
-    public void shouldNotRemoveAllNonExistingElementsFromNonNil() {
-        final Seq<Integer> t = of(1, 2, 3);
-        assertThat(t.removeAll(of(4, 5))).isEqualTo(t);
-        assertNotSame(t, t.removeAll(of(4, 5)));
-    }
-
-    @Test
-    @Override
-    public void shouldRemoveExistingElements() {
-        final Seq<Integer> seq = of(1, 2, 3);
-        assertThat(seq.removeAll(i -> i == 1)).isEqualTo(of(2, 3));
-        assertThat(seq.removeAll(i -> i == 2)).isEqualTo(of(1, 3));
-        assertThat(seq.removeAll(i -> i == 3)).isEqualTo(of(1, 2));
-        assertThat(seq.removeAll(ignore -> true)).isEmpty();
-        assertThat(seq.removeAll(ignore -> false)).isEqualTo(of(1, 2, 3));
-        assertNotSame(seq, seq.removeAll(ignore -> false));
-    }
-
-    @Test
-    @Override
-    public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
-        final Seq<Integer> t = of(1, 2, 3);
-        final Predicate<Integer> isTooBig = i -> i >= 4;
-        assertThat(t.removeAll(isTooBig)).isEqualTo(t);
-        assertNotSame(t, t.removeAll(isTooBig));
-    }
-
-    @Test
-    @Override
-    public void shouldNotRemoveAllNonObjectsElementsFromNonNil() {
-        final Seq<Integer> seq = of(1, 2, 3);
-        assertThat(seq.removeAll(4)).isEqualTo(seq);
-        assertNotSame(seq, seq.removeAll(4));
     }
 
     // -- static concat()
@@ -585,7 +518,7 @@ public class StreamTest extends AbstractLinearSeqTest {
 
     @Test
     public void shouldReturnAnEmptyStreamWhenExtendingAnEmptyStreamWithFunction() {
-        assertThat(Stream.<Integer>of().extend(i -> i + 1)).isEqualTo(of());
+        assertThat(Stream.<Integer> of().extend(i -> i + 1)).isEqualTo(of());
     }
 
     @Test
@@ -632,7 +565,7 @@ public class StreamTest extends AbstractLinearSeqTest {
 
     @Test
     public void shouldEvaluateTailAtMostOnce() {
-        final int[] counter = {0};
+        final int[] counter = { 0 };
         final Stream<Integer> stream = Stream.continually(() -> counter[0]++);
         // this test ensures that the `tail.append(100)` does not modify the tail elements
         final Stream<Integer> tail = stream.tail().append(100);
@@ -646,14 +579,14 @@ public class StreamTest extends AbstractLinearSeqTest {
     public void shouldNotProduceStackOverflow() {
         Stream.range(0, 1_000_000)
                 .map(String::valueOf)
-                .foldLeft(Stream.<String>empty(), Stream::append)
+                .foldLeft(Stream.<String> empty(), Stream::append)
                 .mkString();
     }
 
     @Test // See #327, #594
     public void shouldNotEvaluateHeadOfTailWhenCallingIteratorHasNext() {
 
-        final Integer[] vals = new Integer[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        final Integer[] vals = new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
         final CheckedFunction2<StringBuilder, Integer, Void> doStuff = (builder, i) -> {
             builder.append(i);
@@ -756,8 +689,8 @@ public class StreamTest extends AbstractLinearSeqTest {
     public void shouldUnfoldRightSimpleStream() {
         assertThat(
                 Stream.unfoldRight(10, x -> x == 0
-                        ? Option.none()
-                        : Option.of(new Tuple2<>(x, x - 1))))
+                                            ? Option.none()
+                                            : Option.of(new Tuple2<>(x, x - 1))))
                 .isEqualTo(of(10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
     }
 
@@ -770,8 +703,8 @@ public class StreamTest extends AbstractLinearSeqTest {
     public void shouldUnfoldLeftSimpleStream() {
         assertThat(
                 Stream.unfoldLeft(10, x -> x == 0
-                        ? Option.none()
-                        : Option.of(new Tuple2<>(x - 1, x))))
+                                           ? Option.none()
+                                           : Option.of(new Tuple2<>(x - 1, x))))
                 .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     }
 
@@ -784,8 +717,8 @@ public class StreamTest extends AbstractLinearSeqTest {
     public void shouldUnfoldSimpleStream() {
         assertThat(
                 Stream.unfold(10, x -> x == 0
-                        ? Option.none()
-                        : Option.of(new Tuple2<>(x - 1, x))))
+                                       ? Option.none()
+                                       : Option.of(new Tuple2<>(x - 1, x))))
                 .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     }
 

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -236,11 +236,11 @@ public class StreamTest extends AbstractLinearSeqTest {
     @Override
     public void shouldRemoveExistingElements() {
         final Seq<Integer> seq = of(1, 2, 3);
-        assertThat(seq.removeAll(i -> i == 1)).isEqualTo(of(2, 3));
-        assertThat(seq.removeAll(i -> i == 2)).isEqualTo(of(1, 3));
-        assertThat(seq.removeAll(i -> i == 3)).isEqualTo(of(1, 2));
-        assertThat(seq.removeAll(ignore -> true)).isEmpty();
-        assertThat(seq.removeAll(ignore -> false)).isEqualTo(of(1, 2, 3)).isNotSameAs(of(1, 2, 3));
+        assertThat(seq.reject(i -> i == 1)).isEqualTo(of(2, 3));
+        assertThat(seq.reject(i -> i == 2)).isEqualTo(of(1, 3));
+        assertThat(seq.reject(i -> i == 3)).isEqualTo(of(1, 2));
+        assertThat(seq.reject(ignore -> true)).isEmpty();
+        assertThat(seq.reject(ignore -> false)).isEqualTo(of(1, 2, 3)).isNotSameAs(of(1, 2, 3));
     }
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -232,23 +232,25 @@ public class StreamTest extends AbstractLinearSeqTest {
         assertThat(t.removeAll(of(4, 5))).isEqualTo(t).isNotSameAs(t);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     @Override
     public void shouldRemoveExistingElements() {
         final Seq<Integer> seq = of(1, 2, 3);
-        assertThat(seq.reject(i -> i == 1)).isEqualTo(of(2, 3));
-        assertThat(seq.reject(i -> i == 2)).isEqualTo(of(1, 3));
-        assertThat(seq.reject(i -> i == 3)).isEqualTo(of(1, 2));
-        assertThat(seq.reject(ignore -> true)).isEmpty();
-        assertThat(seq.reject(ignore -> false)).isEqualTo(of(1, 2, 3)).isNotSameAs(of(1, 2, 3));
+        assertThat(seq.removeAll(i -> i == 1)).isEqualTo(of(2, 3));
+        assertThat(seq.removeAll(i -> i == 2)).isEqualTo(of(1, 3));
+        assertThat(seq.removeAll(i -> i == 3)).isEqualTo(of(1, 2));
+        assertThat(seq.removeAll(ignore -> true)).isEmpty();
+        assertThat(seq.removeAll(ignore -> false)).isEqualTo(of(1, 2, 3)).isNotSameAs(of(1, 2, 3));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     @Override
     public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);
         final Predicate<Integer> isTooBig = i -> i >= 4;
-        assertThat(t.reject(isTooBig)).isEqualTo(t).isNotSameAs(t);
+        assertThat(t.removeAll(isTooBig)).isEqualTo(t).isNotSameAs(t);
     }
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -198,9 +198,64 @@ public class StreamTest extends AbstractLinearSeqTest {
         return Stream.transpose((Stream<Stream<T>>) rows);
     }
 
+    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return true;
+    }
+
+    @Test
+    @Override
+    public void shouldRemoveNonExistingElement() {
+        final Seq<Integer> t = of(1, 2, 3);
+        assertThat(t.remove(4)).isEqualTo(t).isNotSameAs(t);
+    }
+
+    @Test
+    @Override
+    public void shouldRemoveFirstElementByPredicateNonExisting() {
+        final Seq<Integer> t = of(1, 2, 3);
+        assertThat(t.removeFirst(v -> v == 4)).isEqualTo(t).isNotSameAs(t);
+    }
+
+    @Test
+    @Override
+    public void shouldRemoveLastElementByPredicateNonExisting() {
+        final Seq<Integer> t = of(1, 2, 3);
+        assertThat(t.removeLast(v -> v == 4)).isEqualTo(t).isNotSameAs(t);
+    }
+
+    @Test
+    @Override
+    public void shouldNotRemoveAllNonExistingElementsFromNonNil() {
+        final Seq<Integer> t = of(1, 2, 3);
+        assertThat(t.removeAll(of(4, 5))).isEqualTo(t).isNotSameAs(t);
+    }
+
+    @Test
+    @Override
+    public void shouldRemoveExistingElements() {
+        final Seq<Integer> seq = of(1, 2, 3);
+        assertThat(seq.removeAll(i -> i == 1)).isEqualTo(of(2, 3));
+        assertThat(seq.removeAll(i -> i == 2)).isEqualTo(of(1, 3));
+        assertThat(seq.removeAll(i -> i == 3)).isEqualTo(of(1, 2));
+        assertThat(seq.removeAll(ignore -> true)).isEmpty();
+        assertThat(seq.removeAll(ignore -> false)).isEqualTo(of(1, 2, 3)).isNotSameAs(of(1, 2, 3));
+    }
+
+    @Test
+    @Override
+    public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
+        final Seq<Integer> t = of(1, 2, 3);
+        final Predicate<Integer> isTooBig = i -> i >= 4;
+        assertThat(t.removeAll(isTooBig)).isEqualTo(t).isNotSameAs(t);
+    }
+
+    @Test
+    @Override
+    public void shouldNotRemoveAllNonObjectsElementsFromNonNil() {
+        final Seq<Integer> seq = of(1, 2, 3);
+        assertThat(seq.removeAll(4)).isEqualTo(seq).isNotSameAs(seq);
     }
 
     // -- static concat()

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -19,7 +19,11 @@
  */
 package io.vavr.collection;
 
-import io.vavr.*;
+import io.vavr.CheckedFunction1;
+import io.vavr.CheckedFunction2;
+import io.vavr.Serializables;
+import io.vavr.Tuple2;
+import io.vavr.Value;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
 import org.junit.Ignore;
@@ -35,6 +39,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 
 import static io.vavr.collection.Stream.concat;
+import static org.junit.Assert.assertNotSame;
 
 public class StreamTest extends AbstractLinearSeqTest {
 
@@ -198,9 +203,71 @@ public class StreamTest extends AbstractLinearSeqTest {
         return Stream.transpose((Stream<Stream<T>>) rows);
     }
 
+    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return true;
+    }
+
+    @Test
+    @Override
+    public void shouldRemoveNonExistingElement() {
+        final Seq<Integer> t = of(1, 2, 3);
+        assertThat(t.remove(4)).isEqualTo(t);
+        assertNotSame(t, t.remove(4));
+    }
+
+    @Test
+    @Override
+    public void shouldRemoveFirstElementByPredicateNonExisting() {
+        final Seq<Integer> t = of(1, 2, 3);
+        assertThat(t.removeFirst(v -> v == 4)).isEqualTo(t);
+        assertNotSame(t, t.removeFirst(v -> v == 4));
+    }
+
+    @Test
+    @Override
+    public void shouldRemoveLastElementByPredicateNonExisting() {
+        final Seq<Integer> t = of(1, 2, 3);
+        assertThat(t.removeLast(v -> v == 4)).isEqualTo(t);
+        assertNotSame(t, t.removeLast(v -> v == 4));
+    }
+
+    @Test
+    @Override
+    public void shouldNotRemoveAllNonExistingElementsFromNonNil() {
+        final Seq<Integer> t = of(1, 2, 3);
+        assertThat(t.removeAll(of(4, 5))).isEqualTo(t);
+        assertNotSame(t, t.removeAll(of(4, 5)));
+    }
+
+    @Test
+    @Override
+    public void shouldRemoveExistingElements() {
+        final Seq<Integer> seq = of(1, 2, 3);
+        assertThat(seq.removeAll(i -> i == 1)).isEqualTo(of(2, 3));
+        assertThat(seq.removeAll(i -> i == 2)).isEqualTo(of(1, 3));
+        assertThat(seq.removeAll(i -> i == 3)).isEqualTo(of(1, 2));
+        assertThat(seq.removeAll(ignore -> true)).isEmpty();
+        assertThat(seq.removeAll(ignore -> false)).isEqualTo(of(1, 2, 3));
+        assertNotSame(seq, seq.removeAll(ignore -> false));
+    }
+
+    @Test
+    @Override
+    public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
+        final Seq<Integer> t = of(1, 2, 3);
+        final Predicate<Integer> isTooBig = i -> i >= 4;
+        assertThat(t.removeAll(isTooBig)).isEqualTo(t);
+        assertNotSame(t, t.removeAll(isTooBig));
+    }
+
+    @Test
+    @Override
+    public void shouldNotRemoveAllNonObjectsElementsFromNonNil() {
+        final Seq<Integer> seq = of(1, 2, 3);
+        assertThat(seq.removeAll(4)).isEqualTo(seq);
+        assertNotSame(seq, seq.removeAll(4));
     }
 
     // -- static concat()
@@ -518,7 +585,7 @@ public class StreamTest extends AbstractLinearSeqTest {
 
     @Test
     public void shouldReturnAnEmptyStreamWhenExtendingAnEmptyStreamWithFunction() {
-        assertThat(Stream.<Integer> of().extend(i -> i + 1)).isEqualTo(of());
+        assertThat(Stream.<Integer>of().extend(i -> i + 1)).isEqualTo(of());
     }
 
     @Test
@@ -565,7 +632,7 @@ public class StreamTest extends AbstractLinearSeqTest {
 
     @Test
     public void shouldEvaluateTailAtMostOnce() {
-        final int[] counter = { 0 };
+        final int[] counter = {0};
         final Stream<Integer> stream = Stream.continually(() -> counter[0]++);
         // this test ensures that the `tail.append(100)` does not modify the tail elements
         final Stream<Integer> tail = stream.tail().append(100);
@@ -579,14 +646,14 @@ public class StreamTest extends AbstractLinearSeqTest {
     public void shouldNotProduceStackOverflow() {
         Stream.range(0, 1_000_000)
                 .map(String::valueOf)
-                .foldLeft(Stream.<String> empty(), Stream::append)
+                .foldLeft(Stream.<String>empty(), Stream::append)
                 .mkString();
     }
 
     @Test // See #327, #594
     public void shouldNotEvaluateHeadOfTailWhenCallingIteratorHasNext() {
 
-        final Integer[] vals = new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        final Integer[] vals = new Integer[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
 
         final CheckedFunction2<StringBuilder, Integer, Void> doStuff = (builder, i) -> {
             builder.append(i);
@@ -689,8 +756,8 @@ public class StreamTest extends AbstractLinearSeqTest {
     public void shouldUnfoldRightSimpleStream() {
         assertThat(
                 Stream.unfoldRight(10, x -> x == 0
-                                            ? Option.none()
-                                            : Option.of(new Tuple2<>(x, x - 1))))
+                        ? Option.none()
+                        : Option.of(new Tuple2<>(x, x - 1))))
                 .isEqualTo(of(10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
     }
 
@@ -703,8 +770,8 @@ public class StreamTest extends AbstractLinearSeqTest {
     public void shouldUnfoldLeftSimpleStream() {
         assertThat(
                 Stream.unfoldLeft(10, x -> x == 0
-                                           ? Option.none()
-                                           : Option.of(new Tuple2<>(x - 1, x))))
+                        ? Option.none()
+                        : Option.of(new Tuple2<>(x - 1, x))))
                 .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     }
 
@@ -717,8 +784,8 @@ public class StreamTest extends AbstractLinearSeqTest {
     public void shouldUnfoldSimpleStream() {
         assertThat(
                 Stream.unfold(10, x -> x == 0
-                                       ? Option.none()
-                                       : Option.of(new Tuple2<>(x - 1, x))))
+                        ? Option.none()
+                        : Option.of(new Tuple2<>(x - 1, x))))
                 .isEqualTo(of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     }
 

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -248,7 +248,7 @@ public class StreamTest extends AbstractLinearSeqTest {
     public void shouldNotRemoveAllNonMatchedElementsFromNonNil() {
         final Seq<Integer> t = of(1, 2, 3);
         final Predicate<Integer> isTooBig = i -> i >= 4;
-        assertThat(t.removeAll(isTooBig)).isEqualTo(t).isNotSameAs(t);
+        assertThat(t.reject(isTooBig)).isEqualTo(t).isNotSameAs(t);
     }
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/VectorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/VectorTest.java
@@ -136,6 +136,7 @@ public class VectorTest extends AbstractIndexedSeqTest {
         return 1;
     }
 
+    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return false;

--- a/vavr/src/test/java/io/vavr/collection/VectorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/VectorTest.java
@@ -136,7 +136,6 @@ public class VectorTest extends AbstractIndexedSeqTest {
         return 1;
     }
 
-    //fixme: delete, when useIsEqualToInsteadOfIsSameAs() will be eliminated from AbstractValueTest class
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return false;


### PR DESCRIPTION
…t class and prepared code for elimination this method from related classes: ArrayTest, HashSetTest, ListTest, QueueTest, StreamTest and VectorTest