### PR TITLE
Add concat methods to Tuple classes

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -2013,14 +2013,12 @@ def generateMainClasses(): Unit = {
 
             ${(i == 0).gen(xs"""
               public <T1> Tuple1<T1> concat(T1 t1) {
-                  Objects.requireNonNull(t1, "t1 is null");
                   return ${im.getType("io.vavr.Tuple")}.of(t1);
               }
             """)}
 
             ${(i > 0 && i < N).gen(xs"""
               public <T${i+1}> Tuple${i+1}<${(1 to i+1).gen(j => s"T$j")(", ")}> concat(T${i+1} t${i+1}) {
-                  Objects.requireNonNull(t${i+1}, "t${i+1} is null");
                   return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}, t${i+1});
               }
             """)}
@@ -2031,7 +2029,6 @@ def generateMainClasses(): Unit = {
                * j=$j
                */
               public <${(i+1 to i+j).gen(k => s"T$k")(", ")}> Tuple${i+j}<${(1 to i+j).gen(k => s"T$k")(", ")}> concat(Tuple$j<${(i+1 to i+j).gen(k => s"T$k")(", ")}> tuple) {
-                  Objects.requireNonNull(tuple, "tuple is null");
                   return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}, ${(1 to j).gen(k => s"tuple._$k")(", ")});
               }
             """)("\n\n")}

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -3421,20 +3421,11 @@ def generateTestClasses(): Unit = {
                   assertThat(actual).isEqualTo(Tuple0.instance());
               }
 
-              ${(i == 0).gen(xs"""
+              ${(i < N).gen(xs"""
                 @$test
                 public void shouldAppendValue() {
-                    final Tuple1<Integer> actual = Tuple0.instance().append(1);
-                    final Tuple1<Integer> expected = Tuple.of(1);
-                    assertThat(actual).isEqualTo(expected);
-                }
-              """)}
-
-              ${(i > 0 && i < N).gen(xs"""
-                @$test
-                public void shouldAppendValue() {
-                    final Tuple${i+1}${if (i == 0) "" else s"<${(1 to i+1).gen(j => s"Integer")(", ")}>"} actual = Tuple.of(${(1 to i).gen(j => xs"$j")(", ")}).append(${i+1});
-                    final Tuple${i+1}${if (i == 0) "" else s"<${(1 to i+1).gen(j => s"Integer")(", ")}>"} expected = Tuple.of(${(1 to i+1).gen(j => xs"$j")(", ")});
+                    final Tuple${i+1}<${(1 to i+1).gen(j => s"Integer")(", ")}> actual = ${ if (i == 0) "Tuple0.instance()" else s"Tuple.of(${(1 to i).gen(j => xs"$j")(", ")})"}.append(${i+1});
+                    final Tuple${i+1}<${(1 to i+1).gen(j => s"Integer")(", ")}> expected = Tuple.of(${(1 to i+1).gen(j => xs"$j")(", ")});
                     assertThat(actual).isEqualTo(expected);
                 }
               """)}

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -2010,26 +2010,20 @@ def generateMainClasses(): Unit = {
                 """}
             }
 
-            ${(i == 0).gen(xs"""
-              public <T1> Tuple1<T1> concat(T1 t1) {
-                  return ${im.getType("io.vavr.Tuple")}.of(t1);
+            ${(i < N).gen(xs"""
+              public <T${i+1}> Tuple${i+1}<${(1 to i+1).gen(j => s"T$j")(", ")}> append(T${i+1} t${i+1}) {
+                  return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}${(i > 0).gen(", ")}t${i+1});
               }
             """)}
 
-            ${(i > 0 && i < N).gen(xs"""
-              public <T${i+1}> Tuple${i+1}<${(1 to i+1).gen(j => s"T$j")(", ")}> concat(T${i+1} t${i+1}) {
-                  return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}, t${i+1});
-              }
-            """)}
-
-            ${(i > 0 && i < N) gen (1 to N-i).gen(j => xs"""
+            ${(i < N) gen (1 to N-i).gen(j => xs"""
               /$javadoc
                * i=$i
                * j=$j
                */
               public <${(i+1 to i+j).gen(k => s"T$k")(", ")}> Tuple${i+j}<${(1 to i+j).gen(k => s"T$k")(", ")}> concat(Tuple$j<${(i+1 to i+j).gen(k => s"T$k")(", ")}> tuple) {
                   Objects.requireNonNull(tuple, "tuple is null");
-                  return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}, ${(1 to j).gen(k => s"tuple._$k")(", ")});
+                  return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}${(i > 0).gen(", ")}${(1 to j).gen(k => s"tuple._$k")(", ")});
               }
             """)("\n\n")}
 

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -3421,6 +3421,24 @@ def generateTestClasses(): Unit = {
                   assertThat(actual).isEqualTo(Tuple0.instance());
               }
 
+              ${(i == 0).gen(xs"""
+                @$test
+                public void shouldAppendValue() {
+                    final Tuple1<Integer> actual = Tuple0.instance().append(1);
+                    final Tuple1<Integer> expected = Tuple.of(1);
+                    assertThat(actual).isEqualTo(expected);
+                }
+              """)}
+
+              ${(i > 0 && i < N).gen(xs"""
+                @$test
+                public void shouldAppendValue() {
+                    final Tuple${i+1}${if (i == 0) "" else s"<${(1 to i+1).gen(j => s"Integer")(", ")}>"} actual = Tuple.of(${(1 to i).gen(j => xs"$j")(", ")}).append(${i+1});
+                    final Tuple${i+1}${if (i == 0) "" else s"<${(1 to i+1).gen(j => s"Integer")(", ")}>"} expected = Tuple.of(${(1 to i+1).gen(j => xs"$j")(", ")});
+                    assertThat(actual).isEqualTo(expected);
+                }
+              """)}
+
               @$test
               public void shouldRecognizeEquality() {
                   final Tuple$i$generics tuple1 = createTuple();

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -3430,6 +3430,15 @@ def generateTestClasses(): Unit = {
                 }
               """)}
 
+              ${(i < N) gen (1 to N-i).gen(j => xs"""
+                @$test
+                public void shouldConcatTuple$j() {
+                    final Tuple${i+j}<${(1 to i+j).gen(j => s"Integer")(", ")}> actual = ${ if (i == 0) "Tuple0.instance()" else s"Tuple.of(${(1 to i).gen(j => xs"$j")(", ")})"}.concat(Tuple.of(${(i+1 to i+j).gen(k => s"$k")(", ")}));
+                    final Tuple${i+j}<${(1 to i+j).gen(j => s"Integer")(", ")}> expected = Tuple.of(${(1 to i+j).gen(j => xs"$j")(", ")});
+                    assertThat(actual).isEqualTo(expected);
+                }
+              """)("\n\n")}
+
               @$test
               public void shouldRecognizeEquality() {
                   final Tuple$i$generics tuple1 = createTuple();

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -2028,6 +2028,7 @@ def generateMainClasses(): Unit = {
                * j=$j
                */
               public <${(i+1 to i+j).gen(k => s"T$k")(", ")}> Tuple${i+j}<${(1 to i+j).gen(k => s"T$k")(", ")}> concat(Tuple$j<${(i+1 to i+j).gen(k => s"T$k")(", ")}> tuple) {
+                  Objects.requireNonNull(tuple, "tuple is null");
                   return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}, ${(1 to j).gen(k => s"tuple._$k")(", ")});
               }
             """)("\n\n")}

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -2011,6 +2011,12 @@ def generateMainClasses(): Unit = {
             }
 
             ${(i < N).gen(xs"""
+              /$javadoc
+               * Append a value to this tuple.
+               *
+               * @param t${i+1} the value to append
+               * @return a new Tuple with the value appended
+               */
               public <T${i+1}> Tuple${i+1}<${(1 to i+1).gen(j => s"T$j")(", ")}> append(T${i+1} t${i+1}) {
                   return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}${(i > 0).gen(", ")}t${i+1});
               }
@@ -2018,8 +2024,11 @@ def generateMainClasses(): Unit = {
 
             ${(i < N) gen (1 to N-i).gen(j => xs"""
               /$javadoc
-               * i=$i
-               * j=$j
+               * Concat a tuple's values to this tuple.
+               *
+               * @param tuple the tuple to concat
+               * @return a new Tuple with the tuple values appended
+               * @throws NullPointerException if {@code tuple} is null
                */
               public <${(i+1 to i+j).gen(k => s"T$k")(", ")}> Tuple${i+j}<${(1 to i+j).gen(k => s"T$k")(", ")}> concat(Tuple$j<${(i+1 to i+j).gen(k => s"T$k")(", ")}> tuple) {
                   Objects.requireNonNull(tuple, "tuple is null");

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1784,7 +1784,6 @@ def generateMainClasses(): Unit = {
       val Objects = im.getType("java.util.Objects")
       val Seq = im.getType("io.vavr.collection.Seq")
       val List = im.getType("io.vavr.collection.List")
-      val Iterator = im.getType("io.vavr.collection.Iterator")
       if(i==2){
         im.getType("java.util.Map")
         im.getType("java.util.AbstractMap")

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1020,7 +1020,7 @@ def generateMainClasses(): Unit = {
                    */
                   long serialVersionUID = 1L;
               }
-              
+
               public static final class Case0<T, R> implements Case<T, R> {
 
                   private static final long serialVersionUID = 1L;
@@ -1097,7 +1097,7 @@ def generateMainClasses(): Unit = {
 
               // These can't be @FunctionalInterfaces because of ambiguities.
               // For benchmarks lambda vs. abstract class see http://www.oracle.com/technetwork/java/jvmls2013kuksen-2014088.pdf
-              
+
               public static abstract class Pattern0<T> implements Pattern<T, T> {
 
                   private static final long serialVersionUID = 1L;
@@ -1443,7 +1443,7 @@ def generateMainClasses(): Unit = {
                * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
                */
               long serialVersionUID = 1L;
-              
+
               /$javadoc
                * Returns a function that always returns the constant
                * value that you give in parameter.
@@ -1733,7 +1733,7 @@ def generateMainClasses(): Unit = {
                 }
               """)}
           }
-          
+
           interface ${className}Module {
 
               // DEV-NOTE: we do not plan to expose this as public API
@@ -2010,6 +2010,31 @@ def generateMainClasses(): Unit = {
                   return $List.of($params);
                 """}
             }
+
+            ${(i == 0).gen(xs"""
+              public <T1> Tuple1<T1> concat(T1 t1) {
+                  Objects.requireNonNull(t1, "t1 is null");
+                  return ${im.getType("io.vavr.Tuple")}.of(t1);
+              }
+            """)}
+
+            ${(i > 0 && i < N).gen(xs"""
+              public <T${i+1}> Tuple${i+1}<${(1 to i+1).gen(j => s"T$j")(", ")}> concat(T${i+1} t${i+1}) {
+                  Objects.requireNonNull(t${i+1}, "t${i+1} is null");
+                  return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}, t${i+1});
+              }
+            """)}
+
+            ${(i > 0 && i < N) gen (1 to N-i).gen(j => xs"""
+              /$javadoc
+               * i=$i
+               * j=$j
+               */
+              public <${(i+1 to i+j).gen(k => s"T$k")(", ")}> Tuple${i+j}<${(1 to i+j).gen(k => s"T$k")(", ")}> concat(Tuple$j<${(i+1 to i+j).gen(k => s"T$k")(", ")}> tuple) {
+                  Objects.requireNonNull(tuple, "tuple is null");
+                  return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}, ${(1 to j).gen(k => s"tuple._$k")(", ")});
+              }
+            """)("\n\n")}
 
             // -- Object
 

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -2014,6 +2014,7 @@ def generateMainClasses(): Unit = {
               /$javadoc
                * Append a value to this tuple.
                *
+               * @param <T${i+1}> type of the value to append
                * @param t${i+1} the value to append
                * @return a new Tuple with the value appended
                */
@@ -2026,6 +2027,7 @@ def generateMainClasses(): Unit = {
               /$javadoc
                * Concat a tuple's values to this tuple.
                *
+               ${(i+1 to i+j).gen(k => s"* @param <T$k> the type of the ${k.ordinal} value in the tuple")("\n")}
                * @param tuple the tuple to concat
                * @return a new Tuple with the tuple values appended
                * @throws NullPointerException if {@code tuple} is null

--- a/vavr/src-gen/main/java/io/vavr/Tuple0.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple0.java
@@ -94,13 +94,22 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
         return List.empty();
     }
 
+    /**
+     * Append a value to this tuple.
+     *
+     * @param t1 the value to append
+     * @return a new Tuple with the value appended
+     */
     public <T1> Tuple1<T1> append(T1 t1) {
         return Tuple.of(t1);
     }
 
     /**
-     * i=0
-     * j=1
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T1> Tuple1<T1> concat(Tuple1<T1> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -108,8 +117,11 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     }
 
     /**
-     * i=0
-     * j=2
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T1, T2> Tuple2<T1, T2> concat(Tuple2<T1, T2> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -117,8 +129,11 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     }
 
     /**
-     * i=0
-     * j=3
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T1, T2, T3> Tuple3<T1, T2, T3> concat(Tuple3<T1, T2, T3> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -126,8 +141,11 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     }
 
     /**
-     * i=0
-     * j=4
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4> concat(Tuple4<T1, T2, T3, T4> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -135,8 +153,11 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     }
 
     /**
-     * i=0
-     * j=5
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T1, T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple5<T1, T2, T3, T4, T5> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -144,8 +165,11 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     }
 
     /**
-     * i=0
-     * j=6
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple6<T1, T2, T3, T4, T5, T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -153,8 +177,11 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     }
 
     /**
-     * i=0
-     * j=7
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple7<T1, T2, T3, T4, T5, T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -162,8 +189,11 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     }
 
     /**
-     * i=0
-     * j=8
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");

--- a/vavr/src-gen/main/java/io/vavr/Tuple0.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple0.java
@@ -96,7 +96,6 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     }
 
     public <T1> Tuple1<T1> concat(T1 t1) {
-        Objects.requireNonNull(t1, "t1 is null");
         return Tuple.of(t1);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple0.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple0.java
@@ -23,7 +23,6 @@ package io.vavr;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import java.io.Serializable;

--- a/vavr/src-gen/main/java/io/vavr/Tuple0.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple0.java
@@ -94,8 +94,80 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
         return List.empty();
     }
 
-    public <T1> Tuple1<T1> concat(T1 t1) {
+    public <T1> Tuple1<T1> append(T1 t1) {
         return Tuple.of(t1);
+    }
+
+    /**
+     * i=0
+     * j=1
+     */
+    public <T1> Tuple1<T1> concat(Tuple1<T1> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(tuple._1);
+    }
+
+    /**
+     * i=0
+     * j=2
+     */
+    public <T1, T2> Tuple2<T1, T2> concat(Tuple2<T1, T2> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(tuple._1, tuple._2);
+    }
+
+    /**
+     * i=0
+     * j=3
+     */
+    public <T1, T2, T3> Tuple3<T1, T2, T3> concat(Tuple3<T1, T2, T3> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(tuple._1, tuple._2, tuple._3);
+    }
+
+    /**
+     * i=0
+     * j=4
+     */
+    public <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4> concat(Tuple4<T1, T2, T3, T4> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(tuple._1, tuple._2, tuple._3, tuple._4);
+    }
+
+    /**
+     * i=0
+     * j=5
+     */
+    public <T1, T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple5<T1, T2, T3, T4, T5> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
+    }
+
+    /**
+     * i=0
+     * j=6
+     */
+    public <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple6<T1, T2, T3, T4, T5, T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6);
+    }
+
+    /**
+     * i=0
+     * j=7
+     */
+    public <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple7<T1, T2, T3, T4, T5, T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6, tuple._7);
+    }
+
+    /**
+     * i=0
+     * j=8
+     */
+    public <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6, tuple._7, tuple._8);
     }
 
     // -- Object

--- a/vavr/src-gen/main/java/io/vavr/Tuple0.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple0.java
@@ -97,6 +97,7 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     /**
      * Append a value to this tuple.
      *
+     * @param <T1> type of the value to append
      * @param t1 the value to append
      * @return a new Tuple with the value appended
      */
@@ -107,6 +108,7 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T1> the type of the 1st value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -119,6 +121,8 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T1> the type of the 1st value in the tuple
+     * @param <T2> the type of the 2nd value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -131,6 +135,9 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T1> the type of the 1st value in the tuple
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -143,6 +150,10 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T1> the type of the 1st value in the tuple
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -155,6 +166,11 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T1> the type of the 1st value in the tuple
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -167,6 +183,12 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T1> the type of the 1st value in the tuple
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -179,6 +201,13 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T1> the type of the 1st value in the tuple
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -191,6 +220,14 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T1> the type of the 1st value in the tuple
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
+     * @param <T8> the type of the 8th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null

--- a/vavr/src-gen/main/java/io/vavr/Tuple0.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple0.java
@@ -95,6 +95,11 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
         return List.empty();
     }
 
+    public <T1> Tuple1<T1> concat(T1 t1) {
+        Objects.requireNonNull(t1, "t1 is null");
+        return Tuple.of(t1);
+    }
+
     // -- Object
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Tuple1.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple1.java
@@ -23,7 +23,6 @@ package io.vavr;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.control.HashCodes;

--- a/vavr/src-gen/main/java/io/vavr/Tuple1.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple1.java
@@ -142,6 +142,74 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
         return List.of(_1);
     }
 
+    public <T2> Tuple2<T1, T2> concat(T2 t2) {
+        Objects.requireNonNull(t2, "t2 is null");
+        return Tuple.of(_1, t2);
+    }
+
+    /**
+     * i=1
+     * j=1
+     */
+    public <T2> Tuple2<T1, T2> concat(Tuple1<T2> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, tuple._1);
+    }
+
+    /**
+     * i=1
+     * j=2
+     */
+    public <T2, T3> Tuple3<T1, T2, T3> concat(Tuple2<T2, T3> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, tuple._1, tuple._2);
+    }
+
+    /**
+     * i=1
+     * j=3
+     */
+    public <T2, T3, T4> Tuple4<T1, T2, T3, T4> concat(Tuple3<T2, T3, T4> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, tuple._1, tuple._2, tuple._3);
+    }
+
+    /**
+     * i=1
+     * j=4
+     */
+    public <T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple4<T2, T3, T4, T5> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4);
+    }
+
+    /**
+     * i=1
+     * j=5
+     */
+    public <T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple5<T2, T3, T4, T5, T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
+    }
+
+    /**
+     * i=1
+     * j=6
+     */
+    public <T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple6<T2, T3, T4, T5, T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6);
+    }
+
+    /**
+     * i=1
+     * j=7
+     */
+    public <T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple7<T2, T3, T4, T5, T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6, tuple._7);
+    }
+
     // -- Object
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Tuple1.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple1.java
@@ -143,7 +143,6 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     }
 
     public <T2> Tuple2<T1, T2> concat(T2 t2) {
-        Objects.requireNonNull(t2, "t2 is null");
         return Tuple.of(_1, t2);
     }
 
@@ -152,7 +151,6 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=1
      */
     public <T2> Tuple2<T1, T2> concat(Tuple1<T2> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1);
     }
 
@@ -161,7 +159,6 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=2
      */
     public <T2, T3> Tuple3<T1, T2, T3> concat(Tuple2<T2, T3> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2);
     }
 
@@ -170,7 +167,6 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=3
      */
     public <T2, T3, T4> Tuple4<T1, T2, T3, T4> concat(Tuple3<T2, T3, T4> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2, tuple._3);
     }
 
@@ -179,7 +175,6 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=4
      */
     public <T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple4<T2, T3, T4, T5> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4);
     }
 
@@ -188,7 +183,6 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=5
      */
     public <T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple5<T2, T3, T4, T5, T6> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
     }
 
@@ -197,7 +191,6 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=6
      */
     public <T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple6<T2, T3, T4, T5, T6, T7> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6);
     }
 
@@ -206,7 +199,6 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=7
      */
     public <T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple7<T2, T3, T4, T5, T6, T7, T8> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6, tuple._7);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple1.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple1.java
@@ -144,6 +144,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     /**
      * Append a value to this tuple.
      *
+     * @param <T2> type of the value to append
      * @param t2 the value to append
      * @return a new Tuple with the value appended
      */
@@ -154,6 +155,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T2> the type of the 2nd value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -166,6 +168,8 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -178,6 +182,9 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -190,6 +197,10 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -202,6 +213,11 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -214,6 +230,12 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -226,6 +248,13 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T2> the type of the 2nd value in the tuple
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
+     * @param <T8> the type of the 8th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null

--- a/vavr/src-gen/main/java/io/vavr/Tuple1.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple1.java
@@ -141,13 +141,22 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
         return List.of(_1);
     }
 
+    /**
+     * Append a value to this tuple.
+     *
+     * @param t2 the value to append
+     * @return a new Tuple with the value appended
+     */
     public <T2> Tuple2<T1, T2> append(T2 t2) {
         return Tuple.of(_1, t2);
     }
 
     /**
-     * i=1
-     * j=1
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T2> Tuple2<T1, T2> concat(Tuple1<T2> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -155,8 +164,11 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     }
 
     /**
-     * i=1
-     * j=2
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T2, T3> Tuple3<T1, T2, T3> concat(Tuple2<T2, T3> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -164,8 +176,11 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     }
 
     /**
-     * i=1
-     * j=3
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T2, T3, T4> Tuple4<T1, T2, T3, T4> concat(Tuple3<T2, T3, T4> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -173,8 +188,11 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     }
 
     /**
-     * i=1
-     * j=4
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple4<T2, T3, T4, T5> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -182,8 +200,11 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     }
 
     /**
-     * i=1
-     * j=5
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple5<T2, T3, T4, T5, T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -191,8 +212,11 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     }
 
     /**
-     * i=1
-     * j=6
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple6<T2, T3, T4, T5, T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -200,8 +224,11 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     }
 
     /**
-     * i=1
-     * j=7
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple7<T2, T3, T4, T5, T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");

--- a/vavr/src-gen/main/java/io/vavr/Tuple1.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple1.java
@@ -150,6 +150,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=1
      */
     public <T2> Tuple2<T1, T2> concat(Tuple1<T2> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1);
     }
 
@@ -158,6 +159,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=2
      */
     public <T2, T3> Tuple3<T1, T2, T3> concat(Tuple2<T2, T3> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2);
     }
 
@@ -166,6 +168,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=3
      */
     public <T2, T3, T4> Tuple4<T1, T2, T3, T4> concat(Tuple3<T2, T3, T4> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2, tuple._3);
     }
 
@@ -174,6 +177,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=4
      */
     public <T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple4<T2, T3, T4, T5> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4);
     }
 
@@ -182,6 +186,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=5
      */
     public <T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple5<T2, T3, T4, T5, T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
     }
 
@@ -190,6 +195,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=6
      */
     public <T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple6<T2, T3, T4, T5, T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6);
     }
 
@@ -198,6 +204,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      * j=7
      */
     public <T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple7<T2, T3, T4, T5, T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6, tuple._7);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple1.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple1.java
@@ -141,7 +141,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
         return List.of(_1);
     }
 
-    public <T2> Tuple2<T1, T2> concat(T2 t2) {
+    public <T2> Tuple2<T1, T2> append(T2 t2) {
         return Tuple.of(_1, t2);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple2.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple2.java
@@ -23,7 +23,6 @@ package io.vavr;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.control.HashCodes;

--- a/vavr/src-gen/main/java/io/vavr/Tuple2.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple2.java
@@ -247,6 +247,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     /**
      * Append a value to this tuple.
      *
+     * @param <T3> type of the value to append
      * @param t3 the value to append
      * @return a new Tuple with the value appended
      */
@@ -257,6 +258,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T3> the type of the 3rd value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -269,6 +271,8 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -281,6 +285,9 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -293,6 +300,10 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -305,6 +316,11 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -317,6 +333,12 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T3> the type of the 3rd value in the tuple
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
+     * @param <T8> the type of the 8th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null

--- a/vavr/src-gen/main/java/io/vavr/Tuple2.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple2.java
@@ -244,13 +244,22 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
         return List.of(_1, _2);
     }
 
+    /**
+     * Append a value to this tuple.
+     *
+     * @param t3 the value to append
+     * @return a new Tuple with the value appended
+     */
     public <T3> Tuple3<T1, T2, T3> append(T3 t3) {
         return Tuple.of(_1, _2, t3);
     }
 
     /**
-     * i=2
-     * j=1
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T3> Tuple3<T1, T2, T3> concat(Tuple1<T3> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -258,8 +267,11 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     }
 
     /**
-     * i=2
-     * j=2
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T3, T4> Tuple4<T1, T2, T3, T4> concat(Tuple2<T3, T4> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -267,8 +279,11 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     }
 
     /**
-     * i=2
-     * j=3
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple3<T3, T4, T5> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -276,8 +291,11 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     }
 
     /**
-     * i=2
-     * j=4
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple4<T3, T4, T5, T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -285,8 +303,11 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     }
 
     /**
-     * i=2
-     * j=5
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple5<T3, T4, T5, T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -294,8 +315,11 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     }
 
     /**
-     * i=2
-     * j=6
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple6<T3, T4, T5, T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");

--- a/vavr/src-gen/main/java/io/vavr/Tuple2.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple2.java
@@ -253,6 +253,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=1
      */
     public <T3> Tuple3<T1, T2, T3> concat(Tuple1<T3> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1);
     }
 
@@ -261,6 +262,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=2
      */
     public <T3, T4> Tuple4<T1, T2, T3, T4> concat(Tuple2<T3, T4> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1, tuple._2);
     }
 
@@ -269,6 +271,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=3
      */
     public <T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple3<T3, T4, T5> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3);
     }
 
@@ -277,6 +280,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=4
      */
     public <T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple4<T3, T4, T5, T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4);
     }
 
@@ -285,6 +289,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=5
      */
     public <T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple5<T3, T4, T5, T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
     }
 
@@ -293,6 +298,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=6
      */
     public <T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple6<T3, T4, T5, T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple2.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple2.java
@@ -245,6 +245,65 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
         return List.of(_1, _2);
     }
 
+    public <T3> Tuple3<T1, T2, T3> concat(T3 t3) {
+        Objects.requireNonNull(t3, "t3 is null");
+        return Tuple.of(_1, _2, t3);
+    }
+
+    /**
+     * i=2
+     * j=1
+     */
+    public <T3> Tuple3<T1, T2, T3> concat(Tuple1<T3> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, tuple._1);
+    }
+
+    /**
+     * i=2
+     * j=2
+     */
+    public <T3, T4> Tuple4<T1, T2, T3, T4> concat(Tuple2<T3, T4> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, tuple._1, tuple._2);
+    }
+
+    /**
+     * i=2
+     * j=3
+     */
+    public <T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple3<T3, T4, T5> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3);
+    }
+
+    /**
+     * i=2
+     * j=4
+     */
+    public <T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple4<T3, T4, T5, T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4);
+    }
+
+    /**
+     * i=2
+     * j=5
+     */
+    public <T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple5<T3, T4, T5, T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
+    }
+
+    /**
+     * i=2
+     * j=6
+     */
+    public <T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple6<T3, T4, T5, T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6);
+    }
+
     // -- Object
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Tuple2.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple2.java
@@ -244,7 +244,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
         return List.of(_1, _2);
     }
 
-    public <T3> Tuple3<T1, T2, T3> concat(T3 t3) {
+    public <T3> Tuple3<T1, T2, T3> append(T3 t3) {
         return Tuple.of(_1, _2, t3);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple2.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple2.java
@@ -246,7 +246,6 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     }
 
     public <T3> Tuple3<T1, T2, T3> concat(T3 t3) {
-        Objects.requireNonNull(t3, "t3 is null");
         return Tuple.of(_1, _2, t3);
     }
 
@@ -255,7 +254,6 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=1
      */
     public <T3> Tuple3<T1, T2, T3> concat(Tuple1<T3> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1);
     }
 
@@ -264,7 +262,6 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=2
      */
     public <T3, T4> Tuple4<T1, T2, T3, T4> concat(Tuple2<T3, T4> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1, tuple._2);
     }
 
@@ -273,7 +270,6 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=3
      */
     public <T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple3<T3, T4, T5> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3);
     }
 
@@ -282,7 +278,6 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=4
      */
     public <T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple4<T3, T4, T5, T6> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4);
     }
 
@@ -291,7 +286,6 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=5
      */
     public <T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple5<T3, T4, T5, T6, T7> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
     }
 
@@ -300,7 +294,6 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * j=6
      */
     public <T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple6<T3, T4, T5, T6, T7, T8> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple3.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple3.java
@@ -23,7 +23,6 @@ package io.vavr;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.control.HashCodes;

--- a/vavr/src-gen/main/java/io/vavr/Tuple3.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple3.java
@@ -277,7 +277,6 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     }
 
     public <T4> Tuple4<T1, T2, T3, T4> concat(T4 t4) {
-        Objects.requireNonNull(t4, "t4 is null");
         return Tuple.of(_1, _2, _3, t4);
     }
 
@@ -286,7 +285,6 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * j=1
      */
     public <T4> Tuple4<T1, T2, T3, T4> concat(Tuple1<T4> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, tuple._1);
     }
 
@@ -295,7 +293,6 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * j=2
      */
     public <T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple2<T4, T5> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, tuple._1, tuple._2);
     }
 
@@ -304,7 +301,6 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * j=3
      */
     public <T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple3<T4, T5, T6> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3);
     }
 
@@ -313,7 +309,6 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * j=4
      */
     public <T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple4<T4, T5, T6, T7> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3, tuple._4);
     }
 
@@ -322,7 +317,6 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * j=5
      */
     public <T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple5<T4, T5, T6, T7, T8> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple3.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple3.java
@@ -278,6 +278,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     /**
      * Append a value to this tuple.
      *
+     * @param <T4> type of the value to append
      * @param t4 the value to append
      * @return a new Tuple with the value appended
      */
@@ -288,6 +289,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T4> the type of the 4th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -300,6 +302,8 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -312,6 +316,9 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -324,6 +331,10 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -336,6 +347,11 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T4> the type of the 4th value in the tuple
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
+     * @param <T8> the type of the 8th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null

--- a/vavr/src-gen/main/java/io/vavr/Tuple3.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple3.java
@@ -276,6 +276,56 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
         return List.of(_1, _2, _3);
     }
 
+    public <T4> Tuple4<T1, T2, T3, T4> concat(T4 t4) {
+        Objects.requireNonNull(t4, "t4 is null");
+        return Tuple.of(_1, _2, _3, t4);
+    }
+
+    /**
+     * i=3
+     * j=1
+     */
+    public <T4> Tuple4<T1, T2, T3, T4> concat(Tuple1<T4> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, tuple._1);
+    }
+
+    /**
+     * i=3
+     * j=2
+     */
+    public <T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple2<T4, T5> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, tuple._1, tuple._2);
+    }
+
+    /**
+     * i=3
+     * j=3
+     */
+    public <T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple3<T4, T5, T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3);
+    }
+
+    /**
+     * i=3
+     * j=4
+     */
+    public <T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple4<T4, T5, T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3, tuple._4);
+    }
+
+    /**
+     * i=3
+     * j=5
+     */
+    public <T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple5<T4, T5, T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
+    }
+
     // -- Object
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Tuple3.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple3.java
@@ -275,13 +275,22 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
         return List.of(_1, _2, _3);
     }
 
+    /**
+     * Append a value to this tuple.
+     *
+     * @param t4 the value to append
+     * @return a new Tuple with the value appended
+     */
     public <T4> Tuple4<T1, T2, T3, T4> append(T4 t4) {
         return Tuple.of(_1, _2, _3, t4);
     }
 
     /**
-     * i=3
-     * j=1
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T4> Tuple4<T1, T2, T3, T4> concat(Tuple1<T4> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -289,8 +298,11 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     }
 
     /**
-     * i=3
-     * j=2
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple2<T4, T5> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -298,8 +310,11 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     }
 
     /**
-     * i=3
-     * j=3
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple3<T4, T5, T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -307,8 +322,11 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     }
 
     /**
-     * i=3
-     * j=4
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple4<T4, T5, T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -316,8 +334,11 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     }
 
     /**
-     * i=3
-     * j=5
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple5<T4, T5, T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");

--- a/vavr/src-gen/main/java/io/vavr/Tuple3.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple3.java
@@ -275,7 +275,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
         return List.of(_1, _2, _3);
     }
 
-    public <T4> Tuple4<T1, T2, T3, T4> concat(T4 t4) {
+    public <T4> Tuple4<T1, T2, T3, T4> append(T4 t4) {
         return Tuple.of(_1, _2, _3, t4);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple3.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple3.java
@@ -284,6 +284,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * j=1
      */
     public <T4> Tuple4<T1, T2, T3, T4> concat(Tuple1<T4> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, tuple._1);
     }
 
@@ -292,6 +293,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * j=2
      */
     public <T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple2<T4, T5> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, tuple._1, tuple._2);
     }
 
@@ -300,6 +302,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * j=3
      */
     public <T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple3<T4, T5, T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3);
     }
 
@@ -308,6 +311,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * j=4
      */
     public <T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple4<T4, T5, T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3, tuple._4);
     }
 
@@ -316,6 +320,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * j=5
      */
     public <T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple5<T4, T5, T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple4.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple4.java
@@ -23,7 +23,6 @@ package io.vavr;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.control.HashCodes;

--- a/vavr/src-gen/main/java/io/vavr/Tuple4.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple4.java
@@ -329,13 +329,22 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
         return List.of(_1, _2, _3, _4);
     }
 
+    /**
+     * Append a value to this tuple.
+     *
+     * @param t5 the value to append
+     * @return a new Tuple with the value appended
+     */
     public <T5> Tuple5<T1, T2, T3, T4, T5> append(T5 t5) {
         return Tuple.of(_1, _2, _3, _4, t5);
     }
 
     /**
-     * i=4
-     * j=1
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple1<T5> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -343,8 +352,11 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     }
 
     /**
-     * i=4
-     * j=2
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple2<T5, T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -352,8 +364,11 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     }
 
     /**
-     * i=4
-     * j=3
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple3<T5, T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -361,8 +376,11 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     }
 
     /**
-     * i=4
-     * j=4
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple4<T5, T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");

--- a/vavr/src-gen/main/java/io/vavr/Tuple4.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple4.java
@@ -329,7 +329,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
         return List.of(_1, _2, _3, _4);
     }
 
-    public <T5> Tuple5<T1, T2, T3, T4, T5> concat(T5 t5) {
+    public <T5> Tuple5<T1, T2, T3, T4, T5> append(T5 t5) {
         return Tuple.of(_1, _2, _3, _4, t5);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple4.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple4.java
@@ -330,6 +330,47 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
         return List.of(_1, _2, _3, _4);
     }
 
+    public <T5> Tuple5<T1, T2, T3, T4, T5> concat(T5 t5) {
+        Objects.requireNonNull(t5, "t5 is null");
+        return Tuple.of(_1, _2, _3, _4, t5);
+    }
+
+    /**
+     * i=4
+     * j=1
+     */
+    public <T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple1<T5> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, _4, tuple._1);
+    }
+
+    /**
+     * i=4
+     * j=2
+     */
+    public <T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple2<T5, T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2);
+    }
+
+    /**
+     * i=4
+     * j=3
+     */
+    public <T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple3<T5, T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2, tuple._3);
+    }
+
+    /**
+     * i=4
+     * j=4
+     */
+    public <T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple4<T5, T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2, tuple._3, tuple._4);
+    }
+
     // -- Object
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Tuple4.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple4.java
@@ -338,6 +338,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * j=1
      */
     public <T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple1<T5> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, tuple._1);
     }
 
@@ -346,6 +347,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * j=2
      */
     public <T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple2<T5, T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2);
     }
 
@@ -354,6 +356,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * j=3
      */
     public <T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple3<T5, T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2, tuple._3);
     }
 
@@ -362,6 +365,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * j=4
      */
     public <T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple4<T5, T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2, tuple._3, tuple._4);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple4.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple4.java
@@ -331,7 +331,6 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     }
 
     public <T5> Tuple5<T1, T2, T3, T4, T5> concat(T5 t5) {
-        Objects.requireNonNull(t5, "t5 is null");
         return Tuple.of(_1, _2, _3, _4, t5);
     }
 
@@ -340,7 +339,6 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * j=1
      */
     public <T5> Tuple5<T1, T2, T3, T4, T5> concat(Tuple1<T5> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, tuple._1);
     }
 
@@ -349,7 +347,6 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * j=2
      */
     public <T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple2<T5, T6> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2);
     }
 
@@ -358,7 +355,6 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * j=3
      */
     public <T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple3<T5, T6, T7> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2, tuple._3);
     }
 
@@ -367,7 +363,6 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * j=4
      */
     public <T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple4<T5, T6, T7, T8> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2, tuple._3, tuple._4);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple4.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple4.java
@@ -332,6 +332,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     /**
      * Append a value to this tuple.
      *
+     * @param <T5> type of the value to append
      * @param t5 the value to append
      * @return a new Tuple with the value appended
      */
@@ -342,6 +343,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T5> the type of the 5th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -354,6 +356,8 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -366,6 +370,9 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -378,6 +385,10 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T5> the type of the 5th value in the tuple
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
+     * @param <T8> the type of the 8th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null

--- a/vavr/src-gen/main/java/io/vavr/Tuple5.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple5.java
@@ -23,7 +23,6 @@ package io.vavr;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.control.HashCodes;

--- a/vavr/src-gen/main/java/io/vavr/Tuple5.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple5.java
@@ -384,6 +384,38 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
         return List.of(_1, _2, _3, _4, _5);
     }
 
+    public <T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(T6 t6) {
+        Objects.requireNonNull(t6, "t6 is null");
+        return Tuple.of(_1, _2, _3, _4, _5, t6);
+    }
+
+    /**
+     * i=5
+     * j=1
+     */
+    public <T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple1<T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, _4, _5, tuple._1);
+    }
+
+    /**
+     * i=5
+     * j=2
+     */
+    public <T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple2<T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, _4, _5, tuple._1, tuple._2);
+    }
+
+    /**
+     * i=5
+     * j=3
+     */
+    public <T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple3<T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, _4, _5, tuple._1, tuple._2, tuple._3);
+    }
+
     // -- Object
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Tuple5.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple5.java
@@ -385,7 +385,6 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     }
 
     public <T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(T6 t6) {
-        Objects.requireNonNull(t6, "t6 is null");
         return Tuple.of(_1, _2, _3, _4, _5, t6);
     }
 
@@ -394,7 +393,6 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * j=1
      */
     public <T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple1<T6> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, tuple._1);
     }
 
@@ -403,7 +401,6 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * j=2
      */
     public <T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple2<T6, T7> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, tuple._1, tuple._2);
     }
 
@@ -412,7 +409,6 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * j=3
      */
     public <T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple3<T6, T7, T8> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, tuple._1, tuple._2, tuple._3);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple5.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple5.java
@@ -383,7 +383,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
         return List.of(_1, _2, _3, _4, _5);
     }
 
-    public <T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(T6 t6) {
+    public <T6> Tuple6<T1, T2, T3, T4, T5, T6> append(T6 t6) {
         return Tuple.of(_1, _2, _3, _4, _5, t6);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple5.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple5.java
@@ -383,13 +383,22 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
         return List.of(_1, _2, _3, _4, _5);
     }
 
+    /**
+     * Append a value to this tuple.
+     *
+     * @param t6 the value to append
+     * @return a new Tuple with the value appended
+     */
     public <T6> Tuple6<T1, T2, T3, T4, T5, T6> append(T6 t6) {
         return Tuple.of(_1, _2, _3, _4, _5, t6);
     }
 
     /**
-     * i=5
-     * j=1
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple1<T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -397,8 +406,11 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     }
 
     /**
-     * i=5
-     * j=2
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple2<T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -406,8 +418,11 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     }
 
     /**
-     * i=5
-     * j=3
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple3<T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");

--- a/vavr/src-gen/main/java/io/vavr/Tuple5.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple5.java
@@ -392,6 +392,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * j=1
      */
     public <T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(Tuple1<T6> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, tuple._1);
     }
 
@@ -400,6 +401,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * j=2
      */
     public <T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple2<T6, T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, tuple._1, tuple._2);
     }
 
@@ -408,6 +410,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * j=3
      */
     public <T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple3<T6, T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, tuple._1, tuple._2, tuple._3);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple5.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple5.java
@@ -386,6 +386,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     /**
      * Append a value to this tuple.
      *
+     * @param <T6> type of the value to append
      * @param t6 the value to append
      * @return a new Tuple with the value appended
      */
@@ -396,6 +397,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T6> the type of the 6th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -408,6 +410,8 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -420,6 +424,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T6> the type of the 6th value in the tuple
+     * @param <T7> the type of the 7th value in the tuple
+     * @param <T8> the type of the 8th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null

--- a/vavr/src-gen/main/java/io/vavr/Tuple6.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple6.java
@@ -23,7 +23,6 @@ package io.vavr;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.control.HashCodes;

--- a/vavr/src-gen/main/java/io/vavr/Tuple6.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple6.java
@@ -439,7 +439,6 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
     }
 
     public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(T7 t7) {
-        Objects.requireNonNull(t7, "t7 is null");
         return Tuple.of(_1, _2, _3, _4, _5, _6, t7);
     }
 
@@ -448,7 +447,6 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * j=1
      */
     public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple1<T7> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, _6, tuple._1);
     }
 
@@ -457,7 +455,6 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * j=2
      */
     public <T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple2<T7, T8> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, _6, tuple._1, tuple._2);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple6.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple6.java
@@ -440,6 +440,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
     /**
      * Append a value to this tuple.
      *
+     * @param <T7> type of the value to append
      * @param t7 the value to append
      * @return a new Tuple with the value appended
      */
@@ -450,6 +451,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T7> the type of the 7th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null
@@ -462,6 +464,8 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T7> the type of the 7th value in the tuple
+     * @param <T8> the type of the 8th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null

--- a/vavr/src-gen/main/java/io/vavr/Tuple6.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple6.java
@@ -446,6 +446,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * j=1
      */
     public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple1<T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, _6, tuple._1);
     }
 
@@ -454,6 +455,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * j=2
      */
     public <T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple2<T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, _6, tuple._1, tuple._2);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple6.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple6.java
@@ -437,13 +437,22 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
         return List.of(_1, _2, _3, _4, _5, _6);
     }
 
+    /**
+     * Append a value to this tuple.
+     *
+     * @param t7 the value to append
+     * @return a new Tuple with the value appended
+     */
     public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> append(T7 t7) {
         return Tuple.of(_1, _2, _3, _4, _5, _6, t7);
     }
 
     /**
-     * i=6
-     * j=1
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple1<T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
@@ -451,8 +460,11 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
     }
 
     /**
-     * i=6
-     * j=2
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple2<T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");

--- a/vavr/src-gen/main/java/io/vavr/Tuple6.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple6.java
@@ -438,6 +438,29 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
         return List.of(_1, _2, _3, _4, _5, _6);
     }
 
+    public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(T7 t7) {
+        Objects.requireNonNull(t7, "t7 is null");
+        return Tuple.of(_1, _2, _3, _4, _5, _6, t7);
+    }
+
+    /**
+     * i=6
+     * j=1
+     */
+    public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(Tuple1<T7> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, _4, _5, _6, tuple._1);
+    }
+
+    /**
+     * i=6
+     * j=2
+     */
+    public <T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple2<T7, T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, _4, _5, _6, tuple._1, tuple._2);
+    }
+
     // -- Object
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Tuple6.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple6.java
@@ -437,7 +437,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
         return List.of(_1, _2, _3, _4, _5, _6);
     }
 
-    public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(T7 t7) {
+    public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> append(T7 t7) {
         return Tuple.of(_1, _2, _3, _4, _5, _6, t7);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple7.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple7.java
@@ -23,7 +23,6 @@ package io.vavr;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.control.HashCodes;

--- a/vavr/src-gen/main/java/io/vavr/Tuple7.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple7.java
@@ -500,6 +500,7 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * j=1
      */
     public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple1<T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, _6, _7, tuple._1);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple7.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple7.java
@@ -494,6 +494,7 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
     /**
      * Append a value to this tuple.
      *
+     * @param <T8> type of the value to append
      * @param t8 the value to append
      * @return a new Tuple with the value appended
      */
@@ -504,6 +505,7 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
     /**
      * Concat a tuple's values to this tuple.
      *
+     * @param <T8> the type of the 8th value in the tuple
      * @param tuple the tuple to concat
      * @return a new Tuple with the tuple values appended
      * @throws NullPointerException if {@code tuple} is null

--- a/vavr/src-gen/main/java/io/vavr/Tuple7.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple7.java
@@ -491,13 +491,22 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
         return List.of(_1, _2, _3, _4, _5, _6, _7);
     }
 
+    /**
+     * Append a value to this tuple.
+     *
+     * @param t8 the value to append
+     * @return a new Tuple with the value appended
+     */
     public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> append(T8 t8) {
         return Tuple.of(_1, _2, _3, _4, _5, _6, _7, t8);
     }
 
     /**
-     * i=7
-     * j=1
+     * Concat a tuple's values to this tuple.
+     *
+     * @param tuple the tuple to concat
+     * @return a new Tuple with the tuple values appended
+     * @throws NullPointerException if {@code tuple} is null
      */
     public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple1<T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");

--- a/vavr/src-gen/main/java/io/vavr/Tuple7.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple7.java
@@ -491,7 +491,7 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
         return List.of(_1, _2, _3, _4, _5, _6, _7);
     }
 
-    public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(T8 t8) {
+    public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> append(T8 t8) {
         return Tuple.of(_1, _2, _3, _4, _5, _6, _7, t8);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple7.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple7.java
@@ -493,7 +493,6 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
     }
 
     public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(T8 t8) {
-        Objects.requireNonNull(t8, "t8 is null");
         return Tuple.of(_1, _2, _3, _4, _5, _6, _7, t8);
     }
 
@@ -502,7 +501,6 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * j=1
      */
     public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple1<T8> tuple) {
-        Objects.requireNonNull(tuple, "tuple is null");
         return Tuple.of(_1, _2, _3, _4, _5, _6, _7, tuple._1);
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple7.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple7.java
@@ -492,6 +492,20 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
         return List.of(_1, _2, _3, _4, _5, _6, _7);
     }
 
+    public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(T8 t8) {
+        Objects.requireNonNull(t8, "t8 is null");
+        return Tuple.of(_1, _2, _3, _4, _5, _6, _7, t8);
+    }
+
+    /**
+     * i=7
+     * j=1
+     */
+    public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(Tuple1<T8> tuple) {
+        Objects.requireNonNull(tuple, "tuple is null");
+        return Tuple.of(_1, _2, _3, _4, _5, _6, _7, tuple._1);
+    }
+
     // -- Object
 
     @Override

--- a/vavr/src-gen/main/java/io/vavr/Tuple8.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple8.java
@@ -23,7 +23,6 @@ package io.vavr;
    G E N E R A T O R   C R A F T E D
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.control.HashCodes;

--- a/vavr/src-gen/test/java/io/vavr/Tuple0Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple0Test.java
@@ -73,6 +73,62 @@ public class Tuple0Test {
     }
 
     @Test
+    public void shouldConcatTuple1() {
+        final Tuple1<Integer> actual = Tuple0.instance().concat(Tuple.of(1));
+        final Tuple1<Integer> expected = Tuple.of(1);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple2() {
+        final Tuple2<Integer, Integer> actual = Tuple0.instance().concat(Tuple.of(1, 2));
+        final Tuple2<Integer, Integer> expected = Tuple.of(1, 2);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple3() {
+        final Tuple3<Integer, Integer, Integer> actual = Tuple0.instance().concat(Tuple.of(1, 2, 3));
+        final Tuple3<Integer, Integer, Integer> expected = Tuple.of(1, 2, 3);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple4() {
+        final Tuple4<Integer, Integer, Integer, Integer> actual = Tuple0.instance().concat(Tuple.of(1, 2, 3, 4));
+        final Tuple4<Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple5() {
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> actual = Tuple0.instance().concat(Tuple.of(1, 2, 3, 4, 5));
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple6() {
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple0.instance().concat(Tuple.of(1, 2, 3, 4, 5, 6));
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple7() {
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple0.instance().concat(Tuple.of(1, 2, 3, 4, 5, 6, 7));
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple8() {
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple0.instance().concat(Tuple.of(1, 2, 3, 4, 5, 6, 7, 8));
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7, 8);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple0 tuple1 = createTuple();
         final Tuple0 tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple0Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple0Test.java
@@ -66,6 +66,13 @@ public class Tuple0Test {
     }
 
     @Test
+    public void shouldAppendValue() {
+        final Tuple1<Integer> actual = Tuple0.instance().append(1);
+        final Tuple1<Integer> expected = Tuple.of(1);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple0 tuple1 = createTuple();
         final Tuple0 tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple1Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple1Test.java
@@ -118,6 +118,55 @@ public class Tuple1Test {
     }
 
     @Test
+    public void shouldConcatTuple1() {
+        final Tuple2<Integer, Integer> actual = Tuple.of(1).concat(Tuple.of(2));
+        final Tuple2<Integer, Integer> expected = Tuple.of(1, 2);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple2() {
+        final Tuple3<Integer, Integer, Integer> actual = Tuple.of(1).concat(Tuple.of(2, 3));
+        final Tuple3<Integer, Integer, Integer> expected = Tuple.of(1, 2, 3);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple3() {
+        final Tuple4<Integer, Integer, Integer, Integer> actual = Tuple.of(1).concat(Tuple.of(2, 3, 4));
+        final Tuple4<Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple4() {
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1).concat(Tuple.of(2, 3, 4, 5));
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple5() {
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1).concat(Tuple.of(2, 3, 4, 5, 6));
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple6() {
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1).concat(Tuple.of(2, 3, 4, 5, 6, 7));
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple7() {
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1).concat(Tuple.of(2, 3, 4, 5, 6, 7, 8));
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7, 8);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple1<Object> tuple1 = createTuple();
         final Tuple1<Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple1Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple1Test.java
@@ -111,6 +111,13 @@ public class Tuple1Test {
     }
 
     @Test
+    public void shouldAppendValue() {
+        final Tuple2<Integer, Integer> actual = Tuple.of(1).append(2);
+        final Tuple2<Integer, Integer> expected = Tuple.of(1, 2);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple1<Object> tuple1 = createTuple();
         final Tuple1<Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple2Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple2Test.java
@@ -173,6 +173,48 @@ public class Tuple2Test {
     }
 
     @Test
+    public void shouldConcatTuple1() {
+        final Tuple3<Integer, Integer, Integer> actual = Tuple.of(1, 2).concat(Tuple.of(3));
+        final Tuple3<Integer, Integer, Integer> expected = Tuple.of(1, 2, 3);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple2() {
+        final Tuple4<Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2).concat(Tuple.of(3, 4));
+        final Tuple4<Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple3() {
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2).concat(Tuple.of(3, 4, 5));
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple4() {
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2).concat(Tuple.of(3, 4, 5, 6));
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple5() {
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2).concat(Tuple.of(3, 4, 5, 6, 7));
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple6() {
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2).concat(Tuple.of(3, 4, 5, 6, 7, 8));
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7, 8);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple2<Object, Object> tuple1 = createTuple();
         final Tuple2<Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple2Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple2Test.java
@@ -166,6 +166,13 @@ public class Tuple2Test {
     }
 
     @Test
+    public void shouldAppendValue() {
+        final Tuple3<Integer, Integer, Integer> actual = Tuple.of(1, 2).append(3);
+        final Tuple3<Integer, Integer, Integer> expected = Tuple.of(1, 2, 3);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple2<Object, Object> tuple1 = createTuple();
         final Tuple2<Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple3Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple3Test.java
@@ -181,6 +181,13 @@ public class Tuple3Test {
     }
 
     @Test
+    public void shouldAppendValue() {
+        final Tuple4<Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3).append(4);
+        final Tuple4<Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple3<Object, Object, Object> tuple1 = createTuple();
         final Tuple3<Object, Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple3Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple3Test.java
@@ -188,6 +188,41 @@ public class Tuple3Test {
     }
 
     @Test
+    public void shouldConcatTuple1() {
+        final Tuple4<Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3).concat(Tuple.of(4));
+        final Tuple4<Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple2() {
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3).concat(Tuple.of(4, 5));
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple3() {
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3).concat(Tuple.of(4, 5, 6));
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple4() {
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3).concat(Tuple.of(4, 5, 6, 7));
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple5() {
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3).concat(Tuple.of(4, 5, 6, 7, 8));
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7, 8);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple3<Object, Object, Object> tuple1 = createTuple();
         final Tuple3<Object, Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple4Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple4Test.java
@@ -212,6 +212,13 @@ public class Tuple4Test {
     }
 
     @Test
+    public void shouldAppendValue() {
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4).append(5);
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple4<Object, Object, Object, Object> tuple1 = createTuple();
         final Tuple4<Object, Object, Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple4Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple4Test.java
@@ -219,6 +219,34 @@ public class Tuple4Test {
     }
 
     @Test
+    public void shouldConcatTuple1() {
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4).concat(Tuple.of(5));
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple2() {
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4).concat(Tuple.of(5, 6));
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple3() {
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4).concat(Tuple.of(5, 6, 7));
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple4() {
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4).concat(Tuple.of(5, 6, 7, 8));
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7, 8);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple4<Object, Object, Object, Object> tuple1 = createTuple();
         final Tuple4<Object, Object, Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple5Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple5Test.java
@@ -245,6 +245,13 @@ public class Tuple5Test {
     }
 
     @Test
+    public void shouldAppendValue() {
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5).append(6);
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple5<Object, Object, Object, Object, Object> tuple1 = createTuple();
         final Tuple5<Object, Object, Object, Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple5Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple5Test.java
@@ -252,6 +252,27 @@ public class Tuple5Test {
     }
 
     @Test
+    public void shouldConcatTuple1() {
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5).concat(Tuple.of(6));
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple2() {
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5).concat(Tuple.of(6, 7));
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple3() {
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5).concat(Tuple.of(6, 7, 8));
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7, 8);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple5<Object, Object, Object, Object, Object> tuple1 = createTuple();
         final Tuple5<Object, Object, Object, Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple6Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple6Test.java
@@ -280,6 +280,13 @@ public class Tuple6Test {
     }
 
     @Test
+    public void shouldAppendValue() {
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5, 6).append(7);
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple6<Object, Object, Object, Object, Object, Object> tuple1 = createTuple();
         final Tuple6<Object, Object, Object, Object, Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple6Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple6Test.java
@@ -287,6 +287,20 @@ public class Tuple6Test {
     }
 
     @Test
+    public void shouldConcatTuple1() {
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5, 6).concat(Tuple.of(7));
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldConcatTuple2() {
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5, 6).concat(Tuple.of(7, 8));
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7, 8);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple6<Object, Object, Object, Object, Object, Object> tuple1 = createTuple();
         final Tuple6<Object, Object, Object, Object, Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple7Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple7Test.java
@@ -317,6 +317,13 @@ public class Tuple7Test {
     }
 
     @Test
+    public void shouldAppendValue() {
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5, 6, 7).append(8);
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7, 8);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple7<Object, Object, Object, Object, Object, Object, Object> tuple1 = createTuple();
         final Tuple7<Object, Object, Object, Object, Object, Object, Object> tuple2 = createTuple();

--- a/vavr/src-gen/test/java/io/vavr/Tuple7Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple7Test.java
@@ -324,6 +324,13 @@ public class Tuple7Test {
     }
 
     @Test
+    public void shouldConcatTuple1() {
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5, 6, 7).concat(Tuple.of(8));
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7, 8);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldRecognizeEquality() {
         final Tuple7<Object, Object, Object, Object, Object, Object, Object> tuple1 = createTuple();
         final Tuple7<Object, Object, Object, Object, Object, Object, Object> tuple2 = createTuple();


### PR DESCRIPTION
Updates the `Generator.scala` script to auto-generate the `concat` methods for the various Tuple classes for #2215.

This is the first stab at it. It's not perfect but I wanted to get some early feedback before I went further. Might be easier if you just checkout the branch and run the scrip to see the output. Below is a quick summary of what is done though.

What's done:
* `Tuple0` has a `concat(T1 t1)` method
* `Tuple1-Tuple7` have the following methods:
  * `concat(TN tn)`
  * multiple `concat(TupleN tuple)` methods

What's left:
* Need to finish adding the various `concat(TupleN tuple)` methods to `Tuple0`.
* Need javadocs on each method
* Tests