### PR TITLE
 Modularization: moving the monad conversion methods where they belong

### DIFF
--- a/vavr/src/main/java/io/vavr/Value.java
+++ b/vavr/src/main/java/io/vavr/Value.java
@@ -1135,19 +1135,6 @@ public interface Value<T> extends Iterable<T> {
     }
 
     /**
-     * Converts this to an {@link Option}.
-     *
-     * @return A new {@link Option}.
-     */
-    default Option<T> toOption() {
-        if (this instanceof Option) {
-            return (Option<T>) this;
-        } else {
-            return isEmpty() ? Option.none() : Option.some(get());
-        }
-    }
-
-    /**
      * Converts this to an {@link Either}.
      *
      * @param left A left value for the {@link Either}
@@ -1330,37 +1317,6 @@ public interface Value<T> extends Iterable<T> {
      */
     default Stream<T> toStream() {
         return ValueModule.toTraversable(this, Stream.empty(), Stream::of, Stream::ofAll);
-    }
-
-    /**
-     * Converts this to a {@link Try}.
-     * <p>
-     * If this value is undefined, i.e. empty, then a new {@code Failure(NoSuchElementException)} is returned,
-     * otherwise a new {@code Success(value)} is returned.
-     *
-     * @return A new {@link Try}.
-     */
-    default Try<T> toTry() {
-        if (this instanceof Try) {
-            return (Try<T>) this;
-        } else {
-            // TODO: workaround. the Value class will be deleted with Vavr 1.0 and conversion will be moved to types
-            return Try.of(this::get).recoverWith(Try.NonFatalThrowable.class, x -> Try.failure(x.getCause()));
-        }
-    }
-
-    /**
-     * Converts this to a {@link Try}.
-     * <p>
-     * If this value is undefined, i.e. empty, then a new {@code Failure(ifEmpty.get())} is returned,
-     * otherwise a new {@code Success(value)} is returned.
-     *
-     * @param ifEmpty an exception supplier
-     * @return A new {@link Try}.
-     */
-    default Try<T> toTry(Supplier<? extends Throwable> ifEmpty) {
-        Objects.requireNonNull(ifEmpty, "ifEmpty is null");
-        return isEmpty() ? Try.failure(ifEmpty.get()) : toTry();
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/Value.java
+++ b/vavr/src/main/java/io/vavr/Value.java
@@ -129,7 +129,6 @@ import static io.vavr.API.*;
  * <li>{@link #toJavaMap(Function)}</li>
  * <li>{@link #toJavaMap(Supplier, Function)}</li>
  * <li>{@link #toJavaMap(Supplier, Function, Function)} </li>
- * <li>{@link #toJavaOptional()}</li>
  * <li>{@link #toJavaParallelStream()}</li>
  * <li>{@link #toJavaSet()}</li>
  * <li>{@link #toJavaSet(Function)}</li>
@@ -142,7 +141,6 @@ import static io.vavr.API.*;
  * <li>{@link #toList()}</li>
  * <li>{@link #toMap(Function)}</li>
  * <li>{@link #toMap(Function, Function)}</li>
- * <li>{@link #toOption()}</li>
  * <li>{@link #toPriorityQueue()}</li>
  * <li>{@link #toPriorityQueue(Comparator)}</li>
  * <li>{@link #toQueue()}</li>
@@ -158,8 +156,6 @@ import static io.vavr.API.*;
  * <li>{@link #toStream()}</li>
  * <li>{@link #toString()}</li>
  * <li>{@link #toTree()}</li>
- * <li>{@link #toTry()}</li>
- * <li>{@link #toTry(Supplier)}</li>
  * <li>{@link #toValid(Object)}</li>
  * <li>{@link #toValid(Supplier)}</li>
  * <li>{@link #toVector()}</li>
@@ -563,19 +559,6 @@ public interface Value<T> extends Iterable<T> {
     }
 
     /**
-     * Converts this to a {@link CompletableFuture}
-     *
-     * @return A new {@link CompletableFuture} containing the value
-     */
-    default CompletableFuture<T> toCompletableFuture() {
-        final CompletableFuture<T> completableFuture = new CompletableFuture<>();
-        Try.of(this::get)
-                .onSuccess(completableFuture::complete)
-                .onFailure(completableFuture::completeExceptionally);
-        return completableFuture;
-    }
-
-    /**
      * Converts this to a {@link Validation}.
      *
      * @param <U>   value type of a {@code Valid}
@@ -852,29 +835,6 @@ public interface Value<T> extends Iterable<T> {
             }
         }
         return map;
-    }
-
-    /**
-     * Converts this to an {@link java.util.Optional}.
-     *
-     * <pre>{@code
-     * // = Optional.empty
-     * Future.of(() -> { throw new Error(); })
-     *       .toJavaOptional()
-     *
-     * // = Optional[ok]
-     * Try.of(() -> "ok")
-     *     .toJavaOptional()
-     *
-     * // = Optional[1]
-     * List.of(1, 2, 3)
-     *     .toJavaOptional()
-     * }</pre>
-     *
-     * @return A new {@link java.util.Optional}.
-     */
-    default Optional<T> toJavaOptional() {
-        return isEmpty() ? Optional.empty() : Optional.ofNullable(get());
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/Value.java
+++ b/vavr/src/main/java/io/vavr/Value.java
@@ -118,9 +118,6 @@ import static io.vavr.API.*;
  * <li>{@link #collect(Supplier, BiConsumer, BiConsumer)}</li>
  * <li>{@link #toArray()}</li>
  * <li>{@link #toCharSeq()}</li>
- * <li>{@link #toEither(Object)}</li>
- * <li>{@link #toEither(Supplier)}</li>
- * <li>{@link #toInvalid(Object)}</li>
  * <li>{@link #toJavaArray()}</li>
  * <li>{@link #toJavaArray(Class)}</li>
  * <li>{@link #toJavaCollection(Function)}</li>
@@ -133,8 +130,6 @@ import static io.vavr.API.*;
  * <li>{@link #toJavaSet()}</li>
  * <li>{@link #toJavaSet(Function)}</li>
  * <li>{@link #toJavaStream()}</li>
- * <li>{@link #toLeft(Object)}</li>
- * <li>{@link #toLeft(Supplier)}</li>
  * <li>{@link #toLinkedMap(Function)}</li>
  * <li>{@link #toLinkedMap(Function, Function)}</li>
  * <li>{@link #toLinkedSet()}</li>
@@ -144,8 +139,6 @@ import static io.vavr.API.*;
  * <li>{@link #toPriorityQueue()}</li>
  * <li>{@link #toPriorityQueue(Comparator)}</li>
  * <li>{@link #toQueue()}</li>
- * <li>{@link #toRight(Object)}</li>
- * <li>{@link #toRight(Supplier)}</li>
  * <li>{@link #toSet()}</li>
  * <li>{@link #toSortedMap(Comparator, Function)}</li>
  * <li>{@link #toSortedMap(Comparator, Function, Function)}</li>
@@ -156,8 +149,6 @@ import static io.vavr.API.*;
  * <li>{@link #toStream()}</li>
  * <li>{@link #toString()}</li>
  * <li>{@link #toTree()}</li>
- * <li>{@link #toValid(Object)}</li>
- * <li>{@link #toValid(Supplier)}</li>
  * <li>{@link #toVector()}</li>
  * </ul>
  *
@@ -559,32 +550,6 @@ public interface Value<T> extends Iterable<T> {
     }
 
     /**
-     * Converts this to a {@link Validation}.
-     *
-     * @param <U>   value type of a {@code Valid}
-     * @param value An instance of a {@code Valid} value
-     * @return A new {@link Validation.Valid} containing the given {@code value} if this is empty, otherwise
-     * a new {@link Validation.Invalid} containing this value.
-     */
-    default <U> Validation<T, U> toInvalid(U value) {
-        return isEmpty() ? Validation.valid(value) : Validation.invalid(get());
-    }
-
-    /**
-     * Converts this to a {@link Validation}.
-     *
-     * @param <U>           value type of a {@code Valid}
-     * @param valueSupplier A supplier of a {@code Valid} value
-     * @return A new {@link Validation.Valid} containing the result of {@code valueSupplier} if this is empty,
-     * otherwise a new {@link Validation.Invalid} containing this value.
-     * @throws NullPointerException if {@code valueSupplier} is null
-     */
-    default <U> Validation<T, U> toInvalid(Supplier<? extends U> valueSupplier) {
-        Objects.requireNonNull(valueSupplier, "valueSupplier is null");
-        return isEmpty() ? Validation.valid(valueSupplier.get()) : Validation.invalid(get());
-    }
-
-    /**
      * Converts this to a Java array with component type {@code Object}
      *
      * <pre>{@code
@@ -938,32 +903,6 @@ public interface Value<T> extends Iterable<T> {
     }
 
     /**
-     * Converts this to a {@link Either}.
-     *
-     * @param <R>   right type
-     * @param right An instance of a right value
-     * @return A new {@link Either.Right} containing the value of {@code right} if this is empty, otherwise
-     * a new {@link Either.Left} containing this value.
-     */
-    default <R> Either<T, R> toLeft(R right) {
-        return isEmpty() ? Either.right(right) : Either.left(get());
-    }
-
-    /**
-     * Converts this to a {@link Either}.
-     *
-     * @param <R>   right type
-     * @param right A supplier of a right value
-     * @return A new {@link Either.Right} containing the result of {@code right} if this is empty, otherwise
-     * a new {@link Either.Left} containing this value.
-     * @throws NullPointerException if {@code right} is null
-     */
-    default <R> Either<T, R> toLeft(Supplier<? extends R> right) {
-        Objects.requireNonNull(right, "right is null");
-        return isEmpty() ? Either.right(right.get()) : Either.left(get());
-    }
-
-    /**
      * Converts this to a {@link List}.
      *
      * @return A new {@link List}.
@@ -1095,68 +1034,6 @@ public interface Value<T> extends Iterable<T> {
     }
 
     /**
-     * Converts this to an {@link Either}.
-     *
-     * @param left A left value for the {@link Either}
-     * @param <L>  Either left component type
-     * @return A new {@link Either}.
-     */
-    default <L> Either<L, T> toEither(L left) {
-        if (this instanceof Either) {
-            return ((Either<?, T>) this).mapLeft(ignored -> left);
-        } else {
-            return isEmpty() ? Left(left) : Right(get());
-        }
-    }
-
-    /**
-     * Converts this to an {@link Either}.
-     *
-     * @param leftSupplier A {@link Supplier} for the left value for the {@link Either}
-     * @param <L>          Validation error component type
-     * @return A new {@link Either}.
-     */
-    default <L> Either<L, T> toEither(Supplier<? extends L> leftSupplier) {
-        Objects.requireNonNull(leftSupplier, "leftSupplier is null");
-        if (this instanceof Either) {
-            return ((Either<?, T>) this).mapLeft(ignored -> leftSupplier.get());
-        } else {
-            return isEmpty() ? Left(leftSupplier.get()) : Right(get());
-        }
-    }
-
-    /**
-     * Converts this to an {@link Validation}.
-     *
-     * @param invalid An invalid value for the {@link Validation}
-     * @param <E>     Validation error component type
-     * @return A new {@link Validation}.
-     */
-    default <E> Validation<E, T> toValid(E invalid) {
-        if (this instanceof Validation) {
-            return ((Validation<?, T>) this).mapErrors(ignored -> invalid);
-        } else {
-            return isEmpty() ? Validation.invalid(invalid) : Validation.valid(get());
-        }
-    }
-
-    /**
-     * Converts this to an {@link Validation}.
-     *
-     * @param invalidSupplier A {@link Supplier} for the invalid value for the {@link Validation}
-     * @param <E>             Validation error component type
-     * @return A new {@link Validation}.
-     */
-    default <E> Validation<E, T> toValid(Supplier<? extends E> invalidSupplier) {
-        Objects.requireNonNull(invalidSupplier, "invalidSupplier is null");
-        if (this instanceof Validation) {
-            return ((Validation<?, T>) this).mapErrors(ignored -> invalidSupplier.get());
-        } else {
-            return isEmpty() ? Validation.invalid(invalidSupplier.get()) : Validation.valid(get());
-        }
-    }
-
-    /**
      * Converts this to a {@link Queue}.
      *
      * @return A new {@link Queue}.
@@ -1194,32 +1071,6 @@ public interface Value<T> extends Iterable<T> {
         final Function<T, PriorityQueue<T>> of = value -> PriorityQueue.of(comparator, value);
         final Function<Iterable<T>, PriorityQueue<T>> ofAll = values -> PriorityQueue.ofAll(comparator, values);
         return ValueModule.toTraversable(this, empty, of, ofAll);
-    }
-
-    /**
-     * Converts this to a {@link Either}.
-     *
-     * @param <L>  left type
-     * @param left An instance of a left value
-     * @return A new {@link Either.Left} containing the value of {@code left} if this is empty, otherwise
-     * a new {@link Either.Right} containing this value.
-     */
-    default <L> Either<L, T> toRight(L left) {
-        return isEmpty() ? Either.left(left) : Either.right(get());
-    }
-
-    /**
-     * Converts this to a {@link Either}.
-     *
-     * @param <L>  left type
-     * @param left A supplier of a left value
-     * @return A new {@link Either.Left} containing the result of {@code left} if this is empty, otherwise
-     * a new {@link Either.Right} containing this value.
-     * @throws NullPointerException if {@code left} is null
-     */
-    default <L> Either<L, T> toRight(Supplier<? extends L> left) {
-        Objects.requireNonNull(left, "left is null");
-        return isEmpty() ? Either.left(left.get()) : Either.right(get());
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/concurrent/Future.java
+++ b/vavr/src/main/java/io/vavr/concurrent/Future.java
@@ -597,7 +597,12 @@ public interface Future<T> extends Value<T> {
         return FutureImpl.of(executor, Try.success(result));
     }
 
-    @Override
+
+    /**
+     * Converts this {@code Future} to a {@link java.util.concurrent.CompletableFuture}
+     *
+     * @return A new {@link CompletableFuture} that completes with this value on success, otherwise it completes exceptionally with this cause.
+     */
     default CompletableFuture<T> toCompletableFuture() {
         final CompletableFuture<T> future = new CompletableFuture<>();
         onSuccess(future::complete);

--- a/vavr/src/main/java/io/vavr/control/Either.java
+++ b/vavr/src/main/java/io/vavr/control/Either.java
@@ -449,7 +449,6 @@ public interface Either<L, R> extends Value<R>, Serializable {
      * If the {@code Either} is a {@code Right} and the predicate doesn't match, the
      * {@code Either} will be turned into a {@code Left} with contents computed by applying
      * the filterVal function to the {@code Either} value.
-     * <p>
      *
      * <pre>{@code
      * import static io.vavr.API.*;
@@ -462,11 +461,11 @@ public interface Either<L, R> extends Value<R>, Serializable {
      * }</pre>
      *
      * @param predicate A predicate
+     * @param zero a function that transforms the right value to a left value, if it does not make it through the given filter {@code predicate}
      * @return an {@code Either} instance
      * @throws NullPointerException if {@code predicate} is null
      */
-    default Either<L,R> filterOrElse(Predicate<? super R> predicate,
-                                     Function<? super R, ? extends L> zero) {
+    default Either<L,R> filterOrElse(Predicate<? super R> predicate, Function<? super R, ? extends L> zero) {
         Objects.requireNonNull(predicate, "predicate is null");
         Objects.requireNonNull(zero, "zero is null");
         if (isLeft() || predicate.test(get())) {

--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -20,7 +20,6 @@
 package io.vavr.control;
 
 import io.vavr.PartialFunction;
-import io.vavr.Tuple;
 import io.vavr.Value;
 import io.vavr.collection.Iterator;
 import io.vavr.collection.Seq;
@@ -430,6 +429,27 @@ public interface Option<T> extends Value<T>, Serializable {
     default <U> U transform(Function<? super Option<T>, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         return f.apply(this);
+    }
+
+    /**
+     * Converts this {@code Option} to a {@link Try}.
+     *
+     * @return {@code Try.success(get())} if this is defined, otherwise {@code Try.failure(new NoSuchElementException())}
+     */
+    default Try<T> toTry() {
+        return isEmpty() ? Try.failure(new NoSuchElementException()) : Try.success(get());
+    }
+
+    /**
+     * Converts this {@code Option} to a {@link Try}.
+     *
+     * @param ifEmpty an exception supplier
+     * @return {@code Try.success(get())} if this is defined, otherwise {@code Try.failure(ifEmpty.get()}
+     * @throws NullPointerException if the given supplier {@code ifEmpty} is null
+     */
+    default Try<T> toTry(Supplier<? extends Throwable> ifEmpty) {
+        Objects.requireNonNull(ifEmpty, "ifEmpty is null");
+        return isEmpty() ? Try.failure(ifEmpty.get()) : Try.success(get());
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -432,6 +432,15 @@ public interface Option<T> extends Value<T>, Serializable {
     }
 
     /**
+     * Converts this {@code Try} to a {@link java.util.Optional}.
+     *
+     * @return {@code Optional.ofNullable(get())} if this is defined, otherwise {@code Optional.empty()}
+     */
+    default Optional<T> toJavaOptional() {
+        return isEmpty() ? Optional.empty() : Optional.ofNullable(get());
+    }
+
+    /**
      * Converts this {@code Option} to a {@link Try}.
      *
      * @return {@code Try.success(get())} if this is defined, otherwise {@code Try.failure(new NoSuchElementException())}

--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -436,7 +436,7 @@ public interface Option<T> extends Value<T>, Serializable {
      *
      * @return {@code Optional.ofNullable(get())} if this is defined, otherwise {@code Optional.empty()}
      */
-    default Optional<T> toJavaOptional() {
+    default Optional<T> toOptional() {
         return isEmpty() ? Optional.empty() : Optional.ofNullable(get());
     }
 

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -994,6 +994,15 @@ public interface Try<T> extends Value<T>, Serializable {
     }
 
     /**
+     * Converts this {@code Try} to a {@link Option}.
+     *
+     * @return {@code Option.some(get())} if this is defined, otherwise {@code Option.none()}
+     */
+    default Option<T> toOption() {
+        return isEmpty() ? Option.none() : Option.some(get());
+    }
+
+    /**
      * Converts this {@code Try} to a {@link Validation}.
      *
      * @return A new {@code Validation}

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -991,6 +992,15 @@ public interface Try<T> extends Value<T>, Serializable {
         } else {
             return Either.right(get());
         }
+    }
+    
+    /**
+     * Converts this {@code Try} to a {@link java.util.Optional}.
+     *
+     * @return {@code Optional.ofNullable(get())} if this is defined, otherwise {@code Optional.empty()}
+     */
+    default Optional<T> toJavaOptional() {
+        return isEmpty() ? Optional.empty() : Optional.ofNullable(get());
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -995,21 +995,21 @@ public interface Try<T> extends Value<T>, Serializable {
     }
     
     /**
-     * Converts this {@code Try} to a {@link java.util.Optional}.
-     *
-     * @return {@code Optional.ofNullable(get())} if this is defined, otherwise {@code Optional.empty()}
-     */
-    default Optional<T> toJavaOptional() {
-        return isEmpty() ? Optional.empty() : Optional.ofNullable(get());
-    }
-
-    /**
      * Converts this {@code Try} to a {@link Option}.
      *
      * @return {@code Option.some(get())} if this is defined, otherwise {@code Option.none()}
      */
     default Option<T> toOption() {
         return isEmpty() ? Option.none() : Option.some(get());
+    }
+
+    /**
+     * Converts this {@code Try} to a {@link java.util.Optional}.
+     *
+     * @return {@code Optional.ofNullable(get())} if this is defined, otherwise {@code Optional.empty()}
+     */
+    default Optional<T> toOptional() {
+        return isEmpty() ? Optional.empty() : Optional.ofNullable(get());
     }
 
     /**

--- a/vavr/src/test/java/io/vavr/AbstractValueTest.java
+++ b/vavr/src/test/java/io/vavr/AbstractValueTest.java
@@ -20,7 +20,6 @@
 package io.vavr;
 
 import io.vavr.collection.*;
-import io.vavr.collection.List;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
 import io.vavr.control.Validation;
@@ -366,20 +365,6 @@ public abstract class AbstractValueTest {
         } else {
             assertThat(map).isEqualTo(io.vavr.collection.TreeMap.of(comparator, 9, 9, 5, 5, 1, 1));
         }
-    }
-
-    @Test
-    public void shouldConvertToEither() {
-        assertThat(empty().toEither("test")).isEqualTo(Left("test"));
-        assertThat(empty().toEither(() -> "test")).isEqualTo(Left("test"));
-        assertThat(of(1).toEither("test")).isEqualTo(Right(1));
-    }
-
-    @Test
-    public void shouldConvertToValidation() {
-        assertThat(empty().toValid("test")).isEqualTo(Invalid("test"));
-        assertThat(empty().toValid(() -> "test")).isEqualTo(Invalid("test"));
-        assertThat(of(1).toValid("test")).isEqualTo(Valid(1));
     }
 
     @Test
@@ -747,98 +732,6 @@ public abstract class AbstractValueTest {
             final java.util.stream.Stream<Integer> s2 = java.util.stream.Stream.of(1, 2, 3);
             assertThat(io.vavr.collection.List.ofAll(s1::iterator)).isEqualTo(io.vavr.collection.List.ofAll(s2::iterator));
         }
-    }
-
-    // toLeft / toRight
-
-    @Test
-    public void shouldConvertToEitherLeftFromValueSupplier() {
-        final Either<Integer, String> either = of(0).toLeft(() -> "fallback");
-        assertThat(either.isLeft()).isTrue();
-        assertThat(either.getLeft()).isEqualTo(0);
-
-        final Either<Object, String> either2 = empty().toLeft(() -> "fallback");
-        assertThat(either2.isRight()).isTrue();
-        assertThat(either2.get()).isEqualTo("fallback");
-    }
-
-    @Test
-    public void shouldConvertToEitherLeftFromValue() {
-        final Either<Integer, String> either = of(0).toLeft("fallback");
-        assertThat(either.isLeft()).isTrue();
-        assertThat(either.getLeft()).isEqualTo(0);
-
-        final Either<Object, String> either2 = empty().toLeft("fallback");
-        assertThat(either2.isRight()).isTrue();
-        assertThat(either2.get()).isEqualTo("fallback");
-    }
-
-    @Test
-    public void shouldConvertToEitherRightFromValueSupplier() {
-        final Either<String, Integer> either = of(0).toRight(() -> "fallback");
-        assertThat(either.isRight()).isTrue();
-        assertThat(either.get()).isEqualTo(0);
-
-        final Either<String, Object> either2 = empty().toRight(() -> "fallback");
-        assertThat(either2.isLeft()).isTrue();
-        assertThat(either2.getLeft()).isEqualTo("fallback");
-    }
-
-    @Test
-    public void shouldConvertToEitherRightFromValue() {
-        final Either<String, Integer> either = of(0).toRight("fallback");
-        assertThat(either.isRight()).isTrue();
-        assertThat(either.get()).isEqualTo(0);
-
-        final Either<String, Object> either2 = empty().toRight("fallback");
-        assertThat(either2.isLeft()).isTrue();
-        assertThat(either2.getLeft()).isEqualTo("fallback");
-    }
-
-    // toValid / toInvalid
-
-    @Test
-    public void shouldConvertToValidationInvalidFromValueSupplier() {
-        final Validation<Integer, String> validation = of(0).toInvalid(() -> "fallback");
-        assertThat(validation.isInvalid()).isTrue();
-        assertThat(validation.getErrors()).isEqualTo(List.of(0));
-
-        final Validation<Object, String> validation2 = empty().toInvalid(() -> "fallback");
-        assertThat(validation2.isValid()).isTrue();
-        assertThat(validation2.get()).isEqualTo("fallback");
-    }
-
-    @Test
-    public void shouldConvertToValidationInvalidFromValue() {
-        final Validation<Integer, String> validation = of(0).toInvalid("fallback");
-        assertThat(validation.isInvalid()).isTrue();
-        assertThat(validation.getErrors()).isEqualTo(List.of(0));
-
-        final Validation<Object, String> validation2 = empty().toInvalid("fallback");
-        assertThat(validation2.isValid()).isTrue();
-        assertThat(validation2.get()).isEqualTo("fallback");
-    }
-
-    @Test
-    public void shouldConvertToValidationRightFromValueSupplier() {
-        final Validation<String, Integer> validation = of(0).toValid(() -> "fallback");
-        assertThat(validation.isValid()).isTrue();
-        assertThat(validation.get()).isEqualTo(0);
-
-        final Validation<String, Object> validation2 = empty().toValid(() -> "fallback");
-        assertThat(validation2.isInvalid()).isTrue();
-        assertThat(validation2.getErrors()).isEqualTo(List.of("fallback"));
-    }
-
-    @Test
-    public void shouldConvertToValidationValidFromValue() {
-        final Validation<String, Integer> validation = of(0).toValid("fallback");
-        assertThat(validation.isValid()).isTrue();
-        assertThat(validation.get()).isEqualTo(0);
-
-        final Validation<String, Object> validation2 = empty().toValid("fallback");
-        assertThat(validation2.isInvalid()).isTrue();
-        assertThat(validation2.getErrors()).isEqualTo(List.of("fallback"));
     }
 
     // -- exists

--- a/vavr/src/test/java/io/vavr/AbstractValueTest.java
+++ b/vavr/src/test/java/io/vavr/AbstractValueTest.java
@@ -369,12 +369,6 @@ public abstract class AbstractValueTest {
     }
 
     @Test
-    public void shouldConvertToOption() {
-        assertThat(empty().toOption()).isSameAs(Option.none());
-        assertThat(of(1).toOption()).isEqualTo(Option.of(1));
-    }
-
-    @Test
     public void shouldConvertToEither() {
         assertThat(empty().toEither("test")).isEqualTo(Left("test"));
         assertThat(empty().toEither(() -> "test")).isEqualTo(Left("test"));
@@ -508,30 +502,6 @@ public abstract class AbstractValueTest {
         } else {
             assertThat(stream).isEqualTo(Stream.of(1, 2, 3));
         }
-    }
-
-    @Test
-    public void shouldConvertNonEmptyToTry() {
-        assertThat(of(1, 2, 3).toTry()).isEqualTo(Try.of(() -> 1));
-    }
-
-    @Test
-    public void shouldConvertEmptyToTry() {
-        final Try<?> actual = empty().toTry();
-        assertThat(actual.isFailure()).isTrue();
-        assertThat(actual.getCause()).isExactlyInstanceOf(NoSuchElementException.class);
-    }
-
-    @Test
-    public void shouldConvertNonEmptyToTryUsingExceptionSupplier() {
-        final Exception x = new Exception("test");
-        assertThat(of(1, 2, 3).toTry(() -> x)).isEqualTo(Try.of(() -> 1));
-    }
-
-    @Test
-    public void shouldConvertEmptyToTryUsingExceptionSupplier() {
-        final Exception x = new Exception("test");
-        assertThat(empty().toTry(() -> x)).isEqualTo(Try.failure(x));
     }
 
     @Test

--- a/vavr/src/test/java/io/vavr/AbstractValueTest.java
+++ b/vavr/src/test/java/io/vavr/AbstractValueTest.java
@@ -699,11 +699,6 @@ public abstract class AbstractValueTest {
     }
 
     @Test
-    public void shouldConvertToJavaOptional() {
-        assertThat(of(1, 2, 3).toJavaOptional()).isEqualTo(Optional.of(1));
-    }
-
-    @Test
     public void shouldConvertToJavaSet() {
         final Value<Integer> value = of(1, 2, 3);
         final java.util.Set<Integer> set = value.toJavaSet();

--- a/vavr/src/test/java/io/vavr/concurrent/FutureTest.java
+++ b/vavr/src/test/java/io/vavr/concurrent/FutureTest.java
@@ -896,19 +896,6 @@ public class FutureTest extends AbstractValueTest {
         assertThat(Try.of(completableFuture::get).get()).isEqualTo(42);
     }
 
-    // -- toTry()
-
-    @Test
-    public void shouldConvertSuccessfulFutureToTry() {
-        assertThat(Future.successful(1).toTry()).isEqualTo(Try.success(1));
-    }
-
-    @Test
-    public void shouldConvertFailedFutureToTry() {
-        assertThat(Future.failed(new Error("!")).toTry())
-                .isEqualTo(Try.failure(new Error("!")));
-    }
-
     // -- transform()
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/EitherLeftProjectionTest.java
+++ b/vavr/src/test/java/io/vavr/control/EitherLeftProjectionTest.java
@@ -160,18 +160,6 @@ public class EitherLeftProjectionTest extends AbstractValueTest {
         assertThat(self.left().toEither()).isEqualTo(self);
     }
 
-    // toJavaOptional
-
-    @Test
-    public void shouldConvertLeftProjectionOfLeftToJavaOptional() {
-        assertThat(Either.left(1).left().toJavaOptional()).isEqualTo(Optional.of(1));
-    }
-
-    @Test
-    public void shouldConvertLeftProjectionOfRightToJavaOptional() {
-        assertThat(Either.<Integer, String> right("x").left().toJavaOptional()).isEqualTo(Optional.empty());
-    }
-
     // filter
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/EitherLeftProjectionTest.java
+++ b/vavr/src/test/java/io/vavr/control/EitherLeftProjectionTest.java
@@ -146,18 +146,6 @@ public class EitherLeftProjectionTest extends AbstractValueTest {
         Either.right("1").left().getOrElseThrow(s -> new RuntimeException(s));
     }
 
-    // toOption
-
-    @Test
-    public void shouldConvertLeftProjectionOfLeftToSome() {
-        assertThat(Either.left(1).left().toOption()).isEqualTo(Option.of(1));
-    }
-
-    @Test
-    public void shouldConvertLeftProjectionOfRightToNone() {
-        assertThat(Either.right("x").left().toOption()).isEqualTo(Option.none());
-    }
-
     // toEither
 
     @Test
@@ -188,7 +176,7 @@ public class EitherLeftProjectionTest extends AbstractValueTest {
 
     @Test
     public void shouldFilterSomeOnLeftProjectionOfLeftIfPredicateMatches() {
-        final boolean actual = Either.left(1).left().filter(i -> true).toOption().isDefined();
+        final boolean actual = Either.left(1).left().filter(i -> true).isDefined();
         assertThat(actual).isTrue();
     }
 

--- a/vavr/src/test/java/io/vavr/control/EitherRightProjectionTest.java
+++ b/vavr/src/test/java/io/vavr/control/EitherRightProjectionTest.java
@@ -152,18 +152,6 @@ public class EitherRightProjectionTest extends AbstractValueTest {
         Either.<String, Integer> left("1").right().getOrElseThrow(i -> new RuntimeException(String.valueOf(i)));
     }
 
-    // toOption
-
-    @Test
-    public void shouldConvertRightProjectionOfLeftToNone() {
-        assertThat(Either.left(0).right().toOption()).isEqualTo(Option.none());
-    }
-
-    @Test
-    public void shouldConvertRightProjectionOfRightToSome() {
-        assertThat(Either.<Integer, String> right("1").right().toOption()).isEqualTo(Option.of("1"));
-    }
-
     // toEither
 
     @Test
@@ -202,7 +190,7 @@ public class EitherRightProjectionTest extends AbstractValueTest {
 
     @Test
     public void shouldFilterSomeOnRightProjectionOfRightIfPredicateMatches() {
-        final boolean actual = Either.<String, Integer> right(1).right().filter(i -> true).toOption().isDefined();
+        final boolean actual = Either.<String, Integer> right(1).right().filter(i -> true).isDefined();
         assertThat(actual).isTrue();
     }
 

--- a/vavr/src/test/java/io/vavr/control/EitherRightProjectionTest.java
+++ b/vavr/src/test/java/io/vavr/control/EitherRightProjectionTest.java
@@ -166,18 +166,6 @@ public class EitherRightProjectionTest extends AbstractValueTest {
         assertThat(self.right().toEither()).isEqualTo(self);
     }
 
-    // toJavaOptional
-
-    @Test
-    public void shouldConvertRightProjectionOfLeftToJavaOptional() {
-        assertThat(Either.left(0).right().toJavaOptional()).isEqualTo(Optional.empty());
-    }
-
-    @Test
-    public void shouldConvertRightProjectionOfRightToJavaOptional() {
-        assertThat(Either.<Integer, String> right("1").right().toJavaOptional()).isEqualTo(Optional.of("1"));
-    }
-
     // -- transform()
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/OptionTest.java
+++ b/vavr/src/test/java/io/vavr/control/OptionTest.java
@@ -459,40 +459,6 @@ public class OptionTest extends AbstractValueTest {
         assertThat(actual[0]).isEqualTo(-1);
     }
 
-    // -- toEither
-
-    @Test
-    public void shouldMakeRightOnSomeToEither() {
-        assertThat(API.Some(5).toEither("bad")).isEqualTo(API.Right(5));
-    }
-
-    @Test
-    public void shouldMakeLeftOnNoneToEither() {
-        assertThat(API.None().toEither("bad")).isEqualTo(API.Left("bad"));
-    }
-
-    @Test
-    public void shouldMakeLeftOnNoneToEitherSupplier() {
-        assertThat(API.None().toEither(() -> "bad")).isEqualTo(API.Left("bad"));
-    }
-
-    // -- toValidation
-
-    @Test
-    public void shouldMakeValidOnSomeToValidation() {
-        assertThat(API.Some(5).toValid("bad")).isEqualTo(API.Valid(5));
-    }
-
-    @Test
-    public void shouldMakeLeftOnNoneToValidation() {
-        assertThat(API.None().toValid("bad")).isEqualTo(API.Invalid("bad"));
-    }
-
-    @Test
-    public void shouldMakeLeftOnNoneToValidationSupplier() {
-        assertThat(API.None().toValid(() -> "bad")).isEqualTo(API.Invalid("bad"));
-    }
-
     // -- peek
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/OptionTest.java
+++ b/vavr/src/test/java/io/vavr/control/OptionTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 
 import java.util.*;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -273,7 +272,7 @@ public class OptionTest extends AbstractValueTest {
         final Option<Integer> some = Option.some(1);
         assertThat(some.toJavaOptional()).isEqualTo(Optional.of(1));
     }
-
+    
     // -- toTry
 
     @Test
@@ -645,24 +644,6 @@ public class OptionTest extends AbstractValueTest {
     public void shouldPreserveSingletonWhenDeserializingNone() {
         final Object none = Serializables.deserialize(Serializables.serialize(Option.none()));
         assertThat(none == Option.none()).isTrue();
-    }
-
-    // -- toCompletableFuture
-
-    @Test
-    public void shouldConvertSomeToCompletableFuture() {
-        final String some = "some";
-        final CompletableFuture<String> future = API.Option(some).toCompletableFuture();
-        assertThat(future.isDone());
-        assertThat(Try.of(future::get).get()).isEqualTo(some);
-    }
-
-    @Test
-    public void shouldConvertNoneToFailedCompletableFuture() {
-
-        final CompletableFuture<Object> future = API.None().toCompletableFuture();
-        assertThat(future.isDone());
-        assertThat(future.isCompletedExceptionally());
     }
 
     // -- spliterator

--- a/vavr/src/test/java/io/vavr/control/OptionTest.java
+++ b/vavr/src/test/java/io/vavr/control/OptionTest.java
@@ -274,6 +274,32 @@ public class OptionTest extends AbstractValueTest {
         assertThat(some.toJavaOptional()).isEqualTo(Optional.of(1));
     }
 
+    // -- toTry
+
+    @Test
+    public void shouldConvertNonEmptyToTry() {
+        assertThat(of(1, 2, 3).toTry()).isEqualTo(Try.of(() -> 1));
+    }
+
+    @Test
+    public void shouldConvertEmptyToTry() {
+        final Try<?> actual = empty().toTry();
+        assertThat(actual.isFailure()).isTrue();
+        assertThat(actual.getCause()).isExactlyInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void shouldConvertNonEmptyToTryUsingExceptionSupplier() {
+        final Exception x = new Exception("test");
+        assertThat(of(1, 2, 3).toTry(() -> x)).isEqualTo(Try.of(() -> 1));
+    }
+
+    @Test
+    public void shouldConvertEmptyToTryUsingExceptionSupplier() {
+        final Exception x = new Exception("test");
+        assertThat(empty().toTry(() -> x)).isEqualTo(Try.failure(x));
+    }
+
     // -- isDefined
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/OptionTest.java
+++ b/vavr/src/test/java/io/vavr/control/OptionTest.java
@@ -259,18 +259,18 @@ public class OptionTest extends AbstractValueTest {
         Option.none().getOrElseThrow(() -> new RuntimeException("none"));
     }
 
-    // -- toJavaOptional
+    // -- toOptional
 
     @Test
-    public void shouldConvertNoneToJavaOptional() {
+    public void shouldConvertNoneToOptional() {
         final Option<Object> none = Option.none();
-        assertThat(none.toJavaOptional()).isEqualTo(Optional.empty());
+        assertThat(none.toOptional()).isEqualTo(Optional.empty());
     }
 
     @Test
-    public void shouldConvertSomeToJavaOptional() {
+    public void shouldConvertSomeToOptional() {
         final Option<Integer> some = Option.some(1);
-        assertThat(some.toJavaOptional()).isEqualTo(Optional.of(1));
+        assertThat(some.toOptional()).isEqualTo(Optional.of(1));
     }
     
     // -- toTry

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -967,17 +967,6 @@ public class TryTest extends AbstractValueTest {
         assertThat(failure().toEither().isLeft()).isTrue();
     }
 
-    @Test
-    public void shouldConvertFailureToEitherLeft() {
-        assertThat(failure().toEither("test").isLeft()).isTrue();
-    }
-
-    @Test
-    public void shouldConvertFailureToEitherLeftSupplier() {
-        assertThat(failure().toEither(() -> "test").isLeft()).isTrue();
-    }
-
-
     // -- toValidation
 
     @Test
@@ -994,18 +983,6 @@ public class TryTest extends AbstractValueTest {
         final Validation<String, Object> validation = failure.toValidation(e -> e.toString());
         assertThat(validation.getErrors().get(0)).isEqualTo(failure.getCause().toString());
         assertThat(validation.isInvalid()).isTrue();
-    }
-
-    // -- toValidation
-
-    @Test
-    public void shouldConvertFailureToValidationLeft() {
-        assertThat(failure().toValid("test").isInvalid()).isTrue();
-    }
-
-    @Test
-    public void shouldConvertFailureToValidationLeftSupplier() {
-        assertThat(failure().toValid(() -> "test").isInvalid()).isTrue();
     }
 
     // -- toOptional

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -33,15 +33,13 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class TryTest extends AbstractValueTest {
 
-    private static final String OK = "ok";
+    private static final String SUCCESS = "success";
     private static final String FAILURE = "failure";
 
     // -- AbstractValueTest
@@ -753,21 +751,21 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldReturnElseWhenOrElseOnFailure() {
-        assertThat(failure().getOrElse(OK)).isEqualTo(OK);
+        assertThat(failure().getOrElse(SUCCESS)).isEqualTo(SUCCESS);
     }
 
     // -- getOrElseGet
 
     @Test
     public void shouldReturnElseWhenOrElseGetOnFailure() {
-        assertThat(failure().getOrElseGet(x -> OK)).isEqualTo(OK);
+        assertThat(failure().getOrElseGet(x -> SUCCESS)).isEqualTo(SUCCESS);
     }
 
     // -- getOrElseThrow
 
     @Test(expected = IllegalStateException.class)
     public void shouldThrowOtherWhenGetOrElseThrowOnFailure() {
-        failure().getOrElseThrow(x -> new IllegalStateException(OK));
+        failure().getOrElseThrow(x -> new IllegalStateException(SUCCESS));
     }
 
     // -- orElseRun
@@ -775,8 +773,8 @@ public class TryTest extends AbstractValueTest {
     @Test
     public void shouldRunElseWhenOrElseRunOnFailure() {
         final String[] result = new String[1];
-        failure().orElseRun(x -> result[0] = OK);
-        assertThat(result[0]).isEqualTo(OK);
+        failure().orElseRun(x -> result[0] = SUCCESS);
+        assertThat(result[0]).isEqualTo(SUCCESS);
     }
 
     // -- recover(Class, Function)
@@ -784,25 +782,25 @@ public class TryTest extends AbstractValueTest {
     @Test
     public void shouldRecoverWhenFailureMatchesExactly() {
         final Try<String> testee = failure();
-        assertThat(testee.recover(IllegalStateException.class, x -> OK).isSuccess()).isTrue();
+        assertThat(testee.recover(IllegalStateException.class, x -> SUCCESS).isSuccess()).isTrue();
     }
 
     @Test
     public void shouldRecoverWhenFailureIsAssignableFrom() {
         final Try<String> testee = failure(UnsupportedOperationException.class);
-        assertThat(testee.recover(RuntimeException.class, x -> OK).isSuccess()).isTrue();
+        assertThat(testee.recover(RuntimeException.class, x -> SUCCESS).isSuccess()).isTrue();
     }
 
     @Test
     public void shouldReturnThisWhenRecoverDifferentTypeOfFailure() {
         final Try<String> testee = failure(IllegalStateException.class);
-        assertThat(testee.recover(NullPointerException.class, x -> OK)).isSameAs(testee);
+        assertThat(testee.recover(NullPointerException.class, x -> SUCCESS)).isSameAs(testee);
     }
 
     @Test
     public void shouldReturnThisWhenRecoverSpecificFailureOnSuccess() {
         final Try<String> testee = success();
-        assertThat(testee.recover(RuntimeException.class, x -> OK)).isSameAs(testee);
+        assertThat(testee.recover(RuntimeException.class, x -> SUCCESS)).isSameAs(testee);
     }
 
     // -- recover(Class, Object)
@@ -810,45 +808,45 @@ public class TryTest extends AbstractValueTest {
     @Test
     public void shouldRecoverWithSuccessWhenFailureMatchesExactly() {
         final Try<String> testee = failure();
-        assertThat(testee.recover(IllegalStateException.class, OK).isSuccess()).isTrue();
+        assertThat(testee.recover(IllegalStateException.class, SUCCESS).isSuccess()).isTrue();
     }
 
     @Test
     public void shouldRecoverWithSuccessWhenFailureIsAssignableFrom() {
         final Try<String> testee = failure(UnsupportedOperationException.class);
-        assertThat(testee.recover(RuntimeException.class, OK).isSuccess()).isTrue();
+        assertThat(testee.recover(RuntimeException.class, SUCCESS).isSuccess()).isTrue();
     }
 
     @Test
     public void shouldReturnThisWhenRecoverWithSuccessDifferentTypeOfFailure() {
         final Try<String> testee = failure(IllegalStateException.class);
-        assertThat(testee.recover(NullPointerException.class, OK)).isSameAs(testee);
+        assertThat(testee.recover(NullPointerException.class, SUCCESS)).isSameAs(testee);
     }
 
     @Test
     public void shouldReturnThisWhenRecoverWithSuccessSpecificFailureOnSuccess() {
         final Try<String> testee = success();
-        assertThat(testee.recover(RuntimeException.class, OK)).isSameAs(testee);
+        assertThat(testee.recover(RuntimeException.class, SUCCESS)).isSameAs(testee);
     }
 
     // -- recover(Function)
 
     @Test
     public void shouldRecoverOnFailure() {
-        assertThat(failure().recover(x -> OK).get()).isEqualTo(OK);
+        assertThat(failure().recover(x -> SUCCESS).get()).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldReturnThisWhenRecoverOnSuccess() {
         final Try<String> testee = success();
-        assertThat(testee.recover(x -> OK)).isSameAs(testee);
+        assertThat(testee.recover(x -> SUCCESS)).isSameAs(testee);
     }
 
     // -- recoverWith(Function)
 
     @Test
     public void shouldRecoverWithOnFailure() {
-        assertThat(TryTest.<String> failure().recoverWith(x -> success()).get()).isEqualTo(OK);
+        assertThat(TryTest.<String> failure().recoverWith(x -> success()).get()).isEqualTo(SUCCESS);
     }
 
     @Test
@@ -863,7 +861,7 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldNotTryToRecoverWhenItIsNotNeeded(){
-        assertThat(Try.of(() -> OK).recoverWith(RuntimeException.class, x -> failure()).get()).isEqualTo(OK);
+        assertThat(Try.of(() -> SUCCESS).recoverWith(RuntimeException.class, x -> failure()).get()).isEqualTo(SUCCESS);
     }
 
     @Test
@@ -883,12 +881,12 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldReturnRecoveredValue(){
-        assertThat(Try.of(() -> {throw error();}).recoverWith(RuntimeException.class, x -> success()).get()).isEqualTo(OK);
+        assertThat(Try.of(() -> {throw error();}).recoverWith(RuntimeException.class, x -> success()).get()).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldHandleErrorDuringRecovering(){
-        final Try<?> t = Try.of(() -> {throw new IllegalArgumentException(OK);}).recoverWith(IOException.class, x -> { throw new IllegalStateException(FAILURE);});
+        final Try<?> t = Try.of(() -> {throw new IllegalArgumentException(SUCCESS);}).recoverWith(IOException.class, x -> { throw new IllegalStateException(FAILURE);});
         assertThatThrownBy(t::get)
                 .isInstanceOf(NonFatalThrowable.class)
                 .hasCauseExactlyInstanceOf(IllegalArgumentException.class);
@@ -898,12 +896,12 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldNotReturnRecoveredValueOnSuccess(){
-        assertThat(Try.of(() -> OK).recoverWith(IOException.class, failure()).get()).isEqualTo(OK);
+        assertThat(Try.of(() -> SUCCESS).recoverWith(IOException.class, failure()).get()).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldReturnRecoveredValueOnFailure(){
-        assertThat(Try.of(() -> {throw new IllegalStateException(FAILURE);}).recoverWith(IllegalStateException.class, success()).get()).isEqualTo(OK);
+        assertThat(Try.of(() -> {throw new IllegalStateException(FAILURE);}).recoverWith(IllegalStateException.class, success()).get()).isEqualTo(SUCCESS);
     }
 
     @Test
@@ -917,22 +915,22 @@ public class TryTest extends AbstractValueTest {
     @Test
     public void shouldConsumeThrowableWhenCallingOnFailureGivenFailure() {
         final String[] result = new String[] { FAILURE };
-        failure().onFailure(x -> result[0] = OK);
-        assertThat(result[0]).isEqualTo(OK);
+        failure().onFailure(x -> result[0] = SUCCESS);
+        assertThat(result[0]).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldConsumeThrowableWhenCallingOnFailureWithMatchingExceptionTypeGivenFailure() {
         final String[] result = new String[] { FAILURE };
-        failure().onFailure(RuntimeException.class, x -> result[0] = OK);
-        assertThat(result[0]).isEqualTo(OK);
+        failure().onFailure(RuntimeException.class, x -> result[0] = SUCCESS);
+        assertThat(result[0]).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldNotConsumeThrowableWhenCallingOnFailureWithNonMatchingExceptionTypeGivenFailure() {
-        final String[] result = new String[] { OK };
+        final String[] result = new String[] { SUCCESS };
         failure().onFailure(Error.class, x -> result[0] = FAILURE);
-        assertThat(result[0]).isEqualTo(OK);
+        assertThat(result[0]).isEqualTo(SUCCESS);
     }
 
     // -- transform
@@ -998,27 +996,6 @@ public class TryTest extends AbstractValueTest {
         assertThat(validation.isInvalid()).isTrue();
     }
 
-    // -- toCompletableFuture
-
-    @Test
-    public void shouldConvertSuccessToCompletableFuture() {
-        final CompletableFuture<String> future = success().toCompletableFuture();
-        assertThat(future.isDone());
-        assertThat(Try.of(future::get).get()).isEqualTo(success().get());
-    }
-
-    @Test
-    public void shouldConvertFailureToFailedCompletableFuture() {
-
-        final CompletableFuture<Object> future = failure().toCompletableFuture();
-        assertThat(future.isDone());
-        assertThat(future.isCompletedExceptionally());
-        assertThatThrownBy(future::get)
-                .isExactlyInstanceOf(ExecutionException.class)
-                .hasCauseExactlyInstanceOf(NonFatalThrowable.class)
-                .hasRootCauseExactlyInstanceOf(IllegalStateException.class);
-    }
-
     // -- toValidation
 
     @Test
@@ -1034,8 +1011,13 @@ public class TryTest extends AbstractValueTest {
     // -- toJavaOptional
 
     @Test
+    public void shouldConvertSuccessToJavaOptional() {
+        assertThat(success().toJavaOptional()).isEqualTo(Optional.of(SUCCESS));
+    }
+
+    @Test
     public void shouldConvertFailureToJavaOptional() {
-        assertThat(failure().toJavaOptional().isPresent()).isFalse();
+        assertThat(failure().toJavaOptional()).isEqualTo(Optional.empty());
     }
 
     // -- filter
@@ -1306,51 +1288,51 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldGetOnSuccess() {
-        assertThat(success().get()).isEqualTo(OK);
+        assertThat(success().get()).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldGetOrElseOnSuccess() {
-        assertThat(success().getOrElse((String) null)).isEqualTo(OK);
+        assertThat(success().getOrElse((String) null)).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldOrElseGetOnSuccess() {
-        assertThat(success().getOrElseGet(x -> null)).isEqualTo(OK);
+        assertThat(success().getOrElseGet(x -> null)).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldOrElseRunOnSuccess() {
-        final String[] result = new String[] { OK };
+        final String[] result = new String[] { SUCCESS };
         success().orElseRun(x -> result[0] = FAILURE);
-        assertThat(result[0]).isEqualTo(OK);
+        assertThat(result[0]).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldOrElseThrowOnSuccess() {
-        assertThat(success().getOrElseThrow(x -> null)).isEqualTo(OK);
+        assertThat(success().getOrElseThrow(x -> null)).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldRecoverOnSuccess() {
-        assertThat(success().recover(x -> null).get()).isEqualTo(OK);
+        assertThat(success().recover(x -> null).get()).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldRecoverWithOnSuccess() {
-        assertThat(success().recoverWith(x -> null).get()).isEqualTo(OK);
+        assertThat(success().recoverWith(x -> null).get()).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldNotConsumeThrowableWhenCallingOnFailureGivenSuccess() {
-        final String[] result = new String[] { OK };
+        final String[] result = new String[] { SUCCESS };
         success().onFailure(x -> result[0] = FAILURE);
-        assertThat(result[0]).isEqualTo(OK);
+        assertThat(result[0]).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldConvertSuccessToOption() {
-        assertThat(success().toOption().get()).isEqualTo(OK);
+        assertThat(success().toOption().get()).isEqualTo(SUCCESS);
     }
 
     @Test
@@ -1369,18 +1351,13 @@ public class TryTest extends AbstractValueTest {
     }
 
     @Test
-    public void shouldConvertSuccessToJavaOptional() {
-        assertThat(success().toJavaOptional().get()).isEqualTo(OK);
-    }
-
-    @Test
     public void shouldFilterMatchingPredicateOnSuccess() {
-        assertThat(success().filter(s -> true).get()).isEqualTo(OK);
+        assertThat(success().filter(s -> true).get()).isEqualTo(SUCCESS);
     }
 
     @Test
     public void shouldFilterMatchingPredicateWithErrorProviderOnSuccess() {
-        assertThat(success().filter(s -> true, s -> new IllegalArgumentException(s)).get()).isEqualTo(OK);
+        assertThat(success().filter(s -> true, s -> new IllegalArgumentException(s)).get()).isEqualTo(SUCCESS);
     }
 
     @Test
@@ -1417,7 +1394,7 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldFlatMapOnSuccess() {
-        assertThat(success().flatMap(s -> Try.of(() -> s + "!")).get()).isEqualTo(OK + "!");
+        assertThat(success().flatMap(s -> Try.of(() -> s + "!")).get()).isEqualTo(SUCCESS + "!");
     }
 
     @Test
@@ -1443,12 +1420,12 @@ public class TryTest extends AbstractValueTest {
     public void shouldForEachOnSuccess() {
         final List<String> actual = new ArrayList<>();
         success().forEach(actual::add);
-        assertThat(actual).isEqualTo(Collections.singletonList(OK));
+        assertThat(actual).isEqualTo(Collections.singletonList(SUCCESS));
     }
 
     @Test
     public void shouldMapOnSuccess() {
-        assertThat(success().map(s -> s + "!").get()).isEqualTo(OK + "!");
+        assertThat(success().map(s -> s + "!").get()).isEqualTo(SUCCESS + "!");
     }
 
     @Test
@@ -1607,7 +1584,7 @@ public class TryTest extends AbstractValueTest {
     }
 
     private Try<String> success() {
-        return Try.of(() -> "ok");
+        return Try.of(() -> SUCCESS);
     }
 
     // -- spliterator

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -232,6 +232,14 @@ public class TryTest extends AbstractValueTest {
         assertThat((Iterator<Integer>) Try.success(1).iterator()).isNotNull();
     }
 
+    // -- toOption
+
+    @Test
+    public void shouldConvertToOption() {
+        assertThat(empty().toOption()).isSameAs(Option.none());
+        assertThat(of(1).toOption()).isEqualTo(Option.of(1));
+    }
+
     @Test
     public void shouldReturnIteratorOfFailure() {
         assertThat((Iterator<Object>) failure().iterator()).isNotNull();

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -1008,16 +1008,16 @@ public class TryTest extends AbstractValueTest {
         assertThat(failure().toValid(() -> "test").isInvalid()).isTrue();
     }
 
-    // -- toJavaOptional
+    // -- toOptional
 
     @Test
-    public void shouldConvertSuccessToJavaOptional() {
-        assertThat(success().toJavaOptional()).isEqualTo(Optional.of(SUCCESS));
+    public void shouldConvertSuccessToOptional() {
+        assertThat(success().toOptional()).isEqualTo(Optional.of(SUCCESS));
     }
 
     @Test
-    public void shouldConvertFailureToJavaOptional() {
-        assertThat(failure().toJavaOptional()).isEqualTo(Optional.empty());
+    public void shouldConvertFailureToOptional() {
+        assertThat(failure().toOptional()).isEqualTo(Optional.empty());
     }
 
     // -- filter


### PR DESCRIPTION
Related to [Opportunity to Improve Conversion of Validation.Invalid<? extends Throwable,T> to Try<T> ](https://github.com/vavr-io/vavr/issues/2207)