### PR TITLE
Implement Traversable#fill(int, T) methods

### DIFF
--- a/vavr-benchmark/src/test/java/io/vavr/collection/ArrayBenchmark.java
+++ b/vavr-benchmark/src/test/java/io/vavr/collection/ArrayBenchmark.java
@@ -41,6 +41,7 @@ public class ArrayBenchmark {
             Prepend.class,
             Append.class,
             Iterate.class
+            , Fill.class
     );
 
     @Test
@@ -396,6 +397,24 @@ public class ArrayBenchmark {
             }
             assert aggregate == EXPECTED_AGGREGATE;
             return aggregate;
+        }
+    }
+
+    public static class Fill extends Base {
+        @Benchmark
+        public Object vavr_persistent_constant_supplier() {
+            final io.vavr.collection.Array<Integer> values = io.vavr.collection.Array.fill(CONTAINER_SIZE, () -> ELEMENTS[0]);
+            final Integer head = values.head();
+            assert Objects.equals(head, ELEMENTS[0]);
+            return head;
+        }
+
+        @Benchmark
+        public Object vavr_persistent_constant_object() {
+            final io.vavr.collection.Array<Integer> values = io.vavr.collection.Array.fill(CONTAINER_SIZE, ELEMENTS[0]);
+            final Integer head = values.head();
+            assert Objects.equals(head, ELEMENTS[0]);
+            return head;
         }
     }
 }

--- a/vavr-benchmark/src/test/java/io/vavr/collection/ListBenchmark.java
+++ b/vavr-benchmark/src/test/java/io/vavr/collection/ListBenchmark.java
@@ -45,6 +45,7 @@ public class ListBenchmark {
             Append.class,
             GroupBy.class,
             Iterate.class
+            , Fill.class
     );
 
     @Test
@@ -644,6 +645,32 @@ public class ListBenchmark {
             }
             assert aggregate == EXPECTED_AGGREGATE;
             return aggregate;
+        }
+    }
+
+    public static class Fill extends Base {
+        @Benchmark
+        public Object scala_persistent() {
+            final scala.collection.immutable.List<?> values = scala.collection.immutable.List$.MODULE$.fill(CONTAINER_SIZE, () -> ELEMENTS[0]);
+            final Object head = values.head();
+            assert Objects.equals(head, ELEMENTS[0]);
+            return head;
+        }
+
+        @Benchmark
+        public Object vavr_persistent_constant_supplier() {
+            final io.vavr.collection.List<Integer> values = io.vavr.collection.List.fill(CONTAINER_SIZE, () -> ELEMENTS[0]);
+            final Integer head = values.head();
+            assert Objects.equals(head, ELEMENTS[0]);
+            return head;
+        }
+
+        @Benchmark
+        public Object vavr_persistent_constant_object() {
+            final io.vavr.collection.List<Integer> values = io.vavr.collection.List.fill(CONTAINER_SIZE, ELEMENTS[0]);
+            final Integer head = values.head();
+            assert Objects.equals(head, ELEMENTS[0]);
+            return head;
         }
     }
 }

--- a/vavr-benchmark/src/test/java/io/vavr/collection/PriorityQueueBenchmark.java
+++ b/vavr-benchmark/src/test/java/io/vavr/collection/PriorityQueueBenchmark.java
@@ -31,6 +31,7 @@ import scalaz.Order;
 import scalaz.Order$;
 
 import java.util.Collections;
+import java.util.Objects;
 
 import static java.util.Arrays.asList;
 import static io.vavr.JmhRunner.create;
@@ -43,6 +44,7 @@ public class PriorityQueueBenchmark {
             Enqueue.class,
             Dequeue.class,
             Sort.class
+            , Fill.class
     );
 
     @Test
@@ -369,6 +371,24 @@ public class PriorityQueueBenchmark {
             }
             assert values.isEmpty() && (aggregate == EXPECTED_AGGREGATE);
             return values;
+        }
+    }
+
+    public static class Fill extends Base {
+        @Benchmark
+        public Object vavr_persistent_constant_supplier() {
+            final io.vavr.collection.PriorityQueue<Integer> values = io.vavr.collection.PriorityQueue.fill(CONTAINER_SIZE, () -> ELEMENTS[0]);
+            final Integer head = values.head();
+            assert Objects.equals(head, ELEMENTS[0]);
+            return head;
+        }
+
+        @Benchmark
+        public Object vavr_persistent_constant_object() {
+            final io.vavr.collection.PriorityQueue<Integer> values = io.vavr.collection.PriorityQueue.fill(CONTAINER_SIZE, ELEMENTS[0]);
+            final Integer head = values.head();
+            assert Objects.equals(head, ELEMENTS[0]);
+            return head;
         }
     }
 }

--- a/vavr-benchmark/src/test/java/io/vavr/collection/VectorBenchmark.java
+++ b/vavr-benchmark/src/test/java/io/vavr/collection/VectorBenchmark.java
@@ -60,6 +60,7 @@ public class VectorBenchmark {
             Slice.class,
             Sort.class,
             Iterate.class
+            , Fill.class
     );
 
     @Test
@@ -1035,6 +1036,32 @@ public class VectorBenchmark {
             });
             assert aggregate[0] == EXPECTED_AGGREGATE;
             return aggregate[0];
+        }
+    }
+
+    public static class Fill extends Base {
+        @Benchmark
+        public Object scala_persistent() {
+            final scala.collection.immutable.Vector<?> values = scala.collection.immutable.Vector$.MODULE$.fill(CONTAINER_SIZE, () -> ELEMENTS[0]);
+            final Object head = values.head();
+            assert Objects.equals(head, ELEMENTS[0]);
+            return head;
+        }
+
+        @Benchmark
+        public Object vavr_persistent_constant_supplier() {
+            final io.vavr.collection.Vector<Integer> values = io.vavr.collection.Vector.fill(CONTAINER_SIZE, () -> ELEMENTS[0]);
+            final Integer head = values.head();
+            assert Objects.equals(head, ELEMENTS[0]);
+            return head;
+        }
+
+        @Benchmark
+        public Object vavr_persistent_constant_object() {
+            final io.vavr.collection.Vector<Integer> values = io.vavr.collection.Vector.fill(CONTAINER_SIZE, ELEMENTS[0]);
+            final Integer head = values.head();
+            assert Objects.equals(head, ELEMENTS[0]);
+            return head;
         }
     }
 }

--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -273,6 +273,18 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
         return io.vavr.collection.Collections.fill(n, s, empty(), Array::of);
     }
 
+    /**
+     * Returns an Array containing {@code n} times the given {@code element}
+     *
+     * @param <T>     Component type of the Array
+     * @param n       The number of elements in the Array
+     * @param element The element
+     * @return An Array of size {@code n}, where each element is the given {@code element}.
+     */
+    public static <T> Array<T> fill(int n, T element) {
+        return io.vavr.collection.Collections.fillObject(n, element, empty(), Array::of);
+    }
+
     public static Array<Character> range(char from, char toExclusive) {
         return ofAll(Iterator.range(from, toExclusive));
     }

--- a/vavr/src/main/java/io/vavr/collection/Collections.java
+++ b/vavr/src/main/java/io/vavr/collection/Collections.java
@@ -170,11 +170,32 @@ final class Collections {
         return tabulate(n, ignored -> supplier.get());
     }
 
+    static <T> Iterator<T> fillObject(int n, T element) {
+        if (n <= 0) {
+            return Iterator.empty();
+        } else {
+            return Iterator.continually(element).take(n);
+        }
+    }
+
     static <C extends Traversable<T>, T> C fill(int n, Supplier<? extends T> s, C empty, Function<T[], C> of) {
         Objects.requireNonNull(s, "s is null");
         Objects.requireNonNull(empty, "empty is null");
         Objects.requireNonNull(of, "of is null");
         return tabulate(n, anything -> s.get(), empty, of);
+    }
+
+    static <C extends Traversable<T>, T> C fillObject(int n, T element, C empty, Function<T[], C> of) {
+        Objects.requireNonNull(empty, "empty is null");
+        Objects.requireNonNull(of, "of is null");
+        if (n <= 0) {
+            return empty;
+        } else {
+            @SuppressWarnings("unchecked")
+            final T[] elements = (T[]) new Object[n];
+            Arrays.fill(elements, element);
+            return of.apply(elements);
+        }
     }
 
     static <T, C, R extends Iterable<T>> Map<C, R> groupBy(Traversable<T> source, Function<? super T, ? extends C> classifier, Function<? super Iterable<T>, R> mapper) {

--- a/vavr/src/main/java/io/vavr/collection/HashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMap.java
@@ -428,7 +428,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     /**
-     * Returns an HashMap containing {@code n} values supplied by a given Supplier {@code s}.
+     * Returns a HashMap containing tuples returned by {@code n} calls to a given Supplier {@code s}.
      *
      * @param <K> The key type
      * @param <V> The value type

--- a/vavr/src/main/java/io/vavr/collection/HashMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMultimap.java
@@ -210,6 +210,20 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
         }
 
         /**
+         * Returns a HashMultimap containing {@code n} times the given {@code element}
+         *
+         * @param <K>     The key type
+         * @param <V2>    The value type
+         * @param n       The number of elements in the HashMultimap
+         * @param element The element
+         * @return A HashMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2}.
+         */
+        @SuppressWarnings("unchecked")
+        public <K, V2 extends V> HashMultimap<K, V2> fill(int n, Tuple2<? extends K, ? extends V2> element) {
+            return ofEntries(Collections.fillObject(n, element));
+        }
+
+        /**
          * Creates a HashMultimap of the given key-value pair.
          *
          * @param key   a key for the map

--- a/vavr/src/main/java/io/vavr/collection/HashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/HashSet.java
@@ -132,7 +132,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
     }
 
     /**
-     * Returns an HashSet containing {@code n} values supplied by a given Supplier {@code s}.
+     * Returns a HashSet containing tuples returned by {@code n} calls to a given Supplier {@code s}.
      *
      * @param <T> Component type of the HashSet
      * @param n   The number of elements in the HashSet

--- a/vavr/src/main/java/io/vavr/collection/Iterator.java
+++ b/vavr/src/main/java/io/vavr/collection/Iterator.java
@@ -453,6 +453,18 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     }
 
     /**
+     * Returns a Iterator containing {@code n} times the given {@code element}
+     *
+     * @param <T>     Component type of the Iterator
+     * @param n       The number of elements
+     * @param element The element
+     * @return An iterator of {@code n} sequence elements, where each element is the given {@code element}.
+     */
+    static <T> Iterator<T> fill(int n, T element) {
+        return io.vavr.collection.Collections.fillObject(n, element);
+    }
+
+    /**
      * Creates an Iterator of characters starting from {@code from}, extending to {@code toExclusive - 1}.
      * <p>
      * Examples:

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -451,7 +451,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     }
 
     /**
-     * Returns a LinkedHashMap containing {@code n} values supplied by a given Supplier {@code s}.
+     * Returns a LinkedHashMap containing tuples returned by {@code n} calls to a given Supplier {@code s}.
      *
      * @param <K> The key type
      * @param <V> The value type

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMultimap.java
@@ -210,6 +210,20 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
         }
 
         /**
+         * Returns a LinkedHashMultimap containing {@code n} times the given {@code element}
+         *
+         * @param <K>     The key type
+         * @param <V2>    The value type
+         * @param n       The number of elements in the LinkedHashMultimap
+         * @param element The element
+         * @return A LinkedHashMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2}.
+         */
+        @SuppressWarnings("unchecked")
+        public <K, V2 extends V> LinkedHashMultimap<K, V2> fill(int n, Tuple2<? extends K, ? extends V2> element) {
+            return ofEntries(Collections.fillObject(n, element));
+        }
+
+        /**
          * Creates a LinkedHashMultimap of the given key-value pair.
          *
          * @param key   A singleton map key.

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -136,7 +136,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
     }
 
     /**
-     * Returns a LinkedHashSet containing {@code n} values supplied by a given Supplier {@code s}.
+     * Returns a LinkedHashSet containing tuples returned by {@code n} calls to a given Supplier {@code s}.
      *
      * @param <T> Component type of the LinkedHashSet
      * @param n   The number of elements in the LinkedHashSet

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -415,6 +415,18 @@ public interface List<T> extends LinearSeq<T> {
         return Collections.fill(n, s, empty(), List::of);
     }
 
+    /**
+     * Returns a List containing {@code n} times the given {@code element}
+     *
+     * @param <T>     Component type of the List
+     * @param n       The number of elements in the List
+     * @param element The element
+     * @return A List of size {@code n}, where each element is the given {@code element}.
+     */
+    static <T> List<T> fill(int n, T element) {
+        return Collections.fillObject(n, element, empty(), List::of);
+    }
+
     static List<Character> range(char from, char toExclusive) {
         return ofAll(Iterator.range(from, toExclusive));
     }

--- a/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
+++ b/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
@@ -283,6 +283,21 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
         return io.vavr.collection.Collections.fill(size, supplier, empty(comparator), values -> ofAll(comparator, io.vavr.collection.List.of(values)));
     }
 
+    /**
+     * Returns a {@link PriorityQueue} containing {@code n} times the given {@code element}
+     *
+     * @param <T>     Component type of the {@link PriorityQueue}
+     * @param size    The number of elements in the {@link PriorityQueue}
+     * @param element The element
+     * @return A {@link PriorityQueue} of size {@code size}, where each element is the given {@code element}.
+     */
+    @GwtIncompatible
+    @SuppressWarnings("unchecked")
+    public static <T> PriorityQueue<T> fill(int size, T element) {
+        final Comparator<? super T> comparator = Comparators.naturalComparator();
+        return io.vavr.collection.Collections.fillObject(size, element, empty(comparator), values -> ofAll(comparator, io.vavr.collection.List.of(values)));
+    }
+
     @Override
     public io.vavr.collection.List<T> toList() {
         io.vavr.collection.List<T> results = io.vavr.collection.List.empty();

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -308,6 +308,18 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
         return io.vavr.collection.Collections.fill(n, s, empty(), Queue::of);
     }
 
+    /**
+     * Returns a Queue containing {@code n} times the given {@code element}
+     *
+     * @param <T>     Component type of the Queue
+     * @param n       The number of elements in the Queue
+     * @param element The element
+     * @return An Queue of size {@code n}, where each element is the given {@code element}.
+     */
+    public static <T> Queue<T> fill(int n, T element) {
+        return io.vavr.collection.Collections.fillObject(n, element, empty(), Queue::of);
+    }
+
     public static Queue<Character> range(char from, char toExclusive) {
         return ofAll(Iterator.range(from, toExclusive));
     }

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -361,6 +361,18 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     /**
+     * Returns a Stream containing {@code n} times the given {@code element}
+     *
+     * @param <T>     Component type of the Stream
+     * @param n       The number of elements in the Stream
+     * @param element The element
+     * @return A Stream of size {@code n}, where each element is the given {@code element}.
+     */
+    static <T> Stream<T> fill(int n, T element) {
+        return Stream.ofAll(io.vavr.collection.Collections.fillObject(n, element));
+    }
+
+    /**
      * Creates a Stream of the given elements.
      *
      * @param <T>      Component type of the Stream.

--- a/vavr/src/main/java/io/vavr/collection/Tree.java
+++ b/vavr/src/main/java/io/vavr/collection/Tree.java
@@ -207,6 +207,18 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     /**
+     * Returns a Tree containing {@code n} times the given {@code element}
+     *
+     * @param <T>     Component type of the Tree
+     * @param n       The number of elements in the Tree
+     * @param element The element
+     * @return A Tree of size {@code n}, where each element is the given {@code element}.
+     */
+    static <T> Tree<T> fill(int n, T element) {
+        return io.vavr.collection.Collections.fillObject(n, element, empty(), Tree::of);
+    }
+
+    /**
      * Recursively builds a non-empty {@code Tree}, starting with the given {@code seed} value and proceeding in depth-first order.
      * <p>
      * The children of a node are created by

--- a/vavr/src/main/java/io/vavr/collection/TreeMap.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeMap.java
@@ -807,7 +807,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
     }
 
     /**
-     * Returns a TreeMap containing {@code n} values supplied by a given Supplier {@code s}.
+     * Returns a TreeMap containing tuples returned by {@code n} calls to a given Supplier {@code s}.
      *
      * @param <K>           The key type
      * @param <V>           The value type
@@ -824,7 +824,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
     }
 
     /**
-     * Returns a TreeMap containing {@code n} values supplied by a given Supplier {@code s}.
+     * Returns a TreeMap containing tuples returned by {@code n} calls to a given Supplier {@code s}.
      * The underlying key comparator is the natural comparator of K.
      *
      * @param <K> The key type

--- a/vavr/src/main/java/io/vavr/collection/TreeMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeMultimap.java
@@ -361,6 +361,37 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
         }
 
         /**
+         * Returns a TreeMultimap containing {@code n} times the given {@code element}
+         * The underlying key comparator is the natural comparator of K.
+         *
+         * @param <K>     The key type
+         * @param <V2>    The value type
+         * @param n       The number of elements in the TreeMultimap
+         * @param element The element
+         * @return A TreeMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2}.
+         */
+        @SuppressWarnings("unchecked")
+        public <K extends Comparable<? super K>, V2 extends V> TreeMultimap<K, V2> fill(int n, Tuple2<? extends K, ? extends V2> element) {
+            return fill(Comparators.naturalComparator(), n, element);
+        }
+
+        /**
+         * Returns a TreeMultimap containing {@code n} times the given {@code element}
+         *
+         * @param <K>           The key type
+         * @param <V2>          The value type
+         * @param keyComparator The comparator used to sort the entries by their key
+         * @param n             The number of elements in the TreeMultimap
+         * @param element       The element
+         * @return A TreeMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2}.
+         */
+        @SuppressWarnings("unchecked")
+        public <K, V2 extends V> TreeMultimap<K, V2> fill(Comparator<? super K> keyComparator, int n, Tuple2<? extends K, ? extends V2> element) {
+            Objects.requireNonNull(keyComparator, "keyComparator is null");
+            return ofEntries(keyComparator, Collections.fillObject(n, element));
+        }
+
+        /**
          * Creates a TreeMultimap of the given key-value pair.
          *
          * @param key   A singleton map key.

--- a/vavr/src/main/java/io/vavr/collection/TreeSet.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeSet.java
@@ -162,7 +162,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     }
 
     /**
-     * Returns a TreeSet containing {@code n} values supplied by a given Supplier {@code s}.
+     * Returns a TreeSet containing tuples returned by {@code n} calls to a given Supplier {@code s}.
      *
      * @param <T>        Component type of the TreeSet
      * @param comparator The comparator used to sort the elements
@@ -178,7 +178,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     }
 
     /**
-     * Returns a TreeSet containing {@code n} values supplied by a given Supplier {@code s}.
+     * Returns a TreeSet containing tuples returned by {@code n} calls to a given Supplier {@code s}.
      * The underlying comparator is the natural comparator of T.
      *
      * @param <T> Component type of the TreeSet

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -158,6 +158,18 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     }
 
     /**
+     * Returns a Vector containing {@code n} times the given {@code element}
+     *
+     * @param <T>     Component type of the Vector
+     * @param n       The number of elements in the Vector
+     * @param element The element
+     * @return A Vector of size {@code n}, where each element is the given {@code element}.
+     */
+    public static <T> Vector<T> fill(int n, T element) {
+        return io.vavr.collection.Collections.fillObject(n, element, empty(), Vector::of);
+    }
+
+    /**
      * Creates a Vector of the given elements.
      * <p>
      * The resulting vector has the same iteration order as the given iterable of elements

--- a/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
@@ -1199,6 +1199,8 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(mapTabulate(-1, i -> new Tuple2<>(i, i))).isEqualTo(empty());
     }
 
+    // -- fill(int, Supplier)
+
     @SuppressWarnings("unchecked")
     @Test
     public void shouldFillTheSeqCallingTheSupplierInTheRightOrder() {
@@ -1211,6 +1213,14 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
     @Test
     public void shouldFillTheSeqWith0Elements() {
         assertThat(mapFill(0, () -> new Tuple2<>(1, 1))).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnSingleMapAfterFillWithConstantKeys() {
+        AtomicInteger value = new AtomicInteger(83);
+        assertThat(mapFill(17, () -> Tuple.of(7, value.getAndIncrement())))
+                .hasSize(1)
+                .isEqualTo(mapOf(7, value.decrementAndGet()));
     }
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/AbstractMultimapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractMultimapTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -192,6 +193,8 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
     abstract protected <K extends Comparable<K>, V> Multimap<K, V> mapTabulate(int n, Function<? super Integer, ? extends Tuple2<? extends K, ? extends V>> f);
 
     abstract protected <K extends Comparable<K>, V> Multimap<K, V> mapFill(int n, Supplier<? extends Tuple2<? extends K, ? extends V>> s);
+
+    abstract protected <K extends Comparable<K>, V> Multimap<K, V> mapFill(int n, Tuple2<? extends K, ? extends V> element);
 
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
@@ -654,6 +657,33 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
     @Test
     public void shouldFillTheSeqWith0ElementsWhenNIsNegative() {
         assertThat(mapFill(-1, () -> new Tuple2<>(1, 1))).isEqualTo(empty());
+    }
+
+    // -- fill(int, Supplier)
+
+    @Test
+    public void shouldReturnManyMapAfterFillWithConstantSupplier() {
+        AtomicInteger value = new AtomicInteger(83);
+        assertThat(mapFill(17, () -> Tuple.of(7, value.getAndIncrement())))
+                .hasSize(17);
+    }
+
+    // -- fill(int, T)
+
+    @Test
+    public void shouldReturnEmptyAfterFillWithZeroCount() {
+        assertThat(mapFill(0, Tuple.of(7, 83))).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnEmptyAfterFillWithNegativeCount() {
+        assertThat(mapFill(-1, Tuple.of(7, 83))).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnManyMapAfterFillWithConstant() {
+        assertThat(mapFill(17, Tuple.of(7, 83)))
+                .hasSize(containerType == Multimap.ContainerType.SEQ ? 17 : 1);
     }
 
     // -- mapTabulate

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -126,6 +126,8 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
 
     abstract protected <T> Seq<? extends Seq<T>> transpose(Seq<? extends Seq<T>> rows);
 
+    abstract protected <T> Traversable<T> fill(int n, T element);
+
     // -- static narrow
 
     @Test
@@ -134,6 +136,34 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         final Seq<Number> numbers = Seq.narrow(doubles);
         final int actual = numbers.append(new BigDecimal("2.0")).sum().intValue();
         assertThat(actual).isEqualTo(3);
+    }
+
+    // -- fill(int, Supplier)
+
+    @Test
+    public void shouldReturnManyAfterFillWithConstantSupplier() {
+        assertThat(fill(17, () -> 7))
+                .hasSize(17)
+                .containsOnly(7);
+    }
+
+    // -- fill(int, T)
+
+    @Test
+    public void shouldReturnEmptyAfterFillWithZeroCount() {
+        assertThat(fill(0, 7)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnEmptyAfterFillWithNegativeCount() {
+        assertThat(fill(-1, 7)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnManyAfterFillWithConstant() {
+        assertThat(fill(17, 7))
+                .hasSize(17)
+                .containsOnly(7);
     }
 
     // -- append

--- a/vavr/src/test/java/io/vavr/collection/AbstractSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSetTest.java
@@ -48,6 +48,15 @@ public abstract class AbstractSetTest extends AbstractTraversableRangeTest {
         assertThat(actual).isEqualTo(3);
     }
 
+    // -- fill(int, Supplier)
+
+    @Test
+    public void shouldReturnSingleAfterFillWithConstant() {
+        assertThat(fill(17, () -> 7))
+                .hasSize(1)
+                .isEqualTo(of(7));
+    }
+
     // -- add
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -2784,6 +2784,8 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         assertThat(tabulate(-1, i -> i)).isEqualTo(empty());
     }
 
+    // -- fill(int, Supplier)
+
     @Test
     public void shouldFillTheSeqCallingTheSupplierInTheRightOrder() {
         final java.util.LinkedList<Integer> ints = new java.util.LinkedList<>(asList(0, 1));

--- a/vavr/src/test/java/io/vavr/collection/ArrayTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ArrayTest.java
@@ -115,6 +115,11 @@ public class ArrayTest extends AbstractIndexedSeqTest {
     }
 
     @Override
+    protected <T> Traversable<T> fill(int n, T element) {
+        return Array.fill(n, element);
+    }
+
+    @Override
     protected Array<Character> range(char from, char toExclusive) {
         return Array.range(from, toExclusive);
     }

--- a/vavr/src/test/java/io/vavr/collection/HashMultimapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/HashMultimapTest.java
@@ -182,6 +182,20 @@ public class HashMultimapTest extends AbstractMultimapTest {
         }
     }
 
+    @Override
+    protected <K extends Comparable<K>, V> Multimap<K, V> mapFill(int n, Tuple2<? extends K, ? extends V> element) {
+        switch (containerType) {
+            case SEQ:
+                return HashMultimap.withSeq().fill(n, element);
+            case SET:
+                return HashMultimap.withSet().fill(n, element);
+            case SORTED_SET:
+                return HashMultimap.withSortedSet(Comparators.naturalComparator()).fill(n, element);
+            default:
+                throw new RuntimeException();
+        }
+    }
+
     // -- static narrow
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/IteratorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/IteratorTest.java
@@ -184,6 +184,10 @@ public class IteratorTest extends AbstractTraversableTest {
         return Iterator.fill(n, s);
     }
 
+    protected <T> Iterator<T> fill(int n, T element) {
+        return Iterator.fill(n, element);
+    }
+
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return true;
@@ -289,6 +293,32 @@ public class IteratorTest extends AbstractTraversableTest {
     @Test
     public void shouldConcatToConcatIterator() {
         assertThat(concat(List.of(1, 2)).concat(List.of(3).iterator())).isEqualTo(Iterator.of(1, 2, 3));
+    }
+
+    // -- fill(int, Supplier)
+
+    @Test
+    public void shouldReturnManyAfterFillWithConstantSupplier() {
+        assertThat(fill(17, () -> 7))
+                .hasSize(17);
+    }
+
+    // -- fill(int, T)
+
+    @Test
+    public void shouldReturnEmptyAfterFillWithZeroCount() {
+        assertThat(fill(0, 7)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnEmptyAfterFillWithNegativeCount() {
+        assertThat(fill(-1, 7)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnManyAfterFillWithConstant() {
+        assertThat(fill(17, 7))
+                .hasSize(17);
     }
 
     // -- concat

--- a/vavr/src/test/java/io/vavr/collection/LinkedHashMultimapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/LinkedHashMultimapTest.java
@@ -182,6 +182,20 @@ public class LinkedHashMultimapTest extends AbstractMultimapTest {
         }
     }
 
+    @Override
+    protected <K extends Comparable<K>, V> Multimap<K, V> mapFill(int n, Tuple2<? extends K, ? extends V> element) {
+        switch (containerType) {
+            case SEQ:
+                return LinkedHashMultimap.withSeq().fill(n, element);
+            case SET:
+                return LinkedHashMultimap.withSet().fill(n, element);
+            case SORTED_SET:
+                return LinkedHashMultimap.withSortedSet(Comparators.naturalComparator()).fill(n, element);
+            default:
+                throw new RuntimeException();
+        }
+    }
+
     // -- narrow
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/ListTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ListTest.java
@@ -122,6 +122,11 @@ public class ListTest extends AbstractLinearSeqTest {
     }
 
     @Override
+    protected <T> Traversable<T> fill(int n, T element) {
+        return List.fill(n, element);
+    }
+
+    @Override
     protected List<Character> range(char from, char toExclusive) {
         return List.range(from, toExclusive);
     }

--- a/vavr/src/test/java/io/vavr/collection/PriorityQueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/PriorityQueueTest.java
@@ -117,6 +117,10 @@ public class PriorityQueueTest extends AbstractTraversableTest {
         return PriorityQueue.fill(n, s);
     }
 
+    protected <T> PriorityQueue<T> fill(int n, T element) {
+        return PriorityQueue.fill(n, element);
+    }
+
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return true;
@@ -179,6 +183,34 @@ public class PriorityQueueTest extends AbstractTraversableTest {
         final PriorityQueue<Number> numbers = PriorityQueue.narrow(doubles);
         final int actual = numbers.enqueue(new BigDecimal("2.0")).sum().intValue();
         assertThat(actual).isEqualTo(3);
+    }
+
+    // -- fill(int, Supplier)
+
+    @Test
+    public void shouldReturnManyAfterFillWithConstantSupplier() {
+        assertThat(fill(17, () -> 7))
+                .hasSize(17)
+                .containsOnly(7);
+    }
+
+    // -- fill(int, T)
+
+    @Test
+    public void shouldReturnEmptyAfterFillWithZeroCount() {
+        assertThat(fill(0, 7)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnEmptyAfterFillWithNegativeCount() {
+        assertThat(fill(-1, 7)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnManyAfterFillWithConstant() {
+        assertThat(fill(17, 7))
+                .hasSize(17)
+                .containsOnly(7);
     }
 
     // -- toList

--- a/vavr/src/test/java/io/vavr/collection/QueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/QueueTest.java
@@ -120,6 +120,11 @@ public class QueueTest extends AbstractLinearSeqTest {
     }
 
     @Override
+    protected <T> Traversable<T> fill(int n, T element) {
+        return Queue.fill(n, element);
+    }
+
+    @Override
     protected Queue<Character> range(char from, char toExclusive) {
         return Queue.range(from, toExclusive);
     }

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -123,6 +123,11 @@ public class StreamTest extends AbstractLinearSeqTest {
     }
 
     @Override
+    protected <T> Traversable<T> fill(int n, T element) {
+        return Stream.fill(n, element);
+    }
+
+    @Override
     protected Stream<Character> range(char from, char toExclusive) {
         return Stream.range(from, toExclusive);
     }

--- a/vavr/src/test/java/io/vavr/collection/TreeMultimapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/TreeMultimapTest.java
@@ -182,6 +182,20 @@ public class TreeMultimapTest extends AbstractMultimapTest {
         }
     }
 
+    @Override
+    protected <K extends Comparable<K>, V> Multimap<K, V> mapFill(int n, Tuple2<? extends K, ? extends V> element) {
+        switch (containerType) {
+            case SEQ:
+                return TreeMultimap.withSeq().fill(n, element);
+            case SET:
+                return TreeMultimap.withSet().fill(n, element);
+            case SORTED_SET:
+                return TreeMultimap.withSortedSet(Comparators.naturalComparator()).fill(n, element);
+            default:
+                throw new RuntimeException();
+        }
+    }
+
     // -- static narrow
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/TreeTest.java
+++ b/vavr/src/test/java/io/vavr/collection/TreeTest.java
@@ -190,6 +190,10 @@ public class TreeTest extends AbstractTraversableTest {
         return Tree.fill(n, s);
     }
 
+    protected <T> Tree<T> fill(int n, T element) {
+        return Tree.fill(n, element);
+    }
+
     @Override
     protected boolean useIsEqualToInsteadOfIsSameAs() {
         return true;
@@ -214,6 +218,34 @@ public class TreeTest extends AbstractTraversableTest {
         final Tree<Number> numbers = Tree.narrow(doubles);
         final boolean actual = numbers.contains(new BigDecimal("2.0"));
         assertThat(actual).isFalse();
+    }
+
+    // -- fill(int, Supplier)
+
+    @Test
+    public void shouldReturnManyAfterFillWithConstantSupplier() {
+        assertThat(fill(17, () -> 7))
+                .hasSize(17)
+                .containsOnly(7);
+    }
+
+    // -- fill(int, T)
+
+    @Test
+    public void shouldReturnEmptyAfterFillWithZeroCount() {
+        assertThat(fill(0, 7)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnEmptyAfterFillWithNegativeCount() {
+        assertThat(fill(-1, 7)).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldReturnManyAfterFillWithConstant() {
+        assertThat(fill(17, 7))
+                .hasSize(17)
+                .containsOnly(7);
     }
 
     // -- static recurse(T, Function)

--- a/vavr/src/test/java/io/vavr/collection/VectorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/VectorTest.java
@@ -117,6 +117,11 @@ public class VectorTest extends AbstractIndexedSeqTest {
     }
 
     @Override
+    protected <T> Traversable<T> fill(int n, T element) {
+        return Vector.fill(n, element);
+    }
+
+    @Override
     protected Vector<Character> range(char from, char toExclusive) {
         return Vector.range(from, toExclusive);
     }


### PR DESCRIPTION
Fixes #2182

In some Collections method `fill(int, T)` don't have sense because for any `n >= 1` they always will be have size `1`.
For this collections I change JavaDoc and don't implement `fill(int, T)`.

For other collections I implement `fill(int, T)`.

I also add come benchmarks, but don't understand them: is them good or bad?
```
Benchmark                                              (CONTAINER_SIZE)   Mode  Cnt        Score   Error  Units
ArrayBenchmark.Fill.vavr_persistent_constant_object                  10  thrpt       1995515,989          ops/s
ArrayBenchmark.Fill.vavr_persistent_constant_object                 100  thrpt       4493540,929          ops/s
ArrayBenchmark.Fill.vavr_persistent_constant_object                1000  thrpt        187667,015          ops/s
ArrayBenchmark.Fill.vavr_persistent_constant_object                2500  thrpt        241171,857          ops/s
ArrayBenchmark.Fill.vavr_persistent_constant_supplier                10  thrpt       4519534,549          ops/s
ArrayBenchmark.Fill.vavr_persistent_constant_supplier               100  thrpt       6738909,798          ops/s
ArrayBenchmark.Fill.vavr_persistent_constant_supplier              1000  thrpt        398973,534          ops/s
ArrayBenchmark.Fill.vavr_persistent_constant_supplier              2500  thrpt        222191,737          ops/s

Benchmark                                             (CONTAINER_SIZE)   Mode  Cnt        Score   Error  Units
ListBenchmark.Fill.scala_persistent                                 10  thrpt        263088,413          ops/s
ListBenchmark.Fill.scala_persistent                                100  thrpt       1234225,597          ops/s
ListBenchmark.Fill.scala_persistent                               1000  thrpt         94787,145          ops/s
ListBenchmark.Fill.scala_persistent                               2500  thrpt         27272,719          ops/s
ListBenchmark.Fill.vavr_persistent_constant_object                  10  thrpt         98096,081          ops/s
ListBenchmark.Fill.vavr_persistent_constant_object                 100  thrpt       1021355,473          ops/s
ListBenchmark.Fill.vavr_persistent_constant_object                1000  thrpt        211110,914          ops/s
ListBenchmark.Fill.vavr_persistent_constant_object                2500  thrpt         80042,128          ops/s
ListBenchmark.Fill.vavr_persistent_constant_supplier                10  thrpt        405868,679          ops/s
ListBenchmark.Fill.vavr_persistent_constant_supplier               100  thrpt       1298274,304          ops/s
ListBenchmark.Fill.vavr_persistent_constant_supplier              1000  thrpt        209578,779          ops/s
ListBenchmark.Fill.vavr_persistent_constant_supplier              2500  thrpt         28176,601          ops/s

Benchmark                                                      (CONTAINER_SIZE)   Mode  Cnt       Score   Error  Units
PriorityQueueBenchmark.Fill.vavr_persistent_constant_object                  10  thrpt       506820,695          ops/s
PriorityQueueBenchmark.Fill.vavr_persistent_constant_object                 100  thrpt        15082,947          ops/s
PriorityQueueBenchmark.Fill.vavr_persistent_constant_object                1000  thrpt         6604,393          ops/s
PriorityQueueBenchmark.Fill.vavr_persistent_constant_object                2500  thrpt         5728,046          ops/s
PriorityQueueBenchmark.Fill.vavr_persistent_constant_supplier                10  thrpt        41507,195          ops/s
PriorityQueueBenchmark.Fill.vavr_persistent_constant_supplier               100  thrpt       104174,230          ops/s
PriorityQueueBenchmark.Fill.vavr_persistent_constant_supplier              1000  thrpt        36894,107          ops/s
PriorityQueueBenchmark.Fill.vavr_persistent_constant_supplier              2500  thrpt        13532,780          ops/s

Benchmark                                               (CONTAINER_SIZE)   Mode  Cnt        Score   Error  Units
VectorBenchmark.Fill.scala_persistent                                 10  thrpt         60914,608          ops/s
VectorBenchmark.Fill.scala_persistent                                100  thrpt        134581,782          ops/s
VectorBenchmark.Fill.scala_persistent                               1000  thrpt        140626,151          ops/s
VectorBenchmark.Fill.scala_persistent                               1026  thrpt         54571,539          ops/s
VectorBenchmark.Fill.scala_persistent                               2500  thrpt          6941,381          ops/s
VectorBenchmark.Fill.vavr_persistent_constant_object                  10  thrpt       5073541,973          ops/s
VectorBenchmark.Fill.vavr_persistent_constant_object                 100  thrpt       1444984,748          ops/s
VectorBenchmark.Fill.vavr_persistent_constant_object                1000  thrpt        327720,170          ops/s
VectorBenchmark.Fill.vavr_persistent_constant_object                1026  thrpt        257781,980          ops/s
VectorBenchmark.Fill.vavr_persistent_constant_object                2500  thrpt        167047,764          ops/s
VectorBenchmark.Fill.vavr_persistent_constant_supplier                10  thrpt       2978342,503          ops/s
VectorBenchmark.Fill.vavr_persistent_constant_supplier               100  thrpt       1968232,493          ops/s
VectorBenchmark.Fill.vavr_persistent_constant_supplier              1000  thrpt        409394,101          ops/s
VectorBenchmark.Fill.vavr_persistent_constant_supplier              1026  thrpt        478027,314          ops/s
VectorBenchmark.Fill.vavr_persistent_constant_supplier              2500  thrpt        208179,434          ops/s
```

Can somebody describe benchmark result for me?

P.S.
Please check my JavaDoc - I am sure that I make many mistakes :(
