### PR TITLE
Removed the unsafe 'sneaky throw'

### DIFF
--- a/vavr-test/generator/Generator.scala
+++ b/vavr-test/generator/Generator.scala
@@ -274,18 +274,21 @@ def generateMainClasses(): Unit = {
                                                   return new CheckResult.Falsified(name, i, $tupleType.of(${(1 to i).gen(j => s"val$j")(", ")}));
                                               }
                                           }
-                                      } catch(CheckError err) {
+                                      } catch($tryType.NonFatalThrowable x) {
+                                          final CheckError err = (CheckError) x.getCause();
                                           logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                                           return new CheckResult.Erroneous(name, i, err, $optionType.some($tupleType.of(${(1 to i).gen(j => s"val$j")(", ")})));
                                       }
-                                  } catch(CheckError err) {
+                                  } catch($tryType.NonFatalThrowable x) {
+                                      final CheckError err = (CheckError) x.getCause();
                                       logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                                       return new CheckResult.Erroneous(name, i, err, $optionType.none());
                                   }
                               }
                               logSatisfied(name, tries, System.currentTimeMillis() - startTime, exhausted);
                               return new CheckResult.Satisfied(name, tries, exhausted);
-                          } catch(CheckError err) {
+                          } catch($tryType.NonFatalThrowable x) {
+                              final CheckError err = (CheckError) x.getCause();
                               logErroneous(name, 0, System.currentTimeMillis() - startTime, err.getMessage());
                               return new CheckResult.Erroneous(name, 0, err, $optionType.none());
                           }

--- a/vavr-test/src-gen/main/java/io/vavr/test/Property.java
+++ b/vavr-test/src-gen/main/java/io/vavr/test/Property.java
@@ -621,18 +621,21 @@ public class Property {
                                     return new CheckResult.Falsified(name, i, Tuple.of(val1));
                                 }
                             }
-                        } catch(CheckError err) {
+                        } catch(Try.NonFatalThrowable x) {
+                            final CheckError err = (CheckError) x.getCause();
                             logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                             return new CheckResult.Erroneous(name, i, err, Option.some(Tuple.of(val1)));
                         }
-                    } catch(CheckError err) {
+                    } catch(Try.NonFatalThrowable x) {
+                        final CheckError err = (CheckError) x.getCause();
                         logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                         return new CheckResult.Erroneous(name, i, err, Option.none());
                     }
                 }
                 logSatisfied(name, tries, System.currentTimeMillis() - startTime, exhausted);
                 return new CheckResult.Satisfied(name, tries, exhausted);
-            } catch(CheckError err) {
+            } catch(Try.NonFatalThrowable x) {
+                final CheckError err = (CheckError) x.getCause();
                 logErroneous(name, 0, System.currentTimeMillis() - startTime, err.getMessage());
                 return new CheckResult.Erroneous(name, 0, err, Option.none());
             }
@@ -700,18 +703,21 @@ public class Property {
                                     return new CheckResult.Falsified(name, i, Tuple.of(val1, val2));
                                 }
                             }
-                        } catch(CheckError err) {
+                        } catch(Try.NonFatalThrowable x) {
+                            final CheckError err = (CheckError) x.getCause();
                             logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                             return new CheckResult.Erroneous(name, i, err, Option.some(Tuple.of(val1, val2)));
                         }
-                    } catch(CheckError err) {
+                    } catch(Try.NonFatalThrowable x) {
+                        final CheckError err = (CheckError) x.getCause();
                         logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                         return new CheckResult.Erroneous(name, i, err, Option.none());
                     }
                 }
                 logSatisfied(name, tries, System.currentTimeMillis() - startTime, exhausted);
                 return new CheckResult.Satisfied(name, tries, exhausted);
-            } catch(CheckError err) {
+            } catch(Try.NonFatalThrowable x) {
+                final CheckError err = (CheckError) x.getCause();
                 logErroneous(name, 0, System.currentTimeMillis() - startTime, err.getMessage());
                 return new CheckResult.Erroneous(name, 0, err, Option.none());
             }
@@ -783,18 +789,21 @@ public class Property {
                                     return new CheckResult.Falsified(name, i, Tuple.of(val1, val2, val3));
                                 }
                             }
-                        } catch(CheckError err) {
+                        } catch(Try.NonFatalThrowable x) {
+                            final CheckError err = (CheckError) x.getCause();
                             logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                             return new CheckResult.Erroneous(name, i, err, Option.some(Tuple.of(val1, val2, val3)));
                         }
-                    } catch(CheckError err) {
+                    } catch(Try.NonFatalThrowable x) {
+                        final CheckError err = (CheckError) x.getCause();
                         logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                         return new CheckResult.Erroneous(name, i, err, Option.none());
                     }
                 }
                 logSatisfied(name, tries, System.currentTimeMillis() - startTime, exhausted);
                 return new CheckResult.Satisfied(name, tries, exhausted);
-            } catch(CheckError err) {
+            } catch(Try.NonFatalThrowable x) {
+                final CheckError err = (CheckError) x.getCause();
                 logErroneous(name, 0, System.currentTimeMillis() - startTime, err.getMessage());
                 return new CheckResult.Erroneous(name, 0, err, Option.none());
             }
@@ -870,18 +879,21 @@ public class Property {
                                     return new CheckResult.Falsified(name, i, Tuple.of(val1, val2, val3, val4));
                                 }
                             }
-                        } catch(CheckError err) {
+                        } catch(Try.NonFatalThrowable x) {
+                            final CheckError err = (CheckError) x.getCause();
                             logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                             return new CheckResult.Erroneous(name, i, err, Option.some(Tuple.of(val1, val2, val3, val4)));
                         }
-                    } catch(CheckError err) {
+                    } catch(Try.NonFatalThrowable x) {
+                        final CheckError err = (CheckError) x.getCause();
                         logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                         return new CheckResult.Erroneous(name, i, err, Option.none());
                     }
                 }
                 logSatisfied(name, tries, System.currentTimeMillis() - startTime, exhausted);
                 return new CheckResult.Satisfied(name, tries, exhausted);
-            } catch(CheckError err) {
+            } catch(Try.NonFatalThrowable x) {
+                final CheckError err = (CheckError) x.getCause();
                 logErroneous(name, 0, System.currentTimeMillis() - startTime, err.getMessage());
                 return new CheckResult.Erroneous(name, 0, err, Option.none());
             }
@@ -961,18 +973,21 @@ public class Property {
                                     return new CheckResult.Falsified(name, i, Tuple.of(val1, val2, val3, val4, val5));
                                 }
                             }
-                        } catch(CheckError err) {
+                        } catch(Try.NonFatalThrowable x) {
+                            final CheckError err = (CheckError) x.getCause();
                             logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                             return new CheckResult.Erroneous(name, i, err, Option.some(Tuple.of(val1, val2, val3, val4, val5)));
                         }
-                    } catch(CheckError err) {
+                    } catch(Try.NonFatalThrowable x) {
+                        final CheckError err = (CheckError) x.getCause();
                         logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                         return new CheckResult.Erroneous(name, i, err, Option.none());
                     }
                 }
                 logSatisfied(name, tries, System.currentTimeMillis() - startTime, exhausted);
                 return new CheckResult.Satisfied(name, tries, exhausted);
-            } catch(CheckError err) {
+            } catch(Try.NonFatalThrowable x) {
+                final CheckError err = (CheckError) x.getCause();
                 logErroneous(name, 0, System.currentTimeMillis() - startTime, err.getMessage());
                 return new CheckResult.Erroneous(name, 0, err, Option.none());
             }
@@ -1056,18 +1071,21 @@ public class Property {
                                     return new CheckResult.Falsified(name, i, Tuple.of(val1, val2, val3, val4, val5, val6));
                                 }
                             }
-                        } catch(CheckError err) {
+                        } catch(Try.NonFatalThrowable x) {
+                            final CheckError err = (CheckError) x.getCause();
                             logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                             return new CheckResult.Erroneous(name, i, err, Option.some(Tuple.of(val1, val2, val3, val4, val5, val6)));
                         }
-                    } catch(CheckError err) {
+                    } catch(Try.NonFatalThrowable x) {
+                        final CheckError err = (CheckError) x.getCause();
                         logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                         return new CheckResult.Erroneous(name, i, err, Option.none());
                     }
                 }
                 logSatisfied(name, tries, System.currentTimeMillis() - startTime, exhausted);
                 return new CheckResult.Satisfied(name, tries, exhausted);
-            } catch(CheckError err) {
+            } catch(Try.NonFatalThrowable x) {
+                final CheckError err = (CheckError) x.getCause();
                 logErroneous(name, 0, System.currentTimeMillis() - startTime, err.getMessage());
                 return new CheckResult.Erroneous(name, 0, err, Option.none());
             }
@@ -1155,18 +1173,21 @@ public class Property {
                                     return new CheckResult.Falsified(name, i, Tuple.of(val1, val2, val3, val4, val5, val6, val7));
                                 }
                             }
-                        } catch(CheckError err) {
+                        } catch(Try.NonFatalThrowable x) {
+                            final CheckError err = (CheckError) x.getCause();
                             logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                             return new CheckResult.Erroneous(name, i, err, Option.some(Tuple.of(val1, val2, val3, val4, val5, val6, val7)));
                         }
-                    } catch(CheckError err) {
+                    } catch(Try.NonFatalThrowable x) {
+                        final CheckError err = (CheckError) x.getCause();
                         logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                         return new CheckResult.Erroneous(name, i, err, Option.none());
                     }
                 }
                 logSatisfied(name, tries, System.currentTimeMillis() - startTime, exhausted);
                 return new CheckResult.Satisfied(name, tries, exhausted);
-            } catch(CheckError err) {
+            } catch(Try.NonFatalThrowable x) {
+                final CheckError err = (CheckError) x.getCause();
                 logErroneous(name, 0, System.currentTimeMillis() - startTime, err.getMessage());
                 return new CheckResult.Erroneous(name, 0, err, Option.none());
             }
@@ -1258,18 +1279,21 @@ public class Property {
                                     return new CheckResult.Falsified(name, i, Tuple.of(val1, val2, val3, val4, val5, val6, val7, val8));
                                 }
                             }
-                        } catch(CheckError err) {
+                        } catch(Try.NonFatalThrowable x) {
+                            final CheckError err = (CheckError) x.getCause();
                             logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                             return new CheckResult.Erroneous(name, i, err, Option.some(Tuple.of(val1, val2, val3, val4, val5, val6, val7, val8)));
                         }
-                    } catch(CheckError err) {
+                    } catch(Try.NonFatalThrowable x) {
+                        final CheckError err = (CheckError) x.getCause();
                         logErroneous(name, i, System.currentTimeMillis() - startTime, err.getMessage());
                         return new CheckResult.Erroneous(name, i, err, Option.none());
                     }
                 }
                 logSatisfied(name, tries, System.currentTimeMillis() - startTime, exhausted);
                 return new CheckResult.Satisfied(name, tries, exhausted);
-            } catch(CheckError err) {
+            } catch(Try.NonFatalThrowable x) {
+                final CheckError err = (CheckError) x.getCause();
                 logErroneous(name, 0, System.currentTimeMillis() - startTime, err.getMessage());
                 return new CheckResult.Erroneous(name, 0, err, Option.none());
             }

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -530,6 +530,7 @@ def generateMainClasses(): Unit = {
            * @param supplier A checked supplier
            * @return {@link $TryType.Success} if no exception occurs, otherwise {@link $TryType.Failure} if an
            * exception occurs calling {@code supplier.get()}.
+           * @throws Error if the result is a {@link $TryType.Failure} and the underlying cause is fatal, i.e. non-recoverable
            */
           public static <T> $TryType<T> Try($CheckedFunction0Type<? extends T> supplier) {
               return $TryType.of(supplier);
@@ -553,6 +554,7 @@ def generateMainClasses(): Unit = {
            * @param <T>       Component type of the {@code Try}.
            * @param exception An exception.
            * @return A new {@link $TryType.Failure}.
+           * @throws Error if the given {@code exception} is fatal, i.e. non-recoverable
            */
           @SuppressWarnings("unchecked")
           public static <T> $TryType.Failure<T> Failure(Throwable exception) {

--- a/vavr/src-gen/main/java/io/vavr/API.java
+++ b/vavr/src-gen/main/java/io/vavr/API.java
@@ -911,6 +911,7 @@ public final class API {
      * @param supplier A checked supplier
      * @return {@link Try.Success} if no exception occurs, otherwise {@link Try.Failure} if an
      * exception occurs calling {@code supplier.get()}.
+     * @throws Error if the result is a {@link Try.Failure} and the underlying cause is fatal, i.e. non-recoverable
      */
     public static <T> Try<T> Try(CheckedFunction0<? extends T> supplier) {
         return Try.of(supplier);
@@ -934,6 +935,7 @@ public final class API {
      * @param <T>       Component type of the {@code Try}.
      * @param exception An exception.
      * @return A new {@link Try.Failure}.
+     * @throws Error if the given {@code exception} is fatal, i.e. non-recoverable
      */
     @SuppressWarnings("unchecked")
     public static <T> Try.Failure<T> Failure(Throwable exception) {

--- a/vavr/src/main/java/io/vavr/Value.java
+++ b/vavr/src/main/java/io/vavr/Value.java
@@ -1344,7 +1344,8 @@ public interface Value<T> extends Iterable<T> {
         if (this instanceof Try) {
             return (Try<T>) this;
         } else {
-            return Try.of(this::get);
+            // TODO: workaround. the Value class will be deleted with Vavr 1.0 and conversion will be moved to types
+            return Try.of(this::get).recoverWith(Try.NonFatalThrowable.class, x -> Try.failure(x.getCause()));
         }
     }
 

--- a/vavr/src/test/java/io/vavr/AbstractValueTest.java
+++ b/vavr/src/test/java/io/vavr/AbstractValueTest.java
@@ -103,7 +103,7 @@ public abstract class AbstractValueTest {
 
     // -- get()
 
-    @Test(expected = NoSuchElementException.class)
+    @Test(expected = RuntimeException.class)
     public void shouldGetEmpty() {
         empty().get();
     }
@@ -165,7 +165,7 @@ public abstract class AbstractValueTest {
         assertThat(empty().getOrElseTry(() -> 2)).isEqualTo(2);
     }
 
-    @Test(expected = Error.class)
+    @Test(expected = RuntimeException.class)
     public void shouldThrowWhenCallingGetOrElseTryOnEmptyValueAndTryIsAFailure() {
         empty().getOrElseTry(() -> {
             throw new Error();
@@ -519,7 +519,7 @@ public abstract class AbstractValueTest {
     public void shouldConvertEmptyToTry() {
         final Try<?> actual = empty().toTry();
         assertThat(actual.isFailure()).isTrue();
-        assertThat(actual.getCause()).isInstanceOf(NoSuchElementException.class);
+        assertThat(actual.getCause()).isExactlyInstanceOf(NoSuchElementException.class);
     }
 
     @Test

--- a/vavr/src/test/java/io/vavr/concurrent/FutureTest.java
+++ b/vavr/src/test/java/io/vavr/concurrent/FutureTest.java
@@ -508,7 +508,7 @@ public class FutureTest extends AbstractValueTest {
     @Test
     public void shouldHandleInterruptedExceptionCorrectlyInAwait() {
         final Future<Void> future = Future.run(() -> { throw new InterruptedException(); });
-        future.await(100, TimeUnit.MILLISECONDS);
+        future.await(1000, TimeUnit.MILLISECONDS);
         assertThat(future.isFailure()).isTrue();
         assertThat(future.getCause().get()).isInstanceOf(InterruptedException.class);
     }


### PR DESCRIPTION
Solves #2049 by reverting #1722.

This version contains the new runtime exception type `NonFatalThrowable`, which is thrown by `Try#get()`. It is a wrapper for non-fatal, non-runtime throwables. The original name was `NonFatalException`.

The `FatalException` disappeared. Instead we re-throw fatal errors. I changed the definition of fatal error. Now only a subset of `Error` is defined to be fatal. Previously we defined `InterruptedException` to be fatal. [Scala folks interpret it as fatal](https://coderwall.com/p/_5zluw/catch-interruptedexception-in-scala-with-try-catch-not-scala-util-try) because they expect it to be handled when Thread.sleep() is interrupted. But it is an Exception. By definition it can't be a fatal error that prevents the VM from running correctly.