### PR TITLE
Fix bug in LinkedHashMap#ofEntries(): list of tuples in some case can contains more elements that contains map itself

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -141,7 +141,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(Tuple2<? extends K, ? extends V> entry) {
         final HashMap<K, V> map = HashMap.of(entry);
         final Queue<Tuple2<K, V>> list = Queue.of((Tuple2<K, V>) entry);
-        return new LinkedHashMap<>(list, map);
+        return wrap(list, map);
     }
 
     /**
@@ -205,7 +205,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K key, V value) {
         final HashMap<K, V> map = HashMap.of(key, value);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(key, value));
-        return new LinkedHashMap<>(list, map);
+        return wrap(list, map);
     }
 
     /**
@@ -222,7 +222,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2));
-        return new LinkedHashMap<>(list, map);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -241,7 +241,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3));
-        return new LinkedHashMap<>(list, map);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -262,7 +262,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4));
-        return new LinkedHashMap<>(list, map);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -285,7 +285,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5));
-        return new LinkedHashMap<>(list, map);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -310,7 +310,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5), Tuple.of(k6, v6));
-        return new LinkedHashMap<>(list, map);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -337,7 +337,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5), Tuple.of(k6, v6), Tuple.of(k7, v7));
-        return new LinkedHashMap<>(list, map);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -366,7 +366,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5), Tuple.of(k6, v6), Tuple.of(k7, v7), Tuple.of(k8, v8));
-        return new LinkedHashMap<>(list, map);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -397,7 +397,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5), Tuple.of(k6, v6), Tuple.of(k7, v7), Tuple.of(k8, v8), Tuple.of(k9, v9));
-        return new LinkedHashMap<>(list, map);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -430,7 +430,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
         final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5), Tuple.of(k6, v6), Tuple.of(k7, v7), Tuple.of(k8, v8), Tuple.of(k9, v9), Tuple.of(k10, v10));
-        return new LinkedHashMap<>(list, map);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -483,8 +483,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
             map = map.put(tuple);
             list = list.append(tuple);
         }
-        list = list.reverse().distinctBy(Tuple2::_1).reverse().toQueue();
-        return wrap(list, map);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -498,9 +497,8 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> LinkedHashMap<K, V> ofEntries(Tuple2<? extends K, ? extends V>... entries) {
         final HashMap<K, V> map = HashMap.ofEntries(entries);
-        Queue<Tuple2<K, V>> list = Queue.of((Tuple2<K, V>[]) entries);
-        list = list.reverse().distinctBy(Tuple2::_1).reverse().toQueue();
-        return wrap(list, map);
+        final Queue<Tuple2<K, V>> list = Queue.of((Tuple2<K, V>[]) entries);
+        return wrapNonUnique(list, map);
     }
 
     /**
@@ -523,8 +521,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
                 map = map.put(entry);
                 list = list.append((Tuple2<K, V>) entry);
             }
-            list = list.reverse().distinctBy(Tuple2::_1).reverse().toQueue();
-            return wrap(list, map);
+            return wrapNonUnique(list, map);
         }
     }
 
@@ -802,7 +799,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
             newList = list.append(Tuple.of(key, value));
         }
         final HashMap<K, V> newMap = map.put(key, value);
-        return new LinkedHashMap<>(newList, newMap);
+        return wrap(newList, newMap);
     }
 
     @Override
@@ -1022,8 +1019,30 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         return mkString(stringPrefix() + "(", ", ", ")");
     }
 
+    /**
+     * Construct Map with given values and key order.
+     *
+     * @param list The list of key-value tuples with unique keys.
+     * @param map  The map of key-value tuples.
+     * @param <K>  The key type
+     * @param <V>  The value type
+     * @return A new Map containing the given map with given key order
+     */
     private static <K, V> LinkedHashMap<K, V> wrap(Queue<Tuple2<K, V>> list, HashMap<K, V> map) {
         return list.isEmpty() ? empty() : new LinkedHashMap<>(list, map);
+    }
+
+    /**
+     * Construct Map with given values and key order.
+     *
+     * @param list The list of key-value tuples with non-unique keys.
+     * @param map  The map of key-value tuples.
+     * @param <K>  The key type
+     * @param <V>  The value type
+     * @return A new Map containing the given map with given key order
+     */
+    private static <K, V> LinkedHashMap<K, V> wrapNonUnique(Queue<Tuple2<K, V>> list, HashMap<K, V> map) {
+        return list.isEmpty() ? empty() : new LinkedHashMap<>(list.reverse().distinctBy(Tuple2::_1).reverse().toQueue(), map);
     }
 
     // We need this method to narrow the argument of `ofEntries`.

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -483,6 +483,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
             map = map.put(tuple);
             list = list.append(tuple);
         }
+        list = list.reverse().distinctBy(Tuple2::_1).reverse().toQueue();
         return wrap(list, map);
     }
 
@@ -497,7 +498,8 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> LinkedHashMap<K, V> ofEntries(Tuple2<? extends K, ? extends V>... entries) {
         final HashMap<K, V> map = HashMap.ofEntries(entries);
-        final Queue<Tuple2<K, V>> list = Queue.of((Tuple2<K, V>[]) entries);
+        Queue<Tuple2<K, V>> list = Queue.of((Tuple2<K, V>[]) entries);
+        list = list.reverse().distinctBy(Tuple2::_1).reverse().toQueue();
         return wrap(list, map);
     }
 
@@ -521,6 +523,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
                 map = map.put(entry);
                 list = list.append((Tuple2<K, V>) entry);
             }
+            list = list.reverse().distinctBy(Tuple2::_1).reverse().toQueue();
             return wrap(list, map);
         }
     }

--- a/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
@@ -159,6 +159,8 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
     @SuppressWarnings("unchecked")
     protected abstract <K extends Comparable<? super K>, V> Map<K, V> mapOfTuples(Tuple2<? extends K, ? extends V>... entries);
 
+    protected abstract <K extends Comparable<? super K>, V> Map<K, V> mapOfTuples(Iterable<? extends Tuple2<? extends K, ? extends V>> entries);
+
     @SuppressWarnings("unchecked")
     protected abstract <K extends Comparable<? super K>, V> Map<K, V> mapOfEntries(java.util.Map.Entry<? extends K, ? extends V>... entries);
 
@@ -1128,6 +1130,38 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
     public void mapOfEntriesShouldReturnTheSingletonEmpty() {
         if (!emptyMapShouldBeSingleton()) { return; }
         assertThat(mapOfEntries()).isSameAs(emptyMap());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mapOfEntriesShouldReplaceEntryByKey() {
+        assertThat(mapOfEntries(
+                asJavaEntry(1, "1"), asJavaEntry(1, "2"),
+                asJavaEntry(2, "3"), asJavaEntry(2, "4")
+        ))
+                .hasSize(2)
+                .isEqualTo(mapOf(1, "2", 2, "4"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void mapOfTuplesVarargShouldReplaceEntryByKey() {
+        assertThat(mapOfTuples(
+                Tuple.of(1, "1"), Tuple.of(1, "2"),
+                Tuple.of(2, "3"), Tuple.of(2, "4")
+        ))
+                .hasSize(2)
+                .isEqualTo(mapOf(1, "2", 2, "4"));
+    }
+
+    @Test
+    public void mapOfTuplesIterableShouldReplaceEntryByKey() {
+        assertThat(mapOfTuples(asList(
+                Tuple.of(1, "1"), Tuple.of(1, "2"),
+                Tuple.of(2, "3"), Tuple.of(2, "4")
+        )))
+                .hasSize(2)
+                .isEqualTo(mapOf(1, "2", 2, "4"));
     }
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/HashMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/HashMapTest.java
@@ -71,6 +71,11 @@ public class HashMapTest extends AbstractMapTest {
         return HashMap.ofEntries(entries);
     }
 
+    @Override
+    protected <K extends Comparable<? super K>, V> Map<K, V> mapOfTuples(Iterable<? extends Tuple2<? extends K, ? extends V>> entries) {
+        return HashMap.ofEntries(entries);
+    }
+
     @SuppressWarnings("varargs")
     @SafeVarargs
     @Override

--- a/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
@@ -52,6 +52,11 @@ public class LinkedHashMapTest extends AbstractMapTest {
         return LinkedHashMap.ofEntries(entries);
     }
 
+    @Override
+    protected <K extends Comparable<? super K>, V> Map<K, V> mapOfTuples(Iterable<? extends Tuple2<? extends K, ? extends V>> entries) {
+        return LinkedHashMap.ofEntries(entries);
+    }
+
     @SuppressWarnings("varargs")
     @SafeVarargs
     @Override

--- a/vavr/src/test/java/io/vavr/collection/TreeMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/TreeMapTest.java
@@ -88,6 +88,11 @@ public class TreeMapTest extends AbstractSortedMapTest {
         return TreeMap.ofEntries(entries);
     }
 
+    @Override
+    protected <K extends Comparable<? super K>, V> Map<K, V> mapOfTuples(Iterable<? extends Tuple2<? extends K, ? extends V>> entries) {
+        return TreeMap.ofEntries(entries);
+    }
+
     @SuppressWarnings("varargs")
     @SafeVarargs
     @Override


### PR DESCRIPTION
In method `LinkedHashMap#ofEntries` (all varians) `list` will contains all tuples from input, but input is client generated and may contain duplicate values for same key.
In this case map must use last value for this key (or throw exception at all), but currently we can build map like this: `LinkedHashMap((1, 1), (1, 2), (2, 3), (2, 4))`.

I fix this bug, but I don't like that i call to `Queue#reverse` twice :(
