### PR TITLE
More conversions from Try to Validation

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -973,20 +973,16 @@ public interface Try<T> extends Value<T>, Serializable {
     }
 
     /**
-     * Converts this {@code Try} to an {@link Validation}.
+     * Converts this {@code Try} to a {@link Validation}.
      *
      * @return A new {@code Validation}
      */
     default Validation<Throwable, T> toValidation() {
-        if (isFailure()) {
-            return Validation.invalid(getCause());
-        } else {
-            return Validation.valid(get());
-        }
+        return toValidation(Function.identity());
     }
 
     /**
-     * Converts this {@code Try} to an {@link Validation}, converting the Throwable (if present)
+     * Converts this {@code Try} to a {@link Validation}, converting the Throwable (if present)
      * to another object using passed {@link Function}.
      *
      * <pre>
@@ -999,9 +995,13 @@ public interface Try<T> extends Value<T>, Serializable {
      * @return A new {@code Validation}
      * @throws NullPointerException if the given {@code throwableMapper} is null.
      */
-    default <U> Validation<U, T> toValidation(Function<Throwable, ? extends U> throwableMapper) {
+    default <U> Validation<U, T> toValidation(Function<? super Throwable, ? extends U> throwableMapper) {
         Objects.requireNonNull(throwableMapper, "throwableMapper is null");
-        return toValidation().mapError(throwableMapper);
+        if (isFailure()) {
+            return Validation.invalid(throwableMapper.apply(getCause()));
+        } else {
+            return Validation.valid(get());
+        }
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -973,6 +973,38 @@ public interface Try<T> extends Value<T>, Serializable {
     }
 
     /**
+     * Converts this {@code Try} to an {@link Validation}.
+     *
+     * @return A new {@code Validation}
+     */
+    default Validation<Throwable, T> toValidation() {
+        if (isFailure()) {
+            return Validation.invalid(getCause());
+        } else {
+            return Validation.valid(get());
+        }
+    }
+
+    /**
+     * Converts this {@code Try} to an {@link Validation}, converting the Throwable (if present)
+     * to another object using passed {@link Function}.
+     *
+     * <pre>
+     * <code>
+     * Validation<Failure, Integer> = Try.of(() -> 1/0).toValidation(t -> Failure.from(throwable.getMessage()));
+     * </code>
+     * </pre>
+     *
+     * @param throwableMapper  A transformation from throwable to desired invalid type of new {@code Validation}
+     * @return A new {@code Validation}
+     * @throws NullPointerException if the given {@code throwableMapper} is null.
+     */
+    default <U> Validation<U, T> toValidation(Function<Throwable, ? extends U> throwableMapper) {
+        Objects.requireNonNull(throwableMapper, "throwableMapper is null");
+        return toValidation().mapError(throwableMapper);
+    }
+
+    /**
      * Transforms this {@code Try}.
      *
      * @param f   A transformation

--- a/vavr/src/main/java/io/vavr/control/Validation.java
+++ b/vavr/src/main/java/io/vavr/control/Validation.java
@@ -126,7 +126,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
      * @return A {@code Valid(t.get())} if t is a Success, otherwise {@code Invalid(t.getCause())}.
      * @throws NullPointerException if {@code t} is null
      */
-    static <T> Validation<Throwable, T> fromTry(Try<T> t) {
+    static <T> Validation<Throwable, T> fromTry(Try<? extends T> t) {
         Objects.requireNonNull(t, "t is null");
         return t.isSuccess() ? valid(t.get()) : invalid(t.getCause());
     }

--- a/vavr/src/main/java/io/vavr/control/Validation.java
+++ b/vavr/src/main/java/io/vavr/control/Validation.java
@@ -119,6 +119,20 @@ public interface Validation<E, T> extends Value<T>, Serializable {
     }
 
     /**
+     * Creates a {@code Validation} of an {@code Either}.
+     *
+     * @param t      A {@code Try}
+     * @param <T>    type of the valid value
+     * @return A {@code Valid(t.get())} if t is a Success, otherwise {@code Invalid(t.getCause())}.
+     * @throws NullPointerException if {@code t} is null
+     */
+    static <T> Validation<Throwable, T> fromTry(Try<T> t) {
+        Objects.requireNonNull(t, "t is null");
+        return t.isSuccess() ? valid(t.get()) : invalid(t.getCause());
+    }
+
+
+    /**
      * Reduces many {@code Validation} instances into a single {@code Validation} by transforming an
      * {@code Iterable<Validation<? extends T>>} into a {@code Validation<Seq<T>>}.
      *

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -978,6 +978,25 @@ public class TryTest extends AbstractValueTest {
         assertThat(failure().toEither(() -> "test").isLeft()).isTrue();
     }
 
+
+    // -- toValidation
+
+    @Test
+    public void shouldConvertFailureToValidation() {
+        Try<Object> failure = failure();
+        final Validation<Throwable, Object> invalid = failure.toValidation();
+        assertThat(invalid.getError()).isEqualTo(failure.getCause());
+        assertThat(invalid.isInvalid()).isTrue();
+    }
+
+    @Test
+    public void shouldConvertFailureToInvalidValidation() {
+        Try<Object> failure = failure();
+        final Validation<String, Object> validation = failure.toValidation(e -> e.toString());
+        assertThat(validation.getError()).isEqualTo(failure.getCause().toString());
+        assertThat(validation.isInvalid()).isTrue();
+    }
+
     // -- toCompletableFuture
 
     @Test
@@ -1306,6 +1325,16 @@ public class TryTest extends AbstractValueTest {
     @Test
     public void shouldConvertSuccessToEither() {
         assertThat(success().toEither().isRight()).isTrue();
+    }
+
+    @Test
+    public void shouldConvertSuccessToValidValidation() {
+        assertThat(success().toValidation().isValid()).isTrue();
+    }
+
+    @Test
+    public void shouldConvertSuccessToValidValidation2() {
+        assertThat(success().toValidation(e -> e.getMessage()).isValid()).isTrue();
     }
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -1333,7 +1333,7 @@ public class TryTest extends AbstractValueTest {
     }
 
     @Test
-    public void shouldConvertSuccessToValidValidation2() {
+    public void shouldConvertSuccessToValidValidationUsingConversionWithMapper() {
         assertThat(success().toValidation(e -> e.getMessage()).isValid()).isTrue();
     }
 

--- a/vavr/src/test/java/io/vavr/control/ValidationTest.java
+++ b/vavr/src/test/java/io/vavr/control/ValidationTest.java
@@ -93,6 +93,24 @@ public class ValidationTest extends AbstractValueTest {
         assertThat(validation.getError()).isEqualTo("vavr");
     }
 
+    // -- Validation.fromTry
+
+    @Test
+    public void shouldCreateFromSuccessTry() {
+        Validation<Throwable, Integer> validation = Validation.fromTry(Try.success(42));
+        assertThat(validation.isValid()).isTrue();
+        assertThat(validation.get()).isEqualTo(42);
+    }
+
+    @Test
+    public void shouldCreateFromFailureTry() {
+        Throwable throwable = new Throwable("vavr");
+        Validation<Throwable, Integer> validation = Validation.fromTry(Try.failure(throwable));
+        assertThat(validation.isValid()).isFalse();
+        assertThat(validation.getError()).isEqualTo(throwable);
+    }
+
+
     // -- Validation.narrow
 
     @Test


### PR DESCRIPTION
 I added a parameterless conversion method plus one more that takes a mapper function allowing transformation of Throwable to e.g. error code.