### PR TITLE
add either, option, try, validation traverse. improve the signature of validation.sequence

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Either.java
+++ b/vavr/src/main/java/io/vavr/control/Either.java
@@ -216,6 +216,24 @@ public interface Either<L, R> extends Value<R>, Serializable {
     }
 
     /**
+     * Maps the values of an iterable to a sequence of mapped values into a single {@code Either} by
+     * transforming an {@code Iterable<? extends T>} into a {@code Either<Seq<U>>}.
+     * <p>
+     *
+     * @param values   An {@code Iterable} of values.
+     * @param mapper   A mapper of values to Eithers
+     * @param <T>      The type of the given values.
+     * @param <U>      The mapped value type.
+     * @return A {@code Either} of a {@link Seq} of results.
+     * @throws NullPointerException if values or f is null.
+     */
+    static <L, T, U> Either<Seq<L>, Seq<U>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Either<? extends L, ? extends U>> mapper) {
+        Objects.requireNonNull(values, "values is null");
+        Objects.requireNonNull(mapper, "mapper is null");
+        return sequence(Iterator.ofAll(values).map(mapper));
+    }
+
+    /**
      * Reduces many {@code Either}s into a single {@code Either} by transforming an
      * {@code Iterable<Either<L, R>>} into a {@code Either<L, Seq<R>>}.
      * <p>
@@ -253,6 +271,24 @@ public interface Either<L, R> extends Value<R>, Serializable {
             }
         }
         return Either.right(rightValues);
+    }
+
+    /**
+     * Maps the values of an iterable to a sequence of mapped values into a single {@code Either} by
+     * transforming an {@code Iterable<? extends T>} into a {@code Either<Seq<U>>}.
+     * <p>
+     *
+     * @param values   An {@code Iterable} of values.
+     * @param mapper   A mapper of values to Eithers
+     * @param <T>      The type of the given values.
+     * @param <U>      The mapped value type.
+     * @return A {@code Either} of a {@link Seq} of results.
+     * @throws NullPointerException if values or f is null.
+     */
+    static <L, T, U> Either<L, Seq<U>> traverseRight(Iterable<? extends T> values, Function<? super T, ? extends Either<? extends L, ? extends U>> mapper) {
+        Objects.requireNonNull(values, "values is null");
+        Objects.requireNonNull(mapper, "mapper is null");
+        return sequenceRight(Iterator.ofAll(values).map(mapper));
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -86,6 +86,24 @@ public interface Option<T> extends Value<T>, Serializable {
     }
 
     /**
+     * Maps the values of an iterable to a sequence of mapped values into a single {@code Option} by
+     * transforming an {@code Iterable<? extends T>} into a {@code Option<Seq<U>>}.
+     * <p>
+     *
+     * @param values   An {@code Iterable} of values.
+     * @param mapper   A mapper of values to Options
+     * @param <T>      The type of the given values.
+     * @param <U>      The mapped value type.
+     * @return A {@code Option} of a {@link Seq} of results.
+     * @throws NullPointerException if values or f is null.
+     */
+    static <T, U> Option<Seq<U>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Option<? extends U>> mapper) {
+        Objects.requireNonNull(values, "values is null");
+        Objects.requireNonNull(mapper, "mapper is null");
+        return sequence(Iterator.ofAll(values).map(mapper));
+    }
+
+    /**
      * Creates a new {@code Some} of a given value.
      * <p>
      * The only difference to {@link Option#of(Object)} is, when called with argument {@code null}.

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -156,6 +156,24 @@ public interface Try<T> extends Value<T>, Serializable {
     }
 
     /**
+     * Maps the values of an iterable to a sequence of mapped values into a single {@code Try} by
+     * transforming an {@code Iterable<? extends T>} into a {@code Try<Seq<U>>}.
+     * <p>
+     *
+     * @param values   An {@code Iterable} of values.
+     * @param mapper   A mapper of values to Trys
+     * @param <T>      The type of the given values.
+     * @param <U>      The mapped value type.
+     * @return A {@code Try} of a {@link Seq} of results.
+     * @throws NullPointerException if values or f is null.
+     */
+    static <T, U> Try<Seq<U>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Try<? extends U>> mapper) {
+        Objects.requireNonNull(values, "values is null");
+        Objects.requireNonNull(mapper, "mapper is null");
+        return sequence(Iterator.ofAll(values).map(mapper));
+    }
+
+    /**
      * Creates a {@link Success} that contains the given {@code value}. Shortcut for {@code new Success<>(value)}.
      *
      * @param value A value.

--- a/vavr/src/main/java/io/vavr/control/Validation.java
+++ b/vavr/src/main/java/io/vavr/control/Validation.java
@@ -220,6 +220,24 @@ public interface Validation<E, T> extends Value<T>, Serializable {
     }
 
     /**
+     * Maps the values of an iterable to a sequence of mapped values into a single {@code Validation} by
+     * transforming an {@code Iterable<? extends T>} into a {@code Validation<Seq<U>>}.
+     * <p>
+     *
+     * @param values   An {@code Iterable} of values.
+     * @param mapper   A mapper of values to Validations
+     * @param <T>      The type of the given values.
+     * @param <U>      The mapped value type.
+     * @return A {@code Validation} of a {@link Seq} of results.
+     * @throws NullPointerException if values or f is null.
+     */
+    static <E, T, U> Validation<E, Seq<U>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Validation<? extends E, ? extends U>> mapper) {
+        Objects.requireNonNull(values, "values is null");
+        Objects.requireNonNull(mapper, "mapper is null");
+        return sequence(Iterator.ofAll(values).map(mapper));
+    }
+
+    /**
      * Narrows a widened {@code Validation<? extends E, ? extends T>} to {@code Validation<E, T>}
      * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.

--- a/vavr/src/main/java/io/vavr/control/Validation.java
+++ b/vavr/src/main/java/io/vavr/control/Validation.java
@@ -205,11 +205,11 @@ public interface Validation<E, T> extends Value<T>, Serializable {
      * or an invalid Validation containing an accumulated List of errors.
      * @throws NullPointerException if values is null
      */
-    static <E, T> Validation<E, Seq<T>> sequence(Iterable<? extends Validation<E, T>> values) {
+    static <E, T> Validation<E, Seq<T>> sequence(Iterable<? extends Validation<? extends E, ? extends T>> values) {
         Objects.requireNonNull(values, "values is null");
         List<E> errors = List.empty();
         List<T> list = List.empty();
-        for (Validation<E, T> value : values) {
+        for (Validation<? extends E, ? extends T> value : values) {
             if (value.isInvalid()) {
                 errors = errors.prependAll(value.getErrors().reverse());
             } else if (errors.isEmpty()) {

--- a/vavr/src/test/java/io/vavr/control/EitherTest.java
+++ b/vavr/src/test/java/io/vavr/control/EitherTest.java
@@ -187,6 +187,90 @@ public class EitherTest extends AbstractValueTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    // -- traverse
+
+    @Test
+    public void shouldThrowWhenTraversingNull() {
+        assertThatThrownBy(() -> Either.traverse(null, null))
+                .isInstanceOf(NullPointerException.class)
+                .withFailMessage("eithers is null");
+    }
+
+    @Test
+    public void shouldTraverseEmptyIterableOfEither() {
+        final Iterable<String> values = List.empty();
+        final Either<Seq<Integer>, Seq<String>> actual = Either.traverse(values, Either::right);
+        final Either<Seq<Integer>, Seq<String>> expected = Either.right(Vector.empty());
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldTraverseNonEmptyIterableOfRight() {
+        final Iterable<String> values = List.of("a", "b", "c");
+        final Either<Seq<Integer>, Seq<String>> actual = Either.traverse(values, Either::right);
+        final Either<Seq<Integer>, Seq<String>> expected = Either.right(Vector.of("a", "b", "c"));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldTraverseNonEmptyIterableOfLeft() {
+        final Iterable<Integer> values = List.of(1, 2, 3);
+        final Either<Seq<Integer>, Seq<String>> actual = Either.traverse(values, Either::left);
+        final Either<Seq<Integer>, Seq<String>> expected = Either.left(Vector.of(1, 2, 3));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldTraverseNonEmptyIterableOfMixedEither() {
+        final Iterable<String> values = List.of("a", "1", "c", "3");
+        final Either<Seq<Integer>, Seq<String>> actual =
+            Either.traverse(values, x -> x.matches("^\\d+$") ? Either.left(Integer.parseInt(x)) : Either.right(x));
+        final Either<Seq<Integer>, Seq<String>> expected = Either.left(Vector.of(1, 3));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    // -- traverseRight
+
+    @Test
+    public void shouldThrowWhenTraversingRightNull() {
+        assertThatThrownBy(() -> Either.traverseRight(null, null))
+                .isInstanceOf(NullPointerException.class)
+                .withFailMessage("eithers is null");
+    }
+
+    @Test
+    public void shouldTraverseRightEmptyIterableOfEither() {
+        final Iterable<String> values = List.empty();
+        final Either<Integer, Seq<String>> actual = Either.traverseRight(values, Either::right);
+        final Either<Integer, Seq<String>> expected = Either.right(Vector.empty());
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldTraverseRightNonEmptyIterableOfRight() {
+        final Iterable<String> values = List.of("a", "b", "c");
+        final Either<Integer, Seq<String>> actual = Either.traverseRight(values, Either::right);
+        final Either<Integer, Seq<String>> expected = Either.right(Vector.of("a", "b", "c"));
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldTraverseRightNonEmptyIterableOfLeft() {
+        final Iterable<Integer> values = List.of(1, 2, 3);
+        final Either<Integer, Seq<String>> actual = Either.traverseRight(values, Either::left);
+        final Either<Integer, Seq<String>> expected = Either.left(1);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldTraverseRightNonEmptyIterableOfMixedEither() {
+        final Iterable<String> values = List.of("a", "1", "c", "3");
+        final Either<Integer, Seq<String>> actual =
+            Either.traverseRight(values, x -> x.matches("^\\d+$") ? Either.left(Integer.parseInt(x)) : Either.right(x));
+        final Either<Integer, Seq<String>> expected = Either.left(1);
+        assertThat(actual).isEqualTo(expected);
+    }
+
     // --
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/OptionTest.java
+++ b/vavr/src/test/java/io/vavr/control/OptionTest.java
@@ -160,6 +160,32 @@ public class OptionTest extends AbstractValueTest {
         assertThat(option instanceof Option.None).isTrue();
     }
 
+    // -- traverse
+
+    @Test
+    public void shouldTraverseListOfNonEmptyOptionsToOptionOfList() {
+        final List<String> options = Arrays.asList("a", "b", "c");
+        final Option<Seq<String>> reducedOption = Option.traverse(options, Option::of);
+        assertThat(reducedOption instanceof Option.Some).isTrue();
+        assertThat(reducedOption.get().size()).isEqualTo(3);
+        assertThat(reducedOption.get().mkString()).isEqualTo("abc");
+    }
+
+    @Test
+    public void shouldTraverseListOfEmptyOptionsToOptionOfList() {
+        final List<Option<String>> options = Arrays.asList(Option.none(), Option.none(), Option.none());
+        final Option<Seq<String>> option = Option.traverse(options, Function.identity());
+        assertThat(option instanceof Option.None).isTrue();
+    }
+
+    @Test
+    public void shouldTraverseListOfMixedOptionsToOptionOfList() {
+        final List<String> options = Arrays.asList("a", "b", "c");
+        final Option<Seq<String>> option =
+            Option.traverse(options, x -> x.equals("b") ? Option.none() : Option.of(x));
+        assertThat(option instanceof Option.None).isTrue();
+    }
+
     // -- get
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -1239,6 +1239,33 @@ public class TryTest extends AbstractValueTest {
         assertThat(reducedTry instanceof Try.Failure).isTrue();
     }
 
+    // -- traverse
+
+    @Test
+    public void shouldTraverseListOfSuccessToTryOfList() {
+        final List<String> tries = Arrays.asList("a", "b", "c");
+        final Try<Seq<String>> reducedTry = Try.traverse(tries, Try::success);
+        assertThat(reducedTry instanceof Try.Success).isTrue();
+        assertThat(reducedTry.get().size()).isEqualTo(3);
+        assertThat(reducedTry.get().mkString()).isEqualTo("abc");
+    }
+
+    @Test
+    public void shouldTraverseListOfFailureToTryOfList() {
+        final Throwable t = new RuntimeException("failure");
+        final List<Throwable> tries = Arrays.asList(t, t, t);
+        final Try<Seq<String>> reducedTry = Try.traverse(tries, Try::failure);
+        assertThat(reducedTry instanceof Try.Failure).isTrue();
+    }
+
+    @Test
+    public void shouldTraverseListOfMixedTryToTryOfList() {
+        final Throwable t = new RuntimeException("failure");
+        final List<String> tries = Arrays.asList("a", "b", "c");
+        final Try<Seq<String>> reducedTry = Try.traverse(tries, x -> x.equals("b") ? Try.failure(t) : Try.success(x));
+        assertThat(reducedTry instanceof Try.Failure).isTrue();
+    }
+
     // serialization
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/ValidationTest.java
+++ b/vavr/src/test/java/io/vavr/control/ValidationTest.java
@@ -179,6 +179,31 @@ public class ValidationTest extends AbstractValueTest {
         assertThat(actual).isEqualTo(Validation.invalid("error1", "error2", "error3", "error4"));
     }
 
+    // -- Validation.traverse
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowWhenTraversingNull() {
+        Validation.traverse(null, null);
+    }
+
+    @Test
+    public void shouldCreateValidWhenTraversingValids() {
+        final Validation<Seq<String>, Seq<Integer>> actual =
+            Validation.traverse(List.of(1, 2), Validation::valid);
+        assertThat(actual).isEqualTo(Validation.valid(List.of(1, 2)));
+    }
+
+    @Test
+    public void shouldCreateInvalidWhenTraversingAnInvalid() {
+        final Validation<String, Seq<Integer>> actual =
+            Validation.traverse(
+                List.of(1, -1, 2, -2),
+                x -> x >= 0
+                    ? Validation.valid(x)
+                    : Validation.invalid("error" + Integer.toString(x), "error" + Integer.toString(x+1)));
+        assertThat(actual).isEqualTo(Validation.invalid("error-1", "error0", "error-2", "error-1"));
+    }
+
     // -- ap
 
     @Test


### PR DESCRIPTION
vavr has Future.traverse and Future.sequence, but for option, try, validation and either it has only sequence.

This PR adds traverse for all of these. Traverse is a pretty standard FP function (arguably even more standard than sequence).

The PR also slightly improves the Validation.sequence signature, regarding variance of the parameters (in a separate commit).