### PR TITLE
update »Scala Maven Plugin« to fix build error on generating Java source(s)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,14 @@ env:
     - secure: GWvKpGPBF1b/2tkYzJ/IwKpGd3kjfYpadIFoQOdQS3r6iZkutZ9FhW6vINIRsgcIRHTVha0BywG7m5sJIYo/jmsDbXc2VJFO7EcXkK6k96VZYb0pHjbXqeP/u9/ZfSzeQ4w3qNYUiXztmmrLjbCzG2gV4D2CqOaug2o81mVj4LI=
     - secure: m91QxOLHBRnJzRyphCivL79i90pE/FO4yg8qTOaDuyTqVXBKnHmdARFOxSMZN9Qn3B3e28xxPaazIsJGCuPXiQKSObqzPLeFHUOa3atUJSckEUW623l1313A9iMFOYbqSBAHFHmiuuAJBwN/E2OnG3BcLZV1FRibW6J1qLRLdJw=
 install: true
+cache:
+  directories:
+    - "$HOME/.m2/repository"
+    - "$HOME/apache-maven-3.5.4"
+before_install:
+  - export M2_HOME=$HOME/apache-maven-3.5.4
+  - if [ ! -d $M2_HOME/bin ]; then curl https://archive.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz | tar zxf - -C $HOME; fi
+  - export PATH=$M2_HOME/bin:$PATH
 script: .travis/run-tests.sh
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
         <maven.source.version>3.0.1</maven.source.version>
         <maven.exec.version>1.5.0</maven.exec.version>
         <maven.gwt.plugin>1.0-rc-6</maven.gwt.plugin>
-        <scala.maven.version>3.3.1</scala.maven.version>
+        <scala.maven.version>3.4.1</scala.maven.version>
         <scala.version>2.12.3</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
     </properties>


### PR DESCRIPTION
With »Scala Maven Plugin« version 3.3.1 the build fails on random
machines with:
```
[INFO]
------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Vavr Parent 1.0.0-SNAPSHOT ......................... SUCCESS [0.277 s]
[INFO] Vavr Match ......................................... SUCCESS [1.478 s]
[INFO] Vavr ............................................... FAILURE [9.971 s]
[INFO] Vavr Benchmark ..................................... SKIPPED
[INFO] Vavr Test 1.0.0-SNAPSHOT ........................... SKIPPED
[INFO]
------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO]
------------------------------------------------------------------------
[INFO] Total time: 12.025 s
[INFO] Finished at: 2018-07-28T12:21:27+02:00
[INFO]
------------------------------------------------------------------------
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:3.3.1:script (default) on project vavr: wrap: java.lang.Exception: A NoSuchMethodError exception was thrown: scala.Predef$.refArrayOps([Ljava/lang/Object;)[Ljava/lang/Object; -> [Help 1]
```

After update to recent version 3.4.1 of the plugin the build finishes
successfully.

Fixes #2269.