### PR TITLE
Validation

### DIFF
--- a/vavr/src/main/java/io/vavr/$.java
+++ b/vavr/src/main/java/io/vavr/$.java
@@ -19,8 +19,10 @@
  */
 package io.vavr;
 
+import io.vavr.collection.Seq;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
+import io.vavr.control.Validation;
 import io.vavr.match.annotation.Patterns;
 import io.vavr.match.annotation.Unapply;
 import io.vavr.collection.List;
@@ -87,4 +89,11 @@ class $ {
     static <T> Tuple1<T> Success(Try.Success<T> success) { return Tuple.of(success.get()); }
     @Unapply
     static <T> Tuple1<Throwable> Failure(Try.Failure<T> failure) { return Tuple.of(failure.getCause()); }
+
+    // Validation
+    @Unapply
+    static <E, T> Tuple1<T> Valid(Validation.Valid<E, T> valid) { return Tuple.of(valid.get()); }
+    @Unapply
+    static <E, T> Tuple1<Seq<E>> Invalid(Validation.Invalid<E, T> invalid) { return Tuple.of(invalid.getErrors()); }
+
 }

--- a/vavr/src/main/java/io/vavr/Value.java
+++ b/vavr/src/main/java/io/vavr/Value.java
@@ -1188,10 +1188,10 @@ public interface Value<T> extends Iterable<T> {
      * Converts this to an {@link Validation}.
      *
      * @param invalid An invalid value for the {@link Validation}
-     * @param <L>     Validation error component type
+     * @param <E>     Validation error component type
      * @return A new {@link Validation}.
      */
-    default <L> Validation<L, T> toValid(L invalid) {
+    default <E> Validation<E, T> toValid(E invalid) {
         if (this instanceof Validation) {
             return ((Validation<?, T>) this).mapError(ignored -> invalid);
         } else {
@@ -1203,12 +1203,12 @@ public interface Value<T> extends Iterable<T> {
      * Converts this to an {@link Validation}.
      *
      * @param invalidSupplier A {@link Supplier} for the invalid value for the {@link Validation}
-     * @param <L>             Validation error component type
+     * @param <E>             Validation error component type
      * @return A new {@link Validation}.
      */
-    default <L> Validation<L, T> toValid(Supplier<? extends L> invalidSupplier) {
+    default <E> Validation<E, T> toValid(Supplier<? extends E> invalidSupplier) {
         Objects.requireNonNull(invalidSupplier, "invalidSupplier is null");
-        if (this instanceof io.vavr.control.Validation) {
+        if (this instanceof Validation) {
             return ((Validation<?, T>) this).mapError(ignored -> invalidSupplier.get());
         } else {
             return isEmpty() ? Validation.invalid(invalidSupplier.get()) : Validation.valid(get());

--- a/vavr/src/main/java/io/vavr/Value.java
+++ b/vavr/src/main/java/io/vavr/Value.java
@@ -1193,7 +1193,7 @@ public interface Value<T> extends Iterable<T> {
      */
     default <E> Validation<E, T> toValid(E invalid) {
         if (this instanceof Validation) {
-            return ((Validation<?, T>) this).mapError(ignored -> invalid);
+            return ((Validation<?, T>) this).mapErrors(ignored -> invalid);
         } else {
             return isEmpty() ? Validation.invalid(invalid) : Validation.valid(get());
         }
@@ -1209,7 +1209,7 @@ public interface Value<T> extends Iterable<T> {
     default <E> Validation<E, T> toValid(Supplier<? extends E> invalidSupplier) {
         Objects.requireNonNull(invalidSupplier, "invalidSupplier is null");
         if (this instanceof Validation) {
-            return ((Validation<?, T>) this).mapError(ignored -> invalidSupplier.get());
+            return ((Validation<?, T>) this).mapErrors(ignored -> invalidSupplier.get());
         } else {
             return isEmpty() ? Validation.invalid(invalidSupplier.get()) : Validation.valid(get());
         }

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -985,11 +985,9 @@ public interface Try<T> extends Value<T>, Serializable {
      * Converts this {@code Try} to a {@link Validation}, converting the Throwable (if present)
      * to another object using passed {@link Function}.
      *
-     * <pre>
-     * <code>
-     * Validation<Failure, Integer> = Try.of(() -> 1/0).toValidation(t -> Failure.from(throwable.getMessage()));
-     * </code>
-     * </pre>
+     * <pre>{@code
+     * Validation<String, Integer> = Try.of(() -> 1/0).toValidation(Throwable::getMessage);
+     * }</pre>
      *
      * @param throwableMapper  A transformation from throwable to desired invalid type of new {@code Validation}
      * @return A new {@code Validation}

--- a/vavr/src/main/java/io/vavr/control/Validation.java
+++ b/vavr/src/main/java/io/vavr/control/Validation.java
@@ -34,40 +34,55 @@ import java.util.function.Supplier;
 
 /**
  * An implementation similar to scalaz's <a href="http://eed3si9n.com/learning-scalaz/Validation.html">Validation</a> control.
- *
  * <p>
  * The Validation type is different from a Monad type, it is an applicative
  * functor. Whereas a Monad will short circuit after the first errors, the
  * applicative functor will continue on, accumulating ALL errors. This is
  * especially helpful in cases such as validation, where you want to know
  * all the validation errors that have occurred, not just the first one.
- * </p>
+ * <p>
+ * <strong>Validation construction:</strong>
  *
- * <pre>
- * <code>
- * <b>Validation construction:</b>
+ * <pre>{@code
+ * // = Valid(5)
+ * Validation<String, Integer> valid = Validation.valid(5);
  *
- * <i>Valid:</i>
- * Validation&lt;String,Integer&gt; valid = Validation.valid(5);
+ * // = Invalid(List("error1", "error2"))
+ * Validation<String, Integer> invalid = Validation.invalid("error1", "error2");
+ * }</pre>
  *
- * <i>Invalid:</i>
- * Validation&lt;List&lt;String&gt;,Integer&gt; invalid = Validation.invalid(List.of("error1","error2"));
+ * <strong>Validation combination:</strong>
  *
- * <b>Validation combination:</b>
+ * <pre>{@code
+ * Validation<String, String> valid1 = Validation.valid("John");
+ * Validation<String, Integer> valid2 = Validation.valid(5);
+ * Validation<String, Option<String>> valid3 = Validation.valid(Option.of("123 Fake St."));
+ * Function3<String, Integer, Option<String>, Person> f = ...;
  *
- * Validation&lt;String,String&gt; valid1 = Validation.valid("John");
- * Validation&lt;String,Integer&gt; valid2 = Validation.valid(5);
- * Validation&lt;String,Option&lt;String&gt;&gt; valid3 = Validation.valid(Option.of("123 Fake St."));
- * Function3&lt;String,Integer,Option&lt;String&gt;,Person&gt; f = ...;
+ * Validation<String, String> result = valid1.combine(valid2).ap((name,age) -> "Name: " + name + " Age: " + age);
+ * Validation<String, Person> result2 = valid1.combine(valid2).combine(valid3).ap(f);
+ * }</pre>
  *
- * Validation&lt;List&lt;String&gt;,String&gt; result = valid1.combine(valid2).ap((name,age) -&gt; "Name: "+name+" Age: "+age);
- * Validation&lt;List&lt;String&gt;,Person&gt; result2 = valid1.combine(valid2).combine(valid3).ap(f);
+ * <strong>Another form of combining validations:</strong>
  *
- * <b>Another form of combining validations:</b>
+ * <pre>{@code
+ * Validation<String, Person> result3 = Validation.combine(valid1, valid2, valid3).ap(f);
+ * }</pre>
  *
- * Validation&lt;List&lt;String&gt;,Person&gt; result3 = Validation.combine(valid1, valid2, valid3).ap(f);
- * </code>
- * </pre>
+ * <hr>
+ *
+ * <strong>Background:</strong>
+ *
+ * Validation is an <em>Applicative</em> that satisfies the following laws (beside the Functor laws):
+ *
+ * <ul>
+ * <li>identity: {@code validation.ap(lift(v -> v)) = validation}</li>
+ * <li>homomorphism: {@code valid(v).ap(lift(f)) = valid(f.apply(v))}</li>
+ * <li>interchange: {@code valid(v).ap(lift(f)) = lift(f).ap(lift(g -> g.apply(v)))}</li>
+ * </ul>
+ *
+ * See also <a href="http://www.staff.city.ac.uk/~ross/papers/Applicative.pdf">Applicative programming with effects</a>
+ * by Conor McBride and Ross Patterson (2008).
  *
  * @param <E> value type in the case of invalid
  * @param <T> value type in the case of valid
@@ -91,25 +106,65 @@ public interface Validation<E, T> extends Value<T>, Serializable {
     }
 
     /**
+     * Lifts a given function {@code f} to a {@code Validation}.
+     * <p>
+     * This method is syntactic sugar because {@link Validation#valid(Object)} does not accept lambdas.
+     *
+     * @param f   a lambda expression
+     * @param <E> type of the error
+     * @param <T> input type of the given function {@code f}
+     * @param <U> output type of the given function {@code f}
+     * @return a new {@code Valid} instance containing the given function {@code f}
+     */
+    @SuppressWarnings("unchecked")
+    static <E, T, U> Validation<E, Function<T, U>> lift(Function<? super T, ? extends U> f) {
+        return new Valid<>((Function<T, U>) f);
+    }
+
+    /**
      * Creates an {@link Invalid} that contains the given {@code error}.
      *
      * @param <E>   type of the given {@code error}
      * @param <T>   type of the value
-     * @param error An error
-     * @return {@code Invalid(error)}
-     * @throws NullPointerException if error is null
+     * @param error a validation error that is encapsulated by the invalid state
+     * @return a new {@link Validation.Invalid} instance that contains the given {@code error}
+     * @throws NullPointerException if {@code error} is null
      */
     static <E, T> Validation<E, T> invalid(E error) {
         Objects.requireNonNull(error, "error is null");
-        return new Invalid<>(error);
+        return new Invalid<>(List.of(error));
     }
 
-    static <E, T> Validation<E, T> invalid(Seq<E> errors) {
+    /**
+     * Creates an {@link Invalid} that contains the given {@code errors}.
+     *
+     * @param <E>    type of the given {@code errors}
+     * @param <T>    type of the value
+     * @param errors validation errors that are encapsulated by the invalid state. Empty errors are allowed (because of {@link #filter(Predicate)}) but not recommended.
+     * @return a new {@link Validation.Invalid} instance that contains the given {@code errors}
+     * @throws NullPointerException if {@code errors} is null
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    static <E, T> Validation<E, T> invalid(E... errors) {
         Objects.requireNonNull(errors, "errors is null");
-        if (errors.size() == 0) {
-            throw new IllegalArgumentException("Errors are empty");
-        }
-        return new Invalid<>(errors);
+        return invalidAll(List.of(errors));
+    }
+
+    /**
+     * Creates an {@link Invalid} that contains the given {@code errors}.
+     *
+     * @param <E>    component type of the given {@code errors}
+     * @param <T>    type of the value
+     * @param errors validation errors that are encapsulated by the invalid state. Empty errors are allowed (because of {@link #filter(Predicate)}) but not recommended.
+     * @return a new {@link Validation.Invalid} instance that contains the given {@code errors}
+     * @throws NullPointerException if {@code errors} is null
+     */
+    @SuppressWarnings("unchecked")
+    static <E, T> Validation<E, T> invalidAll(Iterable<? extends E> errors) {
+        Objects.requireNonNull(errors, "errors is null");
+        final Seq<E> errorSeq = (errors instanceof Seq) ? (Seq<E>) errors : List.ofAll(errors);
+        return new Invalid<>(errorSeq);
     }
 
     /**
@@ -129,8 +184,8 @@ public interface Validation<E, T> extends Value<T>, Serializable {
     /**
      * Creates a {@code Validation} of an {@code Either}.
      *
-     * @param t      A {@code Try}
-     * @param <T>    type of the valid value
+     * @param t   A {@code Try}
+     * @param <T> type of the valid value
      * @return A {@code Valid(t.get())} if t is a Success, otherwise {@code Invalid(t.getCause())}.
      * @throws NullPointerException if {@code t} is null
      */
@@ -138,7 +193,6 @@ public interface Validation<E, T> extends Value<T>, Serializable {
         Objects.requireNonNull(t, "t is null");
         return t.isSuccess() ? valid(t.get()) : invalid(t.getCause());
     }
-
 
     /**
      * Reduces many {@code Validation} instances into a single {@code Validation} by transforming an
@@ -162,7 +216,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
                 list = list.prepend(value.get());
             }
         }
-        return errors.isEmpty() ? valid(list.reverse()) : invalid(errors.reverse());
+        return errors.isEmpty() ? valid(list.reverse()) : invalidAll(errors.reverse());
     }
 
     /**
@@ -181,7 +235,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
     }
 
     /**
-     * Combines two {@code Validation}s into a {@link Builder}.
+     * Combines two {@code Validation}s into a {@link Builder2}.
      *
      * @param <E>         type of error
      * @param <T1>        type of first valid value
@@ -191,10 +245,10 @@ public interface Validation<E, T> extends Value<T>, Serializable {
      * @return an instance of Builder&lt;E,T1,T2&gt;
      * @throws NullPointerException if validation1 or validation2 is null
      */
-    static <E, T1, T2> Builder<E, T1, T2> combine(Validation<E, T1> validation1, Validation<E, T2> validation2) {
+    static <E, T1, T2> Builder2<E, T1, T2> combine(Validation<E, T1> validation1, Validation<E, T2> validation2) {
         Objects.requireNonNull(validation1, "validation1 is null");
         Objects.requireNonNull(validation2, "validation2 is null");
-        return new Builder<>(validation1, validation2);
+        return new Builder2<>(validation1, validation2);
     }
 
     /**
@@ -363,6 +417,25 @@ public interface Validation<E, T> extends Value<T>, Serializable {
     }
 
     /**
+     * Applies a given {@code Validation} that encapsulates a function to this {@code Validation}'s value or combines both errors.
+     *
+     * @param validation a function that transforms this value (on the 'sunny path')
+     * @param <U>        the new value type
+     * @return a new {@code Validation} that contains a transformed value or combined errors.
+     */
+    @SuppressWarnings("unchecked")
+    default <U> Validation<E, U> ap(Validation<E, ? extends Function<? super T, ? extends U>> validation) {
+        Objects.requireNonNull(validation, "validation is null");
+        if (isValid()) {
+            return validation.map(f -> f.apply(get()));
+        } else if (validation.isValid()) {
+            return (Validation<E, U>) this;
+        } else {
+            return invalidAll(getErrors().prependAll(validation.getErrors()));
+        }
+    }
+
+    /**
      * Check whether this is of type {@code Valid}
      *
      * @return true if is a Valid, false if is an Invalid
@@ -490,40 +563,64 @@ public interface Validation<E, T> extends Value<T>, Serializable {
      * @return an instance of type U
      * @throws NullPointerException if fInvalid or fValid is null
      */
-    default <U> U fold(Function<Seq<? extends E>, ? extends U> fInvalid, Function<? super T, ? extends U> fValid) {
+    default <U> U fold(Function<? super Seq<? super E>, ? extends U> fInvalid, Function<? super T, ? extends U> fValid) {
         Objects.requireNonNull(fInvalid, "fInvalid is null");
         Objects.requireNonNull(fValid, "fValid is null");
-        if (isInvalid()) {
-            return fInvalid.apply(this.getErrors());
+        if (isValid()) {
+            return fValid.apply(get());
         } else {
-            final T value = this.get();
-            return fValid.apply(value);
+            return fInvalid.apply(getErrors());
         }
     }
 
     /**
-     * Flip the valid/invalid values for this Validation. If this is a Valid&lt;E,T&gt;, returns Invalid&lt;T,E&gt;.
-     * Or if this is an Invalid&lt;E,T&gt;, return a Valid&lt;T,E&gt;.
+     * Flip the valid/invalid values for this Validation.
+     * <p>
+     * If this is a {@code Valid<E, T>}, {@code swap} returns an {@code Invalid<T, Seq<E>>}.
+     * <p>
+     * If this is an {@code Invalid<E, T>}, {@code swap} returns a {@code Valid<T, Seq<E>>}.
+     * <p>
+     * Please note that {@code validation.swap().swap()} isn't the identity {@code validation}.
      *
-     * @return a flipped instance of Validation
+     * @return a flipped instance of {@code Validation}
      */
     default Validation<T, Seq<E>> swap() {
-        if (isInvalid()) {
-            return Validation.valid(this.getErrors());
+        if (isValid()) {
+            return invalid(get());
         } else {
-            final T value = this.get();
-            return Validation.invalid(value);
+            return valid(getErrors());
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     default <U> Validation<E, U> map(Function<? super T, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
-        if (isInvalid()) {
-            return Validation.invalid(this.getErrors());
+        if (isValid()) {
+            return valid(f.apply(get()));
         } else {
-            final T value = this.get();
-            return Validation.valid(f.apply(value));
+            return (Validation<E, U>) this;
+        }
+    }
+
+    /**
+     * Maps the errors if this {@code Validation} is an {@code Invalid}, otherwise does nothing.
+     * <p>
+     * <strong>Hint</strong>: if a transformation of errors is needed use {@code getErrors().map(f)} instead.
+     * The can be wrapped in an {@code Invalid} again using {@link #invalidAll(Iterable)}.
+     *
+     * @param <U> type of the errors resulting from the mapping
+     * @param f   a function that maps errors
+     * @return an instance of {@code Validation<U, T>}
+     * @throws NullPointerException if the given function {@code f} is null
+     */
+    @SuppressWarnings("unchecked")
+    default <U> Validation<U, T> mapErrors(Function<? super E, ? extends U> f) {
+        Objects.requireNonNull(f, "f is null");
+        if (isValid()) {
+            return (Validation<U, T>) this;
+        } else {
+            return invalidAll(getErrors().map(f));
         }
     }
 
@@ -542,82 +639,96 @@ public interface Validation<E, T> extends Value<T>, Serializable {
      * @throws NullPointerException if invalidMapper or validMapper is null
      */
     default <E2, T2> Validation<E2, T2> bimap(
-            Function<? super Seq<? super E>, ? extends E2> errorMapper,
+            Function<? super E, ? extends E2> errorMapper,
             Function<? super T, ? extends T2> valueMapper) {
         Objects.requireNonNull(errorMapper, "errorMapper is null");
         Objects.requireNonNull(valueMapper, "valueMapper is null");
-        if (isInvalid()) {
-            return Validation.invalid(errorMapper.apply(this.getErrors()));
-        } else {
-            final T value = this.get();
-            return Validation.valid(valueMapper.apply(value));
-        }
-    }
-
-    /**
-     * Applies a function f to the errors of this Validation if this is an Invalid. Otherwise does nothing
-     * if this is a Valid.
-     *
-     * @param <U> type of the errors resulting from the mapping
-     * @param f   a function that maps the errors in this Invalid
-     * @return an instance of Validation&lt;U,T&gt;
-     * @throws NullPointerException if mapping operation f is null
-     */
-    default <U> Validation<U, T> mapError(Function<Seq<? extends E>, ? extends U> f) {
-        Objects.requireNonNull(f, "f is null");
-        if (isInvalid()) {
-            return Validation.invalid(f.apply(this.getErrors()));
-        } else {
-            return Validation.valid(this.get());
-        }
-    }
-
-    default <U> Validation<E, U> ap(Validation<E, ? extends Function<? super T, ? extends U>> validation) {
-        Objects.requireNonNull(validation, "validation is null");
         if (isValid()) {
-            if (validation.isValid()) {
-                final Function<? super T, ? extends U> f = validation.get();
-                final U u = f.apply(this.get());
-                return valid(u);
-            } else {
-                final Seq<E> errors = validation.getErrors();
-                return invalid(errors);
-            }
+            return valid(valueMapper.apply(get()));
         } else {
-            if (validation.isValid()) {
-                final Seq<E> errors = this.getErrors();
-                return invalid(errors);
-            } else {
-                Seq<E> specificErrors = List.ofAll(validation.getErrors());
-                Seq<E> finalErrors = specificErrors.appendAll(this.getErrors());
-                return invalid(finalErrors);
-            }
+            return invalidAll(getErrors().map(errorMapper));
         }
     }
 
     /**
-     * Combines two {@code Validation}s to form a {@link Builder}, which can then be used to perform further
-     * combines, or apply a function to it in order to transform the {@link Builder} into a {@code Validation}.
+     * Combines two {@code Validation}s to form a {@link Builder2}, which can then be used to perform further
+     * combines, or apply a function to it in order to transform the {@link Builder2} into a {@code Validation}.
      *
      * @param <U>        type of the value contained in validation
      * @param validation the validation object to combine this with
      * @return an instance of Builder
      */
-    default <U> Builder<E, T, U> combine(Validation<E, U> validation) {
-        return new Builder<>(this, validation);
+    default <U> Builder2<E, T, U> combine(Validation<E, U> validation) {
+        return new Builder2<>(this, validation);
     }
 
     // -- Implementation of Value
 
-    default Option<Validation<E, T>> filter(Predicate<? super T> predicate) {
+    /**
+     * Tests the value using the given {@code predicate} if this is valid.
+     * Returns this instance, if this is valid and the value makes it through the filter.
+     * <p>
+     * If a value does not make it through the filter, an {@link Invalid} instance is returned, having an empty error list.
+     *
+     * <pre>{@code
+     * // = Valid(1)
+     * Validation.valid(1).filter(i -> i == 1)
+     *
+     * // = Invalid(List())
+     * Validation.valid(1).filter(i -> i == 2)
+     *
+     * // = Invalid(List("err1", "err2"))
+     * Validation.invalid("err1", "err2").filter(o -> true)
+     * }</pre>
+     *
+     * @param predicate a filter function
+     * @return a {@code Validation} instance
+     */
+    default Validation<E, T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return isInvalid() || predicate.test(get()) ? Option.some(this) : Option.none();
+        return isInvalid() || predicate.test(get()) ? this : invalid();
+    }
+
+    /**
+     * Applies a given function {@code f} to the <strong>error sequence</strong> of this {@code Validation}
+     * if this is an {@code Invalid}. Otherwise does nothing if this is a {@code Valid}.
+     *
+     * @param predicate a filtering function that tests errors
+     * @return an instance of {@code Validation<E, T>}
+     * @throws NullPointerException if the give {@code predicate} is null
+     */
+    @SuppressWarnings("unchecked")
+    default Validation<E, T> filterErrors(Predicate<? super E> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        if (isValid()) {
+            return this;
+        } else {
+            return invalidAll(getErrors().filter(predicate));
+        }
     }
 
     @SuppressWarnings("unchecked")
     default <U> Validation<E, U> flatMap(Function<? super T, ? extends Validation<E, ? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return isInvalid() ? (Validation<E, U>) this : (Validation<E, U>) mapper.apply(get());
+        return isValid() ? (Validation<E, U>) mapper.apply(get()) : (Validation<E, U>) this;
+    }
+
+    /**
+     * FlatMaps the errors if this {@code Validation} is an {@code Invalid}, otherwise does nothing.
+     *
+     * @param <U> type of the errors resulting from the mapping
+     * @param f   a function that maps errors to sequences
+     * @return an instance of {@code Validation<U, T>}
+     * @throws NullPointerException if the given function {@code f} is null
+     */
+    @SuppressWarnings("unchecked")
+    default <U> Validation<U, T> flatMapErrors(Function<? super E, ? extends Iterable<? extends U>> f) {
+        Objects.requireNonNull(f, "f is null");
+        if (isValid()) {
+            return (Validation<U, T>) this;
+        } else {
+            return invalidAll(getErrors().flatMap(f));
+        }
     }
 
     @Override
@@ -733,15 +844,6 @@ public interface Validation<E, T> extends Value<T>, Serializable {
 
         private final Seq<E> errors;
 
-        /**
-         * Construct an {@code Invalid}
-         *
-         * @param error The value of this errors
-         */
-        private Invalid(E error) {
-            this.errors = List.of(error);
-        }
-
         private Invalid(Seq<E> errors) {
             this.errors = errors;
         }
@@ -757,7 +859,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
         }
 
         @Override
-        public T get() throws RuntimeException {
+        public T get() throws NoSuchElementException {
             throw new NoSuchElementException("get of 'invalid' Validation");
         }
 
@@ -788,18 +890,18 @@ public interface Validation<E, T> extends Value<T>, Serializable {
 
     }
 
-    final class Builder<E, T1, T2> {
+    final class Builder2<E, T1, T2> {
 
-        private Validation<E, T1> v1;
-        private Validation<E, T2> v2;
+        private final Validation<E, T1> v1;
+        private final Validation<E, T2> v2;
 
-        private Builder(Validation<E, T1> v1, Validation<E, T2> v2) {
+        private Builder2(Validation<E, T1> v1, Validation<E, T2> v2) {
             this.v1 = v1;
             this.v2 = v2;
         }
 
         public <R> Validation<E, R> ap(Function2<T1, T2, R> f) {
-            return v2.ap(v1.ap(Validation.valid(f.curried())));
+            return v2.ap(v1.ap(valid(f.curried())));
         }
 
         public <T3> Builder3<E, T1, T2, T3> combine(Validation<E, T3> v3) {
@@ -810,9 +912,9 @@ public interface Validation<E, T> extends Value<T>, Serializable {
 
     final class Builder3<E, T1, T2, T3> {
 
-        private Validation<E, T1> v1;
-        private Validation<E, T2> v2;
-        private Validation<E, T3> v3;
+        private final Validation<E, T1> v1;
+        private final Validation<E, T2> v2;
+        private final Validation<E, T3> v3;
 
         private Builder3(Validation<E, T1> v1, Validation<E, T2> v2, Validation<E, T3> v3) {
             this.v1 = v1;
@@ -821,7 +923,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
         }
 
         public <R> Validation<E, R> ap(Function3<T1, T2, T3, R> f) {
-            return v3.ap(v2.ap(v1.ap(Validation.valid(f.curried()))));
+            return v3.ap(v2.ap(v1.ap(valid(f.curried()))));
         }
 
         public <T4> Builder4<E, T1, T2, T3, T4> combine(Validation<E, T4> v4) {
@@ -832,10 +934,10 @@ public interface Validation<E, T> extends Value<T>, Serializable {
 
     final class Builder4<E, T1, T2, T3, T4> {
 
-        private Validation<E, T1> v1;
-        private Validation<E, T2> v2;
-        private Validation<E, T3> v3;
-        private Validation<E, T4> v4;
+        private final Validation<E, T1> v1;
+        private final Validation<E, T2> v2;
+        private final Validation<E, T3> v3;
+        private final Validation<E, T4> v4;
 
         private Builder4(Validation<E, T1> v1, Validation<E, T2> v2, Validation<E, T3> v3, Validation<E, T4> v4) {
             this.v1 = v1;
@@ -845,7 +947,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
         }
 
         public <R> Validation<E, R> ap(Function4<T1, T2, T3, T4, R> f) {
-            return v4.ap(v3.ap(v2.ap(v1.ap(Validation.valid(f.curried())))));
+            return v4.ap(v3.ap(v2.ap(v1.ap(valid(f.curried())))));
         }
 
         public <T5> Builder5<E, T1, T2, T3, T4, T5> combine(Validation<E, T5> v5) {
@@ -856,11 +958,11 @@ public interface Validation<E, T> extends Value<T>, Serializable {
 
     final class Builder5<E, T1, T2, T3, T4, T5> {
 
-        private Validation<E, T1> v1;
-        private Validation<E, T2> v2;
-        private Validation<E, T3> v3;
-        private Validation<E, T4> v4;
-        private Validation<E, T5> v5;
+        private final Validation<E, T1> v1;
+        private final Validation<E, T2> v2;
+        private final Validation<E, T3> v3;
+        private final Validation<E, T4> v4;
+        private final Validation<E, T5> v5;
 
         private Builder5(Validation<E, T1> v1, Validation<E, T2> v2, Validation<E, T3> v3, Validation<E, T4> v4, Validation<E, T5> v5) {
             this.v1 = v1;
@@ -871,7 +973,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
         }
 
         public <R> Validation<E, R> ap(Function5<T1, T2, T3, T4, T5, R> f) {
-            return v5.ap(v4.ap(v3.ap(v2.ap(v1.ap(Validation.valid(f.curried()))))));
+            return v5.ap(v4.ap(v3.ap(v2.ap(v1.ap(valid(f.curried()))))));
         }
 
         public <T6> Builder6<E, T1, T2, T3, T4, T5, T6> combine(Validation<E, T6> v6) {
@@ -882,12 +984,12 @@ public interface Validation<E, T> extends Value<T>, Serializable {
 
     final class Builder6<E, T1, T2, T3, T4, T5, T6> {
 
-        private Validation<E, T1> v1;
-        private Validation<E, T2> v2;
-        private Validation<E, T3> v3;
-        private Validation<E, T4> v4;
-        private Validation<E, T5> v5;
-        private Validation<E, T6> v6;
+        private final Validation<E, T1> v1;
+        private final Validation<E, T2> v2;
+        private final Validation<E, T3> v3;
+        private final Validation<E, T4> v4;
+        private final Validation<E, T5> v5;
+        private final Validation<E, T6> v6;
 
         private Builder6(Validation<E, T1> v1, Validation<E, T2> v2, Validation<E, T3> v3, Validation<E, T4> v4, Validation<E, T5> v5, Validation<E, T6> v6) {
             this.v1 = v1;
@@ -899,7 +1001,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
         }
 
         public <R> Validation<E, R> ap(Function6<T1, T2, T3, T4, T5, T6, R> f) {
-            return v6.ap(v5.ap(v4.ap(v3.ap(v2.ap(v1.ap(Validation.valid(f.curried())))))));
+            return v6.ap(v5.ap(v4.ap(v3.ap(v2.ap(v1.ap(valid(f.curried())))))));
         }
 
         public <T7> Builder7<E, T1, T2, T3, T4, T5, T6, T7> combine(Validation<E, T7> v7) {
@@ -910,13 +1012,13 @@ public interface Validation<E, T> extends Value<T>, Serializable {
 
     final class Builder7<E, T1, T2, T3, T4, T5, T6, T7> {
 
-        private Validation<E, T1> v1;
-        private Validation<E, T2> v2;
-        private Validation<E, T3> v3;
-        private Validation<E, T4> v4;
-        private Validation<E, T5> v5;
-        private Validation<E, T6> v6;
-        private Validation<E, T7> v7;
+        private final Validation<E, T1> v1;
+        private final Validation<E, T2> v2;
+        private final Validation<E, T3> v3;
+        private final Validation<E, T4> v4;
+        private final Validation<E, T5> v5;
+        private final Validation<E, T6> v6;
+        private final Validation<E, T7> v7;
 
         private Builder7(Validation<E, T1> v1, Validation<E, T2> v2, Validation<E, T3> v3, Validation<E, T4> v4, Validation<E, T5> v5, Validation<E, T6> v6, Validation<E, T7> v7) {
             this.v1 = v1;
@@ -929,7 +1031,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
         }
 
         public <R> Validation<E, R> ap(Function7<T1, T2, T3, T4, T5, T6, T7, R> f) {
-            return v7.ap(v6.ap(v5.ap(v4.ap(v3.ap(v2.ap(v1.ap(Validation.valid(f.curried()))))))));
+            return v7.ap(v6.ap(v5.ap(v4.ap(v3.ap(v2.ap(v1.ap(valid(f.curried()))))))));
         }
 
         public <T8> Builder8<E, T1, T2, T3, T4, T5, T6, T7, T8> combine(Validation<E, T8> v8) {
@@ -940,14 +1042,14 @@ public interface Validation<E, T> extends Value<T>, Serializable {
 
     final class Builder8<E, T1, T2, T3, T4, T5, T6, T7, T8> {
 
-        private Validation<E, T1> v1;
-        private Validation<E, T2> v2;
-        private Validation<E, T3> v3;
-        private Validation<E, T4> v4;
-        private Validation<E, T5> v5;
-        private Validation<E, T6> v6;
-        private Validation<E, T7> v7;
-        private Validation<E, T8> v8;
+        private final Validation<E, T1> v1;
+        private final Validation<E, T2> v2;
+        private final Validation<E, T3> v3;
+        private final Validation<E, T4> v4;
+        private final Validation<E, T5> v5;
+        private final Validation<E, T6> v6;
+        private final Validation<E, T7> v7;
+        private final Validation<E, T8> v8;
 
         private Builder8(Validation<E, T1> v1, Validation<E, T2> v2, Validation<E, T3> v3, Validation<E, T4> v4, Validation<E, T5> v5, Validation<E, T6> v6, Validation<E, T7> v7, Validation<E, T8> v8) {
             this.v1 = v1;
@@ -961,7 +1063,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
         }
 
         public <R> Validation<E, R> ap(Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
-            return v8.ap(v7.ap(v6.ap(v5.ap(v4.ap(v3.ap(v2.ap(v1.ap(Validation.valid(f.curried())))))))));
+            return v8.ap(v7.ap(v6.ap(v5.ap(v4.ap(v3.ap(v2.ap(v1.ap(valid(f.curried())))))))));
         }
     }
 }

--- a/vavr/src/main/java/io/vavr/control/Validation.java
+++ b/vavr/src/main/java/io/vavr/control/Validation.java
@@ -607,7 +607,7 @@ public interface Validation<E, T> extends Value<T>, Serializable {
      * Maps the errors if this {@code Validation} is an {@code Invalid}, otherwise does nothing.
      * <p>
      * <strong>Hint</strong>: if a transformation of errors is needed use {@code getErrors().map(f)} instead.
-     * The can be wrapped in an {@code Invalid} again using {@link #invalidAll(Iterable)}.
+     * They can be wrapped in an {@code Invalid} again using {@link #invalidAll(Iterable)}.
      *
      * @param <U> type of the errors resulting from the mapping
      * @param f   a function that maps errors

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -20,7 +20,6 @@
 package io.vavr.control;
 
 import static io.vavr.API.*;
-import static io.vavr.Predicates.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -37,6 +36,7 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -85,47 +85,38 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldExecuteAndFinallyOnSuccess(){
-        MutableInteger count = new MutableInteger(0);
-
-        Try.run(() -> count.setValue(0)).andFinally(() -> count.setValue(1));
-
-        assertThat(count.getValue()).isEqualTo(1);
+        final AtomicInteger count = new AtomicInteger();
+        Try.run(() -> count.set(0)).andFinally(() -> count.set(1));
+        assertThat(count.get()).isEqualTo(1);
     }
 
     @Test
     public void shouldExecuteAndFinallyTryOnSuccess(){
-        MutableInteger count = new MutableInteger(0);
-
-        Try.run(() -> count.setValue(0)).andFinallyTry(() -> count.setValue(1));
-
-        assertThat(count.getValue()).isEqualTo(1);
+        final AtomicInteger count = new AtomicInteger();
+        Try.run(() -> count.set(0)).andFinallyTry(() -> count.set(1));
+        assertThat(count.get()).isEqualTo(1);
     }
 
     @Test
     public void shouldExecuteAndFinallyOnFailure(){
-        MutableInteger count = new MutableInteger(0);
-
-        Try.run(() -> {throw new IllegalStateException(FAILURE);})
-                .andFinally(() -> count.setValue(1));
-
-        assertThat(count.getValue()).isEqualTo(1);
+        final AtomicInteger count = new AtomicInteger();
+        Try.run(() -> { throw new IllegalStateException(FAILURE); })
+                .andFinally(() -> count.set(1));
+        assertThat(count.get()).isEqualTo(1);
     }
 
     @Test
     public void shouldExecuteAndFinallyTryOnFailure(){
-        MutableInteger count = new MutableInteger(0);
-
-        Try.run(() -> {throw new IllegalStateException(FAILURE);})
-                .andFinallyTry(() -> count.setValue(1));
-
-        assertThat(count.getValue()).isEqualTo(1);
+        final AtomicInteger count = new AtomicInteger();
+        Try.run(() -> { throw new IllegalStateException(FAILURE); })
+                .andFinallyTry(() -> count.set(1));
+        assertThat(count.get()).isEqualTo(1);
     }
 
     @Test
     public void shouldExecuteAndFinallyTryOnFailureWithFailure(){
-        Try<Object> result = Try.of(() -> {throw new IllegalStateException(FAILURE);})
-                .andFinallyTry(() -> {throw new IllegalStateException(FAILURE);});
-
+        final Try<Object> result = Try.of(() -> { throw new IllegalStateException(FAILURE); })
+                .andFinallyTry(() -> { throw new IllegalStateException(FAILURE); });
         assertThat(result.isFailure());
     }
 
@@ -213,25 +204,25 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldReturnSelfOnOrElseIfSuccess() {
-        Try<Integer> success = Try.success(42);
+        final Try<Integer> success = Try.success(42);
         assertThat(success.orElse(Try.success(0))).isSameAs(success);
     }
 
     @Test
     public void shouldReturnSelfOnOrElseSupplierIfSuccess() {
-        Try<Integer> success = Try.success(42);
+        final Try<Integer> success = Try.success(42);
         assertThat(success.orElse(() -> Try.success(0))).isSameAs(success);
     }
 
     @Test
     public void shouldReturnAlternativeOnOrElseIfFailure() {
-        Try<Integer> success = Try.success(42);
+        final Try<Integer> success = Try.success(42);
         assertThat(Try.failure(new RuntimeException()).orElse(success)).isSameAs(success);
     }
 
     @Test
     public void shouldReturnAlternativeOnOrElseSupplierIfFailure() {
-        Try<Integer> success = Try.success(42);
+        final Try<Integer> success = Try.success(42);
         assertThat(Try.failure(new RuntimeException()).orElse(() -> success)).isSameAs(success);
     }
 
@@ -270,7 +261,7 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldReturnValueIfSuccess() {
-        Try<Integer> success = Try.success(42);
+        final Try<Integer> success = Try.success(42);
         assertThat(success.fold(t -> {
             throw new AssertionError("Not expected to be called");
         }, Function.identity())).isEqualTo(42);
@@ -278,7 +269,7 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldReturnAlternateValueIfFailure() {
-        Try<Integer> success = Try.failure(new NullPointerException("something was null"));
+        final Try<Integer> success = Try.failure(new NullPointerException("something was null"));
         assertThat(success.<Integer>fold(t -> 42, a -> {
             throw new AssertionError("Not expected to be called");
         })).isEqualTo(42);
@@ -379,7 +370,7 @@ public class TryTest extends AbstractValueTest {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
             isClosed = true;
         }
     }
@@ -627,17 +618,17 @@ public class TryTest extends AbstractValueTest {
     // -- Failure.Cause
 
     @Test(expected = InterruptedException.class)
-    public void shouldRethrowInterruptedException() throws Exception {
+    public void shouldRethrowInterruptedException() {
         Try.failure(new InterruptedException());
     }
 
     @Test(expected = OutOfMemoryError.class)
-    public void shouldRethrowOutOfMemoryError() throws Exception {
+    public void shouldRethrowOutOfMemoryError() {
         Try.failure(new OutOfMemoryError());
     }
 
     @Test
-    public void shouldDetectNonFatalException() throws Exception {
+    public void shouldDetectNonFatalException() {
         final Exception exception = new Exception();
         assertThat(Try.failure(exception).getCause()).isSameAs(exception);
     }
@@ -686,7 +677,7 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldReturnEqualsOnFatal() {
-        UnknownError error = new UnknownError();
+        final UnknownError error = new UnknownError();
         try {
             Try.of(() -> {
                 throw error;
@@ -983,7 +974,7 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldConvertFailureToValidation() {
-        Try<Object> failure = failure();
+        final Try<Object> failure = failure();
         final Validation<Throwable, Object> invalid = failure.toValidation();
         assertThat(invalid.getErrors().get(0)).isEqualTo(failure.getCause());
         assertThat(invalid.isInvalid()).isTrue();
@@ -991,7 +982,7 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldConvertFailureToInvalidValidation() {
-        Try<Object> failure = failure();
+        final Try<Object> failure = failure();
         final Validation<String, Object> validation = failure.toValidation(e -> e.toString());
         assertThat(validation.getErrors().get(0)).isEqualTo(failure.getCause().toString());
         assertThat(validation.isInvalid()).isTrue();
@@ -1001,7 +992,7 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldConvertSuccessToCompletableFuture() {
-        CompletableFuture<String> future = success().toCompletableFuture();
+        final CompletableFuture<String> future = success().toCompletableFuture();
         assertThat(future.isDone());
         assertThat(Try.of(future::get).get()).isEqualTo(success().get());
     }
@@ -1063,7 +1054,7 @@ public class TryTest extends AbstractValueTest {
     }
 
     @Test
-    public void shouldReturnIdentityWhenFilterWithErrorProviderOnFailure() throws Exception {
+    public void shouldReturnIdentityWhenFilterWithErrorProviderOnFailure() {
         final Try<String> identity = failure();
         assertThat(identity.filter(s -> false, ignored -> new IllegalArgumentException())).isEqualTo(identity);
     }
@@ -1225,8 +1216,8 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldConvertListOfSuccessToTryOfList() {
-        List<Try<String>> tries = Arrays.asList(Try.success("a"), Try.success("b"), Try.success("c"));
-        Try<Seq<String>> reducedTry = Try.sequence(tries);
+        final List<Try<String>> tries = Arrays.asList(Try.success("a"), Try.success("b"), Try.success("c"));
+        final Try<Seq<String>> reducedTry = Try.sequence(tries);
         assertThat(reducedTry instanceof Try.Success).isTrue();
         assertThat(reducedTry.get().size()).isEqualTo(3);
         assertThat(reducedTry.get().mkString()).isEqualTo("abc");
@@ -1234,17 +1225,17 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldConvertListOfFailureToTryOfList() {
-        Throwable t = new RuntimeException("failure");
-        List<Try<String>> tries = Arrays.asList(Try.failure(t), Try.failure(t), Try.failure(t));
-        Try<Seq<String>> reducedTry = Try.sequence(tries);
+        final Throwable t = new RuntimeException("failure");
+        final List<Try<String>> tries = Arrays.asList(Try.failure(t), Try.failure(t), Try.failure(t));
+        final Try<Seq<String>> reducedTry = Try.sequence(tries);
         assertThat(reducedTry instanceof Try.Failure).isTrue();
     }
 
     @Test
     public void shouldConvertListOfMixedTryToTryOfList() {
-        Throwable t = new RuntimeException("failure");
-        List<Try<String>> tries = Arrays.asList(Try.success("a"), Try.failure(t), Try.success("c"));
-        Try<Seq<String>> reducedTry = Try.sequence(tries);
+        final Throwable t = new RuntimeException("failure");
+        final List<Try<String>> tries = Arrays.asList(Try.success("a"), Try.failure(t), Try.success("c"));
+        final Try<Seq<String>> reducedTry = Try.sequence(tries);
         assertThat(reducedTry instanceof Try.Failure).isTrue();
     }
 
@@ -1335,7 +1326,7 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldConvertSuccessToValidValidationUsingConversionWithMapper() {
-        assertThat(success().toValidation(e -> e.getMessage()).isValid()).isTrue();
+        assertThat(success().toValidation(Throwable::getMessage).isValid()).isTrue();
     }
 
     @Test
@@ -1573,22 +1564,6 @@ public class TryTest extends AbstractValueTest {
 
     private Try<String> success() {
         return Try.of(() -> "ok");
-    }
-
-    private class MutableInteger {
-        private int value;
-
-        public MutableInteger(int value) {
-            this.value = value;
-        }
-
-        public int getValue() {
-            return value;
-        }
-
-        public void setValue(int value) {
-            this.value = value;
-        }
     }
 
     // -- spliterator


### PR DESCRIPTION
Follow-up of #2073

### Summary (Validation):

* changed signature of `filter()` -> that implied that we have to allow **empty error lists** of Validation.Invalid
* renamed `mapError()` to `mapErrors()`
* restored signature of `mapErrors()`
* added `flatMapErrors()`
* added `filterErrors()`
* reverted `bimap()` signature
* added `Validation.lift(Function)`
* added `Validation.invalid(E...)`
* changed `Validation.invalid(Seq)` to `Validation.invalidAll(Iterable)` (name-change because of ambiguities)
* renamed `Validation.Builder` to `Validation.Builder2` (accordingly to the other Builder names)
* changed some generic bounds
* simplified `ap()` implementation
* (more minor changes)

### Summary (other changes):

* re-added `$Valid()` and `$Invalid()` matching patterns
* fixed javadoc
* cleaned up some tests (independent of Validation)
