### PR TITLE
Modularization: made PartialFunction independent of Option and Value.

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -209,7 +209,7 @@ public interface Option<T> extends Value<T>, Serializable {
      */
     default <R> Option<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         Objects.requireNonNull(partialFunction, "partialFunction is null");
-        return flatMap(partialFunction.lift()::apply);
+        return filter(partialFunction::isDefinedAt).map(partialFunction::apply);
     }
 
     /**

--- a/vavr/src/test/java/io/vavr/PartialFunctionTest.java
+++ b/vavr/src/test/java/io/vavr/PartialFunctionTest.java
@@ -19,66 +19,152 @@
  */
 package io.vavr;
 
-import io.vavr.collection.HashMap;
-import io.vavr.collection.List;
-import io.vavr.control.Either;
-import io.vavr.control.Option;
 import org.junit.Test;
 
-import java.util.function.Predicate;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// DEV-NOTE: we must not write pf.apply(t) tests for the case pf.isDefinedAt(t) == false
 public class PartialFunctionTest {
 
+    // -- andThen
+
     @Test
-    public void shouldReturnSome() {
-        Option<String> oneToOne = HashMap.of(1, "One").lift().apply(1);
-        assertThat(oneToOne).isEqualTo(Option.some("One"));
+    public void shouldComposeWithAndThenAndCheckDefinedState() {
+        assertThat(hyperbola.andThen(hyperbola).isDefinedAt(0.5d)).isTrue();
     }
 
     @Test
-    public void shouldReturnNone() {
-        Option<String> oneToOne = HashMap.<Integer, String>empty().lift().apply(1);
-        assertThat(oneToOne).isEqualTo(Option.none());
+    public void shouldComposeWithAndThenAndApplyDefinedValue() {
+        assertThat(hyperbola.andThen(hyperbola).apply(0.5d)).isEqualTo(0.5d);
     }
 
     @Test
-    public void shouldUnliftTotalFunctionReturningAnOption() {
-        final Predicate<Number> isEven = n -> n.intValue() % 2 == 0;
-        final Function1<Number, Option<String>> totalFunction = n -> isEven.test(n) ? Option.some("even") : Option.none();
+    public void shouldComposeWithAndThenAndCheckUndefinedState() {
+        assertThat(hyperbola.andThen(hyperbola).isDefinedAt(0d)).isFalse();
+    }
 
-        final PartialFunction<Integer, CharSequence> partialFunction = PartialFunction.unlift(totalFunction);
+    // -- apply
 
-        assertThat(partialFunction.isDefinedAt(1)).isFalse();
-        assertThat(partialFunction.isDefinedAt(2)).isTrue();
-        assertThat(partialFunction.apply(2)).isEqualTo("even");
+    @Test
+    public void shouldApplyDefinedDomainValue() {
+        assertThat(hyperbola.apply(1d)).isEqualTo(1d);
+    }
+
+    // -- applyOrElse
+
+    @Test
+    public void shouldApplyOrElseWhenDefined() {
+        assertThat(hyperbola.applyOrElse(1d, d -> 0d)).isEqualTo(1d);
     }
 
     @Test
-    public void shouldNotBeDefinedAtLeft() {
-        final Either<RuntimeException, Object> left = Either.left(new RuntimeException());
+    public void shouldApplyOrElseWhenUndefined() {
+        assertThat(hyperbola.applyOrElse(0d, d -> Double.NaN).isNaN()).isTrue();
+    }
 
-        assertThat(PartialFunction.getIfDefined().isDefinedAt(left)).isFalse();
+    // -- compose
+
+    @Test
+    public void shouldComposePartialFunctionWithFunctionDefinedCase() {
+        assertThat(hyperbola.compose(Function.identity()).apply(1d)).isEqualTo(1d);
+    }
+
+    // -- isDefinedAt
+
+    @Test
+    public void  shouldRecognizeDefinedDomainValue() {
+        assertThat(hyperbola.isDefinedAt(1d)).isTrue();
     }
 
     @Test
-    public void shouldBeDefinedAtRight() {
-        Either<Object, Number> right = Either.right(42);
+    public void  shouldRecognizeUndefinedDomainValue() {
+        assertThat(hyperbola.isDefinedAt(0d)).isFalse();
+    }
 
-        PartialFunction<Either<Object, Number>, Number> ifDefined = PartialFunction.getIfDefined();
+    // -- orElse
 
-        assertThat(ifDefined.isDefinedAt(right)).isTrue();
-        assertThat(ifDefined.apply(right)).isEqualTo(42);
+    @Test
+    public void shouldComposeWithOrElseThisDefinedFallbackDefined() {
+        final PartialFunction<Double, Double> testee = hyperbola.orElse(nan);
+        assertThat(testee.isDefinedAt(1d)).isTrue();
+        assertThat(testee.apply(1d)).isEqualTo(1d);
     }
 
     @Test
-    public void shouldCollectSomeValuesAndIgnoreNone() {
-        final List<Integer> evenNumbers = List.range(0, 10)
-          .map(n -> n % 2 == 0 ? Option.some(n) : Option.<Integer>none())
-          .collect(PartialFunction.getIfDefined());
-
-        assertThat(evenNumbers).containsExactly(0, 2, 4, 6, 8);
+    public void shouldComposeWithOrElseThisDefinedFallbackUndefined() {
+        final PartialFunction<Double, Double> testee = hyperbola.orElse(undefined);
+        assertThat(testee.isDefinedAt(1d)).isTrue();
     }
+
+    @Test
+    public void shouldComposeWithOrElseThisUndefinedFallbackDefined() {
+        final PartialFunction<Double, Double> testee = hyperbola.orElse(nan);
+        assertThat(testee.isDefinedAt(0d)).isTrue();
+        assertThat(testee.apply(0d)).isNaN();
+    }
+
+    @Test
+    public void shouldComposeWithOrElseThisUndefinedFallbackUndefined() {
+        final PartialFunction<Double, Double> testee = hyperbola.orElse(undefined);
+        assertThat(testee.isDefinedAt(0d)).isFalse();
+    }
+
+    // -- runWith
+
+    @Test
+    public void shouldRunWithDefinedPartialFunction() {
+        final boolean[] sideEffect = new boolean[] { false };
+        final Function<Double, Boolean> testee = hyperbola.runWith(d -> sideEffect[0] = true);
+        assertThat(testee.apply(1d)).isTrue();
+        assertThat(sideEffect[0]).isTrue();
+    }
+
+    @Test
+    public void shouldRunWithUndefinedPartialFunction() {
+        final boolean[] sideEffect = new boolean[] { false };
+        final Function<Double, Boolean> testee = hyperbola.runWith(d -> sideEffect[0] = true);
+        assertThat(testee.apply(0d)).isFalse();
+        assertThat(sideEffect[0]).isFalse();
+    }
+
+    // -- testees
+
+    private static PartialFunction<Double, Double> hyperbola = new PartialFunction<Double, Double>() {
+        private static final long serialVersionUID = 1L;
+        @Override
+        public Double apply(Double x) {
+            return 1/x;
+        }
+        @Override
+        public boolean isDefinedAt(Double x) {
+            return x != 0;
+        }
+    };
+
+    private static PartialFunction<Double, Double> nan = new PartialFunction<Double, Double>() {
+        private static final long serialVersionUID = 1L;
+        @Override
+        public Double apply(Double aDouble) {
+            return Double.NaN;
+        }
+        @Override
+        public boolean isDefinedAt(Double value) {
+            return true;
+        }
+    };
+
+    private static PartialFunction<Double, Double> undefined = new PartialFunction<Double, Double>() {
+        private static final long serialVersionUID = 1L;
+        @Override
+        public Double apply(Double aDouble) {
+            throw new UnsupportedOperationException();
+        }
+        @Override
+        public boolean isDefinedAt(Double value) {
+            return false;
+        }
+    };
 
 }


### PR DESCRIPTION
Applied the boy-scout rule (a good deed every day) and aligned PartialFunction to Scala 2.12.

_(Note: Scala's companion objects generally might contain additional functionality that we did not consider, yet. Not only for PartialFunction.)_