### PR TITLE
Check a test result more directly, with values instead of a string representation

### DIFF
--- a/vavr/src/test/java/io/vavr/collection/AbstractMultimapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractMultimapTest.java
@@ -365,7 +365,7 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
     @Test
     public void shouldConvertToMap() {
         Multimap<Integer, Integer> mm = emptyIntInt().put(1, 2).put(1, 3);
-        assertThat(mm.asMap().get(1).get().mkString(",")).isEqualTo("2,3");
+        assertThat(mm.asMap().get(1).get()).isEqualTo(HashSet.of(2, 3));
     }
 
     // -- biMap


### PR DESCRIPTION
Check the result of converting a Multimap to a Map directly using values instead of a string representation.