### PR TITLE
Moved Iterable.exists/.forAll to Traversable

### DIFF
--- a/src/main/java/io/vavr/Iterable.java
+++ b/src/main/java/io/vavr/Iterable.java
@@ -22,7 +22,6 @@ import io.vavr.collection.Iterator;
 
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * Extension of the well-known Java {@link java.lang.Iterable} in the sense that a rich
@@ -40,35 +39,6 @@ public interface Iterable<T> extends java.lang.Iterable<T> {
      */
     @Override
     Iterator<T> iterator();
-
-    /**
-     * Checks, if an element exists such that the predicate holds.
-     *
-     * @param predicate A Predicate
-     * @return true, if predicate holds for one or more elements, false otherwise
-     * @throws NullPointerException if {@code predicate} is null
-     */
-    default boolean exists(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        for (T t : this) {
-            if (predicate.test(t)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Checks, if the given predicate holds for all elements.
-     *
-     * @param predicate A Predicate
-     * @return true, if the predicate holds for all elements, false otherwise
-     * @throws NullPointerException if {@code predicate} is null
-     */
-    default boolean forAll(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return !exists(predicate.negate());
-    }
 
     // `Iterable<T>` must not have a generic type bound, see TraversableTest ShouldJustCompile
     default <C> C to(Function<? super java.lang.Iterable<T>, C> fromIterable) {

--- a/src/main/java/io/vavr/collection/Traversable.java
+++ b/src/main/java/io/vavr/collection/Traversable.java
@@ -18,9 +18,40 @@
  */
 package io.vavr.collection;
 
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 public interface Traversable<T> extends io.vavr.Iterable<T> {
+
+    /**
+     * Checks, if an element exists such that the predicate holds.
+     *
+     * @param predicate A Predicate
+     * @return true, if predicate holds for one or more elements, false otherwise
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    default boolean exists(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        for (T t : this) {
+            if (predicate.test(t)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks, if the given predicate holds for all elements.
+     *
+     * @param predicate A Predicate
+     * @return true, if the predicate holds for all elements, false otherwise
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    default boolean forAll(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return !exists(predicate.negate());
+    }
 
     <U> Traversable<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 

--- a/src/test/java/io/vavr/IterableTest.java
+++ b/src/test/java/io/vavr/IterableTest.java
@@ -28,68 +28,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class IterableTest {
 
-    // -- .exists(Predicate)
-
-    @Test
-    void shouldThrowOnExistsWithNullPredicate() {
-        final Iterable<Integer> testee = Iterator::empty;
-        assertEquals("predicate is null",
-                assertThrows(NullPointerException.class, () -> testee.forAll(null)).getMessage()
-        );
-    }
-
-    @Test
-    void shouldBeAwareOfExistingElementWhenSingleton() {
-        final Iterable<Integer> testee = () -> Iterator.of(1);
-        assertTrue(testee.exists(i -> i == 1));
-    }
-
-    @Test
-    void shouldBeAwareOfExistingElementWhenContainingMultipleElements() {
-        final Iterable<Integer> testee = () -> Iterator.of(1, 2);
-        assertTrue(testee.exists(i -> i == 2));
-    }
-
-    @Test
-    void shouldBeAwareOfNonExistingElementWhenEmpty() {
-        final Iterable<Integer> testee = Iterator::empty;
-        assertFalse(testee.exists(i -> i == -1));
-    }
-
-    @Test
-    void shouldBeAwareOfNonExistingElementWhenSingleton() {
-        final Iterable<Integer> testee = () -> Iterator.of(1);
-        assertFalse(testee.exists(i -> i == -1));
-    }
-
-    @Test
-    void shouldBeAwareOfNonExistingElementWhenContainingMultipleElememnts() {
-        final Iterable<Integer> testee = () -> Iterator.of(1, 2);
-        assertFalse(testee.exists(i -> i == -1));
-    }
-
-    // -- .forAll(Predicate)
-
-    @Test
-    void shouldThrowOnForAllWithNullPredicate() {
-        final Iterable<Integer> testee = Iterator::empty;
-        assertEquals("predicate is null",
-            assertThrows(NullPointerException.class, () -> testee.forAll(null)).getMessage()
-        );
-    }
-
-    @Test
-    void shouldBeAwareOfPropertyThatHoldsForAll() {
-        final Iterable<Integer> testee = () -> Iterator.of(0, 2);
-        assertTrue(testee.forAll(i -> i % 2 == 0));
-    }
-
-    @Test
-    void shouldBeAwareOfPropertyThatNotHoldsForAll() {
-        final Iterable<Integer> testee = () -> Iterator.of(1, 2);
-        assertFalse(testee.forAll(i -> i % 2 == 0));
-    }
-
     // -- .to(Function)
 
     @Test

--- a/src/test/java/io/vavr/collection/TraversableTest.java
+++ b/src/test/java/io/vavr/collection/TraversableTest.java
@@ -18,9 +18,78 @@
  */
 package io.vavr.collection;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.function.Function;
 
-class TraversableTest {
+import static org.junit.jupiter.api.Assertions.*;
+
+interface TraversableTest {
+
+    @SuppressWarnings("unchecked")
+    <T> Traversable<T> of(T... elements);
+
+    // -- .exists(Predicate)
+
+    @Test
+    default void shouldThrowOnExistsWithNullPredicate() {
+        final Traversable<Integer> testee = of();
+        assertEquals("predicate is null",
+                assertThrows(NullPointerException.class, () -> testee.forAll(null)).getMessage()
+        );
+    }
+
+    @Test
+    default void shouldBeAwareOfExistingElementWhenSingleton() {
+        final Traversable<Integer> testee = of(1);
+        assertTrue(testee.exists(i -> i == 1));
+    }
+
+    @Test
+    default void shouldBeAwareOfExistingElementWhenContainingMultipleElements() {
+        final Traversable<Integer> testee = of(1, 2);
+        assertTrue(testee.exists(i -> i == 2));
+    }
+
+    @Test
+    default void shouldBeAwareOfNonExistingElementWhenEmpty() {
+        final Traversable<Integer> testee = of();
+        assertFalse(testee.exists(i -> i == -1));
+    }
+
+    @Test
+    default void shouldBeAwareOfNonExistingElementWhenSingleton() {
+        final Traversable<Integer> testee = of(1);
+        assertFalse(testee.exists(i -> i == -1));
+    }
+
+    @Test
+    default void shouldBeAwareOfNonExistingElementWhenContainingMultipleElememnts() {
+        final Traversable<Integer> testee = of(1, 2);
+        assertFalse(testee.exists(i -> i == -1));
+    }
+
+    // -- .forAll(Predicate)
+
+    @Test
+    default void shouldThrowOnForAllWithNullPredicate() {
+        final Traversable<Integer> testee = of();
+        assertEquals("predicate is null",
+                assertThrows(NullPointerException.class, () -> testee.forAll(null)).getMessage()
+        );
+    }
+
+    @Test
+    default void shouldBeAwareOfPropertyThatHoldsForAll() {
+        final Traversable<Integer> testee = of(0, 2);
+        assertTrue(testee.forAll(i -> i % 2 == 0));
+    }
+
+    @Test
+    default void shouldBeAwareOfPropertyThatNotHoldsForAll() {
+        final Traversable<Integer> testee = of(1, 2);
+        assertFalse(testee.forAll(i -> i % 2 == 0));
+    }
 
 }
 


### PR DESCRIPTION
This is an important design decision.

Iterable is at the top of Vavr's type hierarchy.

![iterable](https://user-images.githubusercontent.com/743833/52524100-8422c380-2c99-11e9-94c7-68910fc11968.png)

Unlike Value before, Iterable's scope is restricted to provide a rich io.vavr.collection.**Iterator**.
Additionally we have a generic conversion method **.to** (experimental).

I move .exists and .forAll to Traversable because they suggest to operate on multiple values and in order to keep Iterable small and clean. **An** Iterable is not necessarily a collection.

Other Iterable types are Option, Try and Either. There we use **fold** to achieve the same as **exists** and **forAll**. This way we keep the API surface area small and remove redundancies.

```java
// Predicate<T> exists = ...
option.fold(() -> false, exists::test)

// Predicate<T> forAll = ...
option.fold(() -> true, forAll::test)
```
