### PR TITLE
Added merge operation on Either

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Either.java
+++ b/vavr/src/main/java/io/vavr/control/Either.java
@@ -110,12 +110,8 @@ public interface Either<L, R> extends Value<R>, Serializable {
      * @param <T> commonly assignable type
      * @return left or right - whichever is resolved
      */
-    static <T> T  merge(Either<T,T> either) {
-        if (either.isLeft()) {
-            return either.getLeft();
-        } else {
-            return either.get();
-        }
+    static <T> T  merge(Either<? extends T,T> either) {
+        return either.getOrElseGet(Function.identity());
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/control/Either.java
+++ b/vavr/src/main/java/io/vavr/control/Either.java
@@ -100,6 +100,24 @@ public interface Either<L, R> extends Value<R>, Serializable {
         return (Either<L, R>) either;
     }
 
+
+    /**
+     * Return a value of right or left if both sides have same type.
+     *
+     *  Use this to elegantly resolve last step of computation.
+     *
+     * @param either value with both sides of the same type
+     * @param <T> commonly assignable type
+     * @return left or right - whichever is resolved
+     */
+    static <T> T  merge(Either<T,T> either) {
+        if (either.isLeft()) {
+            return either.getLeft();
+        } else {
+            return either.get();
+        }
+    }
+
     /**
      * Returns the left value.
      *

--- a/vavr/src/test/java/io/vavr/control/EitherTest.java
+++ b/vavr/src/test/java/io/vavr/control/EitherTest.java
@@ -426,4 +426,20 @@ public class EitherTest extends AbstractValueTest {
     public void shouldReturnSizeWhenSpliterator() {
         assertThat(of(1).spliterator().getExactSizeIfKnown()).isEqualTo(1);
     }
+
+    // merge
+
+    @Test
+    public void shouldMergeRight() {
+        final Either<String, Integer> right = Either.right(1);
+        Either<String,String> result = right.map(String::valueOf);
+        assertThat(Either.merge(result)).isEqualTo("1");
+    }
+
+    @Test
+    public void shouldMergeLeft() {
+        final Either<String, Integer> right = Either.left("ok");
+        Either<String,String> result = right.map(String::valueOf);
+        assertThat(Either.merge(result)).isEqualTo("ok");
+    }
 }


### PR DESCRIPTION
I copied approach from Scalaz \/ disjunction, where I can end computations in a nice way - mapping both Left and Right side of Either to the same type. Thus eventually assigning it to a result (http response or String in a single step. 

At  the moment almost same can be achieved by `getOrElseGet` but if both sides are already mapped to the same type (like String. HttpEntity) it  is unnecessary complex call.

see merge at https://static.javadoc.io/org.scalaz/scalaz_2.12/7.3.0-M22/scalaz/$bslash$div.html