### PR TITLE
remove `(Constant)?Function[0-8]#constant`

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1445,19 +1445,6 @@ def generateMainClasses(): Unit = {
               long serialVersionUID = 1L;
 
               /$javadoc
-               * Returns a function that always returns the constant
-               * value that you give in parameter.
-               *
-               ${(1 to i).gen(j => s"* @param <T$j> generic parameter type $j of the resulting function")("\n")}
-               * @param <R> the result type
-               * @param value the value to be returned
-               * @return a function always returning the given value
-               */
-              static $fullGenerics $className$fullGenerics constant(R value) {
-                  return ($params) -> value;
-              }
-
-              /$javadoc
                * Creates a {@code $className} based on
                * <ul>
                * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>
@@ -2914,12 +2901,6 @@ def generateTestClasses(): Unit = {
               public void shouldGetArity() {
                   final $name$i<$generics> f = ($functionArgs) -> null;
                   $assertThat(f.arity()).isEqualTo($i);
-              }
-
-              @$test
-              public void shouldConstant()${checked.gen(" throws Throwable")} {
-                  final $name$i<$generics> f = $name$i.constant(6);
-                  $assertThat(f.apply(${(1 to i).gen(j => s"$j")(", ")})).isEqualTo(6);
               }
 
               @$test

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction0.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction0.java
@@ -46,19 +46,6 @@ public interface CheckedFunction0<R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <R> CheckedFunction0<R> constant(R value) {
-        return () -> value;
-    }
-
-    /**
      * Creates a {@code CheckedFunction0} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
@@ -48,19 +48,6 @@ public interface CheckedFunction1<T1, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, R> CheckedFunction1<T1, R> constant(R value) {
-        return (t1) -> value;
-    }
-
-    /**
      * Creates a {@code CheckedFunction1} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
@@ -50,20 +50,6 @@ public interface CheckedFunction2<T1, T2, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, R> CheckedFunction2<T1, T2, R> constant(R value) {
-        return (t1, t2) -> value;
-    }
-
-    /**
      * Creates a {@code CheckedFunction2} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
@@ -50,21 +50,6 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, R> CheckedFunction3<T1, T2, T3, R> constant(R value) {
-        return (t1, t2, t3) -> value;
-    }
-
-    /**
      * Creates a {@code CheckedFunction3} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
@@ -51,22 +51,6 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, R> CheckedFunction4<T1, T2, T3, T4, R> constant(R value) {
-        return (t1, t2, t3, t4) -> value;
-    }
-
-    /**
      * Creates a {@code CheckedFunction4} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
@@ -52,23 +52,6 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, R> CheckedFunction5<T1, T2, T3, T4, T5, R> constant(R value) {
-        return (t1, t2, t3, t4, t5) -> value;
-    }
-
-    /**
      * Creates a {@code CheckedFunction5} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
@@ -53,24 +53,6 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, R> CheckedFunction6<T1, T2, T3, T4, T5, T6, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6) -> value;
-    }
-
-    /**
      * Creates a {@code CheckedFunction6} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
@@ -54,25 +54,6 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <T7> generic parameter type 7 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, R> CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6, t7) -> value;
-    }
-
-    /**
      * Creates a {@code CheckedFunction7} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
@@ -55,26 +55,6 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lam
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <T7> generic parameter type 7 of the resulting function
-     * @param <T8> generic parameter type 8 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, T8, R> CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6, t7, t8) -> value;
-    }
-
-    /**
      * Creates a {@code CheckedFunction8} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/Function0.java
+++ b/vavr/src-gen/main/java/io/vavr/Function0.java
@@ -46,19 +46,6 @@ public interface Function0<R> extends Lambda<R>, Supplier<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <R> Function0<R> constant(R value) {
-        return () -> value;
-    }
-
-    /**
      * Creates a {@code Function0} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -49,19 +49,6 @@ public interface Function1<T1, R> extends Lambda<R>, Function<T1, R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, R> Function1<T1, R> constant(R value) {
-        return (t1) -> value;
-    }
-
-    /**
      * Creates a {@code Function1} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/Function2.java
+++ b/vavr/src-gen/main/java/io/vavr/Function2.java
@@ -50,20 +50,6 @@ public interface Function2<T1, T2, R> extends Lambda<R>, BiFunction<T1, T2, R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, R> Function2<T1, T2, R> constant(R value) {
-        return (t1, t2) -> value;
-    }
-
-    /**
      * Creates a {@code Function2} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/Function3.java
+++ b/vavr/src-gen/main/java/io/vavr/Function3.java
@@ -50,21 +50,6 @@ public interface Function3<T1, T2, T3, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, R> Function3<T1, T2, T3, R> constant(R value) {
-        return (t1, t2, t3) -> value;
-    }
-
-    /**
      * Creates a {@code Function3} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/Function4.java
+++ b/vavr/src-gen/main/java/io/vavr/Function4.java
@@ -51,22 +51,6 @@ public interface Function4<T1, T2, T3, T4, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, R> Function4<T1, T2, T3, T4, R> constant(R value) {
-        return (t1, t2, t3, t4) -> value;
-    }
-
-    /**
      * Creates a {@code Function4} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/Function5.java
+++ b/vavr/src-gen/main/java/io/vavr/Function5.java
@@ -52,23 +52,6 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, R> Function5<T1, T2, T3, T4, T5, R> constant(R value) {
-        return (t1, t2, t3, t4, t5) -> value;
-    }
-
-    /**
      * Creates a {@code Function5} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/Function6.java
+++ b/vavr/src-gen/main/java/io/vavr/Function6.java
@@ -53,24 +53,6 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, R> Function6<T1, T2, T3, T4, T5, T6, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6) -> value;
-    }
-
-    /**
      * Creates a {@code Function6} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/Function7.java
+++ b/vavr/src-gen/main/java/io/vavr/Function7.java
@@ -54,25 +54,6 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Lambda<R> {
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <T7> generic parameter type 7 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, R> Function7<T1, T2, T3, T4, T5, T6, T7, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6, t7) -> value;
-    }
-
-    /**
      * Creates a {@code Function7} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/main/java/io/vavr/Function8.java
+++ b/vavr/src-gen/main/java/io/vavr/Function8.java
@@ -55,26 +55,6 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Lambda<R> 
     long serialVersionUID = 1L;
 
     /**
-     * Returns a function that always returns the constant
-     * value that you give in parameter.
-     *
-     * @param <T1> generic parameter type 1 of the resulting function
-     * @param <T2> generic parameter type 2 of the resulting function
-     * @param <T3> generic parameter type 3 of the resulting function
-     * @param <T4> generic parameter type 4 of the resulting function
-     * @param <T5> generic parameter type 5 of the resulting function
-     * @param <T6> generic parameter type 6 of the resulting function
-     * @param <T7> generic parameter type 7 of the resulting function
-     * @param <T8> generic parameter type 8 of the resulting function
-     * @param <R> the result type
-     * @param value the value to be returned
-     * @return a function always returning the given value
-     */
-    static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> constant(R value) {
-        return (t1, t2, t3, t4, t5, t6, t7, t8) -> value;
-    }
-
-    /**
      * Creates a {@code Function8} based on
      * <ul>
      * <li><a href="https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html">method reference</a></li>

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction0Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction0Test.java
@@ -57,12 +57,6 @@ public class CheckedFunction0Test {
     }
 
     @Test
-    public void shouldConstant() throws Throwable {
-        final CheckedFunction0<Object> f = CheckedFunction0.constant(6);
-        assertThat(f.apply()).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final CheckedFunction0<Object> f = () -> null;
         final CheckedFunction0<Object> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction1Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction1Test.java
@@ -64,12 +64,6 @@ public class CheckedFunction1Test {
     }
 
     @Test
-    public void shouldConstant() throws Throwable {
-        final CheckedFunction1<Object, Object> f = CheckedFunction1.constant(6);
-        assertThat(f.apply(1)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final CheckedFunction1<Object, Object> f = (o1) -> null;
         final CheckedFunction1<Object, Object> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction2Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction2Test.java
@@ -63,12 +63,6 @@ public class CheckedFunction2Test {
     }
 
     @Test
-    public void shouldConstant() throws Throwable {
-        final CheckedFunction2<Object, Object, Object> f = CheckedFunction2.constant(6);
-        assertThat(f.apply(1, 2)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final CheckedFunction2<Object, Object, Object> f = (o1, o2) -> null;
         final Function1<Object, CheckedFunction1<Object, Object>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction3Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction3Test.java
@@ -64,12 +64,6 @@ public class CheckedFunction3Test {
     }
 
     @Test
-    public void shouldConstant() throws Throwable {
-        final CheckedFunction3<Object, Object, Object, Object> f = CheckedFunction3.constant(6);
-        assertThat(f.apply(1, 2, 3)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final CheckedFunction3<Object, Object, Object, Object> f = (o1, o2, o3) -> null;
         final Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction4Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction4Test.java
@@ -65,12 +65,6 @@ public class CheckedFunction4Test {
     }
 
     @Test
-    public void shouldConstant() throws Throwable {
-        final CheckedFunction4<Object, Object, Object, Object, Object> f = CheckedFunction4.constant(6);
-        assertThat(f.apply(1, 2, 3, 4)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final CheckedFunction4<Object, Object, Object, Object, Object> f = (o1, o2, o3, o4) -> null;
         final Function1<Object, Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction5Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction5Test.java
@@ -66,12 +66,6 @@ public class CheckedFunction5Test {
     }
 
     @Test
-    public void shouldConstant() throws Throwable {
-        final CheckedFunction5<Object, Object, Object, Object, Object, Object> f = CheckedFunction5.constant(6);
-        assertThat(f.apply(1, 2, 3, 4, 5)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final CheckedFunction5<Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction6Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction6Test.java
@@ -67,12 +67,6 @@ public class CheckedFunction6Test {
     }
 
     @Test
-    public void shouldConstant() throws Throwable {
-        final CheckedFunction6<Object, Object, Object, Object, Object, Object, Object> f = CheckedFunction6.constant(6);
-        assertThat(f.apply(1, 2, 3, 4, 5, 6)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final CheckedFunction6<Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>>>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction7Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction7Test.java
@@ -68,12 +68,6 @@ public class CheckedFunction7Test {
     }
 
     @Test
-    public void shouldConstant() throws Throwable {
-        final CheckedFunction7<Object, Object, Object, Object, Object, Object, Object, Object> f = CheckedFunction7.constant(6);
-        assertThat(f.apply(1, 2, 3, 4, 5, 6, 7)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final CheckedFunction7<Object, Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6, o7) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>>>>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction8Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction8Test.java
@@ -69,12 +69,6 @@ public class CheckedFunction8Test {
     }
 
     @Test
-    public void shouldConstant() throws Throwable {
-        final CheckedFunction8<Object, Object, Object, Object, Object, Object, Object, Object, Object> f = CheckedFunction8.constant(6);
-        assertThat(f.apply(1, 2, 3, 4, 5, 6, 7, 8)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final CheckedFunction8<Object, Object, Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6, o7, o8) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, CheckedFunction1<Object, Object>>>>>>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/Function0Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function0Test.java
@@ -62,12 +62,6 @@ public class Function0Test {
     }
 
     @Test
-    public void shouldConstant() {
-        final Function0<Object> f = Function0.constant(6);
-        assertThat(f.apply()).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final Function0<Object> f = () -> null;
         final Function0<Object> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/Function1Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function1Test.java
@@ -63,12 +63,6 @@ public class Function1Test {
     }
 
     @Test
-    public void shouldConstant() {
-        final Function1<Object, Object> f = Function1.constant(6);
-        assertThat(f.apply(1)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final Function1<Object, Object> f = (o1) -> null;
         final Function1<Object, Object> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/Function2Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function2Test.java
@@ -61,12 +61,6 @@ public class Function2Test {
     }
 
     @Test
-    public void shouldConstant() {
-        final Function2<Object, Object, Object> f = Function2.constant(6);
-        assertThat(f.apply(1, 2)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final Function2<Object, Object, Object> f = (o1, o2) -> null;
         final Function1<Object, Function1<Object, Object>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/Function3Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function3Test.java
@@ -62,12 +62,6 @@ public class Function3Test {
     }
 
     @Test
-    public void shouldConstant() {
-        final Function3<Object, Object, Object, Object> f = Function3.constant(6);
-        assertThat(f.apply(1, 2, 3)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final Function3<Object, Object, Object, Object> f = (o1, o2, o3) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Object>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/Function4Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function4Test.java
@@ -63,12 +63,6 @@ public class Function4Test {
     }
 
     @Test
-    public void shouldConstant() {
-        final Function4<Object, Object, Object, Object, Object> f = Function4.constant(6);
-        assertThat(f.apply(1, 2, 3, 4)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final Function4<Object, Object, Object, Object, Object> f = (o1, o2, o3, o4) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Object>>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/Function5Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function5Test.java
@@ -64,12 +64,6 @@ public class Function5Test {
     }
 
     @Test
-    public void shouldConstant() {
-        final Function5<Object, Object, Object, Object, Object, Object> f = Function5.constant(6);
-        assertThat(f.apply(1, 2, 3, 4, 5)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final Function5<Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Object>>>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/Function6Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function6Test.java
@@ -65,12 +65,6 @@ public class Function6Test {
     }
 
     @Test
-    public void shouldConstant() {
-        final Function6<Object, Object, Object, Object, Object, Object, Object> f = Function6.constant(6);
-        assertThat(f.apply(1, 2, 3, 4, 5, 6)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final Function6<Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Object>>>>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/Function7Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function7Test.java
@@ -66,12 +66,6 @@ public class Function7Test {
     }
 
     @Test
-    public void shouldConstant() {
-        final Function7<Object, Object, Object, Object, Object, Object, Object, Object> f = Function7.constant(6);
-        assertThat(f.apply(1, 2, 3, 4, 5, 6, 7)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final Function7<Object, Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6, o7) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Object>>>>>>> curried = f.curried();

--- a/vavr/src-gen/test/java/io/vavr/Function8Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function8Test.java
@@ -67,12 +67,6 @@ public class Function8Test {
     }
 
     @Test
-    public void shouldConstant() {
-        final Function8<Object, Object, Object, Object, Object, Object, Object, Object, Object> f = Function8.constant(6);
-        assertThat(f.apply(1, 2, 3, 4, 5, 6, 7, 8)).isEqualTo(6);
-    }
-
-    @Test
     public void shouldCurry() {
         final Function8<Object, Object, Object, Object, Object, Object, Object, Object, Object> f = (o1, o2, o3, o4, o5, o6, o7, o8) -> null;
         final Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Function1<Object, Object>>>>>>>> curried = f.curried();


### PR DESCRIPTION
From [1]:

> Hi @skestle, instead of widening the API I strive for simplifying it.
> We should remove the constant function in favor of using the existing
>
> ```
> interface Function1<T1, R> {
>     static <T1, R> Function1<T1, R> of(Function1<T1, R> methodReference) {
>        return methodReference;
>    }
> }
> ```
>
> Then the use-cases can be implemented like this:
> ```
> // = Function1.constant(1)
> Function1.of(ignored -> 1);
>
> // = Function1.suppliedWith(() -> 1)
> Function1.of(ignored -> 1);
> ```
> I will create an issue.

Closes #2266.

[1] https://github.com/vavr-io/vavr/issues/2259#issuecomment-408408676