### PR TITLE
Removed javax.annotation.Generated occurrences

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -736,7 +736,6 @@ def generateMainClasses(): Unit = {
               /$javadoc
                * For-comprehension with ${i.numerus("Iterable")}.
                */
-              @javax.annotation.Generated("Generator.scala")
               public static class For$i<$generics> {
 
                   ${(1 to i).gen(j => xs"""private final Iterable<T$j> ts$j;""")("\n")}
@@ -976,7 +975,6 @@ def generateMainClasses(): Unit = {
            * Scala-like structural pattern matching for Java. Instances are obtained via {@link API#Match(Object)}.
            * @param <T> type of the object that is matched
            */
-          @javax.annotation.Generated("Generator.scala")
           @GwtIncompatible
           public static final class Match<T> {
 
@@ -1015,7 +1013,6 @@ def generateMainClasses(): Unit = {
               // -- CASES
 
               // javac needs fqn's here
-              @javax.annotation.Generated("Generator.scala")
               public interface Case<T, R> extends $PartialFunctionType<T, R> {
 
                   /**
@@ -1023,8 +1020,7 @@ def generateMainClasses(): Unit = {
                    */
                   long serialVersionUID = 1L;
               }
-
-              @javax.annotation.Generated("Generator.scala")
+              
               public static final class Case0<T, R> implements Case<T, R> {
 
                   private static final long serialVersionUID = 1L;
@@ -1057,7 +1053,6 @@ def generateMainClasses(): Unit = {
                   case _ => s"Function$i"
                 }
                 xs"""
-                  @javax.annotation.Generated("Generator.scala")
                   public static final class Case$i<T, $generics, R> implements Case<T, R> {
 
                       private static final long serialVersionUID = 1L;
@@ -1097,14 +1092,12 @@ def generateMainClasses(): Unit = {
                * @param <R> Type of the single or composite part this pattern decomposes
                */
               // javac needs fqn's here
-              @javax.annotation.Generated("Generator.scala")
               public interface Pattern<T, R> extends $PartialFunctionType<T, R> {
               }
 
               // These can't be @FunctionalInterfaces because of ambiguities.
               // For benchmarks lambda vs. abstract class see http://www.oracle.com/technetwork/java/jvmls2013kuksen-2014088.pdf
-
-              @javax.annotation.Generated("Generator.scala")
+              
               public static abstract class Pattern0<T> implements Pattern<T, T> {
 
                   private static final long serialVersionUID = 1L;
@@ -1158,7 +1151,6 @@ def generateMainClasses(): Unit = {
                 val unapplyTupleType = s"Tuple$i<$unapplyGenerics>"
                 val args = (1 to i).gen(j => s"Pattern<T$j, ?> p$j")(", ")
                 xs"""
-                  @javax.annotation.Generated("Generator.scala")
                   public static abstract class Pattern$i<T, $resultGenerics> implements Pattern<T, $resultType> {
 
                       private static final long serialVersionUID = 1L;
@@ -1349,7 +1341,6 @@ def generateMainClasses(): Unit = {
          * to standard Java library and Vavr types.
          * @author Daniel Dietrich
          */
-        @javax.annotation.Generated("Generator.scala")
         public final class API {
 
             private API() {
@@ -1446,7 +1437,6 @@ def generateMainClasses(): Unit = {
            * @author Daniel Dietrich
            */
           @FunctionalInterface
-          @javax.annotation.Generated("Generator.scala")
           public interface $className$fullGenerics extends Lambda<R>$additionalExtends {
 
               /$javadoc
@@ -1743,8 +1733,7 @@ def generateMainClasses(): Unit = {
                 }
               """)}
           }
-
-          @javax.annotation.Generated("Generator.scala")
+          
           interface ${className}Module {
 
               // DEV-NOTE: we do not plan to expose this as public API
@@ -1807,7 +1796,6 @@ def generateMainClasses(): Unit = {
          ${(0 to i).gen(j => if (j == 0) "*" else s"* @param <T$j> type of the ${j.ordinal} element")("\n")}
          * @author Daniel Dietrich
          */
-        @javax.annotation.Generated("Generator.scala")
         public final class $className$generics implements Tuple, Comparable<$className$generics>, ${im.getType("java.io.Serializable")} {
 
             private static final long serialVersionUID = 1L;
@@ -2142,7 +2130,6 @@ def generateMainClasses(): Unit = {
          *
          * @author Daniel Dietrich
          */
-        @javax.annotation.Generated("Generator.scala")
         public interface Tuple {
 
             /**
@@ -2228,7 +2215,6 @@ def generateMainClasses(): Unit = {
        *
        * @author Pap Lőrinc
        */
-      @javax.annotation.Generated("Generator.scala")
       interface ArrayType<T> {
           @SuppressWarnings("unchecked")
           static <T> ArrayType<T> obj() { return (ArrayType<T>) ObjectArrayType.INSTANCE; }
@@ -2352,7 +2338,6 @@ def generateMainClasses(): Unit = {
       val isPrimitive = arrayType != "Object"
 
       xs"""
-        @javax.annotation.Generated("Generator.scala")
         final class $className implements ArrayType<$wrapperType>, ${im.getType("java.io.Serializable")} {
             private static final long serialVersionUID = 1L;
             static final $className INSTANCE = new $className();

--- a/vavr/src-gen/main/java/io/vavr/API.java
+++ b/vavr/src-gen/main/java/io/vavr/API.java
@@ -99,7 +99,6 @@ import java.util.function.Supplier;
  * to standard Java library and Vavr types.
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public final class API {
 
     private API() {
@@ -2436,7 +2435,6 @@ public final class API {
     /**
      * For-comprehension with one Iterable.
      */
-    @javax.annotation.Generated("Generator.scala")
     public static class For1<T1> {
 
         private final Iterable<T1> ts1;
@@ -2470,7 +2468,6 @@ public final class API {
     /**
      * For-comprehension with two Iterables.
      */
-    @javax.annotation.Generated("Generator.scala")
     public static class For2<T1, T2> {
 
         private final Iterable<T1> ts1;
@@ -2500,7 +2497,6 @@ public final class API {
     /**
      * For-comprehension with three Iterables.
      */
-    @javax.annotation.Generated("Generator.scala")
     public static class For3<T1, T2, T3> {
 
         private final Iterable<T1> ts1;
@@ -2533,7 +2529,6 @@ public final class API {
     /**
      * For-comprehension with 4 Iterables.
      */
-    @javax.annotation.Generated("Generator.scala")
     public static class For4<T1, T2, T3, T4> {
 
         private final Iterable<T1> ts1;
@@ -2569,7 +2564,6 @@ public final class API {
     /**
      * For-comprehension with 5 Iterables.
      */
-    @javax.annotation.Generated("Generator.scala")
     public static class For5<T1, T2, T3, T4, T5> {
 
         private final Iterable<T1> ts1;
@@ -2608,7 +2602,6 @@ public final class API {
     /**
      * For-comprehension with 6 Iterables.
      */
-    @javax.annotation.Generated("Generator.scala")
     public static class For6<T1, T2, T3, T4, T5, T6> {
 
         private final Iterable<T1> ts1;
@@ -2650,7 +2643,6 @@ public final class API {
     /**
      * For-comprehension with 7 Iterables.
      */
-    @javax.annotation.Generated("Generator.scala")
     public static class For7<T1, T2, T3, T4, T5, T6, T7> {
 
         private final Iterable<T1> ts1;
@@ -2695,7 +2687,6 @@ public final class API {
     /**
      * For-comprehension with 8 Iterables.
      */
-    @javax.annotation.Generated("Generator.scala")
     public static class For8<T1, T2, T3, T4, T5, T6, T7, T8> {
 
         private final Iterable<T1> ts1;
@@ -3077,7 +3068,6 @@ public final class API {
      * Scala-like structural pattern matching for Java. Instances are obtained via {@link API#Match(Object)}.
      * @param <T> type of the object that is matched
      */
-    @javax.annotation.Generated("Generator.scala")
     @GwtIncompatible
     public static final class Match<T> {
 
@@ -3116,7 +3106,6 @@ public final class API {
         // -- CASES
 
         // javac needs fqn's here
-        @javax.annotation.Generated("Generator.scala")
         public interface Case<T, R> extends PartialFunction<T, R> {
 
             /**
@@ -3125,7 +3114,6 @@ public final class API {
             long serialVersionUID = 1L;
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static final class Case0<T, R> implements Case<T, R> {
 
             private static final long serialVersionUID = 1L;
@@ -3149,7 +3137,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static final class Case1<T, T1, R> implements Case<T, R> {
 
             private static final long serialVersionUID = 1L;
@@ -3173,7 +3160,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static final class Case2<T, T1, T2, R> implements Case<T, R> {
 
             private static final long serialVersionUID = 1L;
@@ -3197,7 +3183,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static final class Case3<T, T1, T2, T3, R> implements Case<T, R> {
 
             private static final long serialVersionUID = 1L;
@@ -3221,7 +3206,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static final class Case4<T, T1, T2, T3, T4, R> implements Case<T, R> {
 
             private static final long serialVersionUID = 1L;
@@ -3245,7 +3229,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static final class Case5<T, T1, T2, T3, T4, T5, R> implements Case<T, R> {
 
             private static final long serialVersionUID = 1L;
@@ -3269,7 +3252,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static final class Case6<T, T1, T2, T3, T4, T5, T6, R> implements Case<T, R> {
 
             private static final long serialVersionUID = 1L;
@@ -3293,7 +3275,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static final class Case7<T, T1, T2, T3, T4, T5, T6, T7, R> implements Case<T, R> {
 
             private static final long serialVersionUID = 1L;
@@ -3317,7 +3298,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static final class Case8<T, T1, T2, T3, T4, T5, T6, T7, T8, R> implements Case<T, R> {
 
             private static final long serialVersionUID = 1L;
@@ -3351,14 +3331,12 @@ public final class API {
          * @param <R> Type of the single or composite part this pattern decomposes
          */
         // javac needs fqn's here
-        @javax.annotation.Generated("Generator.scala")
         public interface Pattern<T, R> extends PartialFunction<T, R> {
         }
 
         // These can't be @FunctionalInterfaces because of ambiguities.
         // For benchmarks lambda vs. abstract class see http://www.oracle.com/technetwork/java/jvmls2013kuksen-2014088.pdf
 
-        @javax.annotation.Generated("Generator.scala")
         public static abstract class Pattern0<T> implements Pattern<T, T> {
 
             private static final long serialVersionUID = 1L;
@@ -3404,7 +3382,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static abstract class Pattern1<T, T1> implements Pattern<T, T1> {
 
             private static final long serialVersionUID = 1L;
@@ -3435,7 +3412,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static abstract class Pattern2<T, T1, T2> implements Pattern<T, Tuple2<T1, T2>> {
 
             private static final long serialVersionUID = 1L;
@@ -3467,7 +3443,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static abstract class Pattern3<T, T1, T2, T3> implements Pattern<T, Tuple3<T1, T2, T3>> {
 
             private static final long serialVersionUID = 1L;
@@ -3500,7 +3475,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static abstract class Pattern4<T, T1, T2, T3, T4> implements Pattern<T, Tuple4<T1, T2, T3, T4>> {
 
             private static final long serialVersionUID = 1L;
@@ -3534,7 +3508,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static abstract class Pattern5<T, T1, T2, T3, T4, T5> implements Pattern<T, Tuple5<T1, T2, T3, T4, T5>> {
 
             private static final long serialVersionUID = 1L;
@@ -3569,7 +3542,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static abstract class Pattern6<T, T1, T2, T3, T4, T5, T6> implements Pattern<T, Tuple6<T1, T2, T3, T4, T5, T6>> {
 
             private static final long serialVersionUID = 1L;
@@ -3605,7 +3577,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static abstract class Pattern7<T, T1, T2, T3, T4, T5, T6, T7> implements Pattern<T, Tuple7<T1, T2, T3, T4, T5, T6, T7>> {
 
             private static final long serialVersionUID = 1L;
@@ -3642,7 +3613,6 @@ public final class API {
             }
         }
 
-        @javax.annotation.Generated("Generator.scala")
         public static abstract class Pattern8<T, T1, T2, T3, T4, T5, T6, T7, T8> implements Pattern<T, Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> {
 
             private static final long serialVersionUID = 1L;

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction0.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction0.java
@@ -38,7 +38,6 @@ import java.util.function.Supplier;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface CheckedFunction0<R> extends Lambda<R> {
 
     /**
@@ -222,7 +221,6 @@ public interface CheckedFunction0<R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface CheckedFunction0Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
@@ -40,7 +40,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface CheckedFunction1<T1, R> extends Lambda<R> {
 
     /**
@@ -254,7 +253,6 @@ public interface CheckedFunction1<T1, R> extends Lambda<R> {
     }
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface CheckedFunction1Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface CheckedFunction2<T1, T2, R> extends Lambda<R> {
 
     /**
@@ -249,7 +248,6 @@ public interface CheckedFunction2<T1, T2, R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface CheckedFunction2Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface CheckedFunction3<T1, T2, T3, R> extends Lambda<R> {
 
     /**
@@ -266,7 +265,6 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface CheckedFunction3Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
@@ -43,7 +43,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface CheckedFunction4<T1, T2, T3, T4, R> extends Lambda<R> {
 
     /**
@@ -285,7 +284,6 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface CheckedFunction4Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
@@ -44,7 +44,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
 
     /**
@@ -305,7 +304,6 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface CheckedFunction5Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
@@ -45,7 +45,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
 
     /**
@@ -326,7 +325,6 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface CheckedFunction6Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
@@ -46,7 +46,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<R> {
 
     /**
@@ -348,7 +347,6 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface CheckedFunction7Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
@@ -47,7 +47,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lambda<R> {
 
     /**
@@ -371,7 +370,6 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lam
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface CheckedFunction8Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/Function0.java
+++ b/vavr/src-gen/main/java/io/vavr/Function0.java
@@ -38,7 +38,6 @@ import java.util.function.Supplier;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface Function0<R> extends Lambda<R>, Supplier<R> {
 
     /**
@@ -196,7 +195,6 @@ public interface Function0<R> extends Lambda<R>, Supplier<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface Function0Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -41,7 +41,6 @@ import java.util.function.Predicate;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface Function1<T1, R> extends Lambda<R>, Function<T1, R> {
 
     /**
@@ -245,7 +244,6 @@ public interface Function1<T1, R> extends Lambda<R>, Function<T1, R> {
     }
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface Function1Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/Function2.java
+++ b/vavr/src-gen/main/java/io/vavr/Function2.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface Function2<T1, T2, R> extends Lambda<R>, BiFunction<T1, T2, R> {
 
     /**
@@ -213,7 +212,6 @@ public interface Function2<T1, T2, R> extends Lambda<R>, BiFunction<T1, T2, R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface Function2Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/Function3.java
+++ b/vavr/src-gen/main/java/io/vavr/Function3.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface Function3<T1, T2, T3, R> extends Lambda<R> {
 
     /**
@@ -230,7 +229,6 @@ public interface Function3<T1, T2, T3, R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface Function3Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/Function4.java
+++ b/vavr/src-gen/main/java/io/vavr/Function4.java
@@ -43,7 +43,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface Function4<T1, T2, T3, T4, R> extends Lambda<R> {
 
     /**
@@ -249,7 +248,6 @@ public interface Function4<T1, T2, T3, T4, R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface Function4Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/Function5.java
+++ b/vavr/src-gen/main/java/io/vavr/Function5.java
@@ -44,7 +44,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface Function5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
 
     /**
@@ -269,7 +268,6 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface Function5Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/Function6.java
+++ b/vavr/src-gen/main/java/io/vavr/Function6.java
@@ -45,7 +45,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
 
     /**
@@ -290,7 +289,6 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface Function6Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/Function7.java
+++ b/vavr/src-gen/main/java/io/vavr/Function7.java
@@ -46,7 +46,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<R> {
 
     /**
@@ -312,7 +311,6 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<R> {
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface Function7Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/Function8.java
+++ b/vavr/src-gen/main/java/io/vavr/Function8.java
@@ -47,7 +47,6 @@ import java.util.function.Function;
  * @author Daniel Dietrich
  */
 @FunctionalInterface
-@javax.annotation.Generated("Generator.scala")
 public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lambda<R> {
 
     /**
@@ -335,7 +334,6 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lambda<R> 
 
 }
 
-@javax.annotation.Generated("Generator.scala")
 interface Function8Module {
 
     // DEV-NOTE: we do not plan to expose this as public API

--- a/vavr/src-gen/main/java/io/vavr/Tuple.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple.java
@@ -33,7 +33,6 @@ import java.util.Objects;
  *
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public interface Tuple {
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Tuple0.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple0.java
@@ -36,7 +36,6 @@ import java.util.function.Supplier;
  *
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/vavr/src-gen/main/java/io/vavr/Tuple1.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple1.java
@@ -37,7 +37,6 @@ import java.util.function.Function;
  * @param <T1> type of the 1st element
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/vavr/src-gen/main/java/io/vavr/Tuple2.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple2.java
@@ -41,7 +41,6 @@ import java.util.function.Function;
  * @param <T2> type of the 2nd element
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/vavr/src-gen/main/java/io/vavr/Tuple3.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple3.java
@@ -39,7 +39,6 @@ import java.util.function.Function;
  * @param <T3> type of the 3rd element
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2, T3>>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/vavr/src-gen/main/java/io/vavr/Tuple4.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple4.java
@@ -40,7 +40,6 @@ import java.util.function.Function;
  * @param <T4> type of the 4th element
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1, T2, T3, T4>>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/vavr/src-gen/main/java/io/vavr/Tuple5.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple5.java
@@ -41,7 +41,6 @@ import java.util.function.Function;
  * @param <T5> type of the 5th element
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple5<T1, T2, T3, T4, T5>>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/vavr/src-gen/main/java/io/vavr/Tuple6.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple6.java
@@ -42,7 +42,6 @@ import java.util.function.Function;
  * @param <T6> type of the 6th element
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<Tuple6<T1, T2, T3, T4, T5, T6>>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/vavr/src-gen/main/java/io/vavr/Tuple7.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple7.java
@@ -43,7 +43,6 @@ import java.util.function.Function;
  * @param <T7> type of the 7th element
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparable<Tuple7<T1, T2, T3, T4, T5, T6, T7>>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/vavr/src-gen/main/java/io/vavr/Tuple8.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple8.java
@@ -44,7 +44,6 @@ import java.util.function.Function;
  * @param <T8> type of the 8th element
  * @author Daniel Dietrich
  */
-@javax.annotation.Generated("Generator.scala")
 public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comparable<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/vavr/src-gen/main/java/io/vavr/collection/ArrayType.java
+++ b/vavr/src-gen/main/java/io/vavr/collection/ArrayType.java
@@ -32,7 +32,6 @@ import java.util.Collection;
  *
  * @author Pap Lőrinc
  */
-@javax.annotation.Generated("Generator.scala")
 interface ArrayType<T> {
     @SuppressWarnings("unchecked")
     static <T> ArrayType<T> obj() { return (ArrayType<T>) ObjectArrayType.INSTANCE; }
@@ -145,7 +144,6 @@ interface ArrayType<T> {
         return (T) results;
     }
 
-    @javax.annotation.Generated("Generator.scala")
     final class BooleanArrayType implements ArrayType<Boolean>, Serializable {
         private static final long serialVersionUID = 1L;
         static final BooleanArrayType INSTANCE = new BooleanArrayType();
@@ -187,7 +185,6 @@ interface ArrayType<T> {
         }
     }
 
-    @javax.annotation.Generated("Generator.scala")
     final class ByteArrayType implements ArrayType<Byte>, Serializable {
         private static final long serialVersionUID = 1L;
         static final ByteArrayType INSTANCE = new ByteArrayType();
@@ -229,7 +226,6 @@ interface ArrayType<T> {
         }
     }
 
-    @javax.annotation.Generated("Generator.scala")
     final class CharArrayType implements ArrayType<Character>, Serializable {
         private static final long serialVersionUID = 1L;
         static final CharArrayType INSTANCE = new CharArrayType();
@@ -271,7 +267,6 @@ interface ArrayType<T> {
         }
     }
 
-    @javax.annotation.Generated("Generator.scala")
     final class DoubleArrayType implements ArrayType<Double>, Serializable {
         private static final long serialVersionUID = 1L;
         static final DoubleArrayType INSTANCE = new DoubleArrayType();
@@ -313,7 +308,6 @@ interface ArrayType<T> {
         }
     }
 
-    @javax.annotation.Generated("Generator.scala")
     final class FloatArrayType implements ArrayType<Float>, Serializable {
         private static final long serialVersionUID = 1L;
         static final FloatArrayType INSTANCE = new FloatArrayType();
@@ -355,7 +349,6 @@ interface ArrayType<T> {
         }
     }
 
-    @javax.annotation.Generated("Generator.scala")
     final class IntArrayType implements ArrayType<Integer>, Serializable {
         private static final long serialVersionUID = 1L;
         static final IntArrayType INSTANCE = new IntArrayType();
@@ -397,7 +390,6 @@ interface ArrayType<T> {
         }
     }
 
-    @javax.annotation.Generated("Generator.scala")
     final class LongArrayType implements ArrayType<Long>, Serializable {
         private static final long serialVersionUID = 1L;
         static final LongArrayType INSTANCE = new LongArrayType();
@@ -439,7 +431,6 @@ interface ArrayType<T> {
         }
     }
 
-    @javax.annotation.Generated("Generator.scala")
     final class ShortArrayType implements ArrayType<Short>, Serializable {
         private static final long serialVersionUID = 1L;
         static final ShortArrayType INSTANCE = new ShortArrayType();
@@ -481,7 +472,6 @@ interface ArrayType<T> {
         }
     }
 
-    @javax.annotation.Generated("Generator.scala")
     final class ObjectArrayType implements ArrayType<Object>, Serializable {
         private static final long serialVersionUID = 1L;
         static final ObjectArrayType INSTANCE = new ObjectArrayType();


### PR DESCRIPTION
Fixes #2154

With Vavr 0.9.2 we build fine with JDK9. However, source and target compatibility are set to Java 1.8.
With this change Vavr build fine, even if we set source and target compatibility to Java 1.9 🤩