### PR TITLE
Revert "Solved TODO regarding lambda to method ref conversion in IDEA"

### DIFF
--- a/vavr/src/main/java/io/vavr/Lazy.java
+++ b/vavr/src/main/java/io/vavr/Lazy.java
@@ -111,9 +111,10 @@ public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
      * @return A lazy sequence of values.
      * @throws NullPointerException if values is null
      */
+    @SuppressWarnings("Convert2MethodRef") // TODO should be fixed in JDK 9 and Idea
     public static <T> Lazy<Seq<T>> sequence(Iterable<? extends Lazy<? extends T>> values) {
         Objects.requireNonNull(values, "values is null");
-        return Lazy.of(() -> Vector.ofAll(values).map(Lazy::get));
+        return Lazy.of(() -> Vector.ofAll(values).map(lazy -> lazy.get()));
     }
 
     /**


### PR DESCRIPTION
Reverts vavr-io/vavr#2354

This breaks the JDK 9 build of our CI build matrix.
Namely, we need to stay backward compatible, even for bugs (!)