### PR TITLE
Avoid swallowing exceptions in `Try`.

### DIFF
--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -1241,10 +1241,15 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldConvertListOfFailureToTryOfList() {
-        final Throwable t = new RuntimeException("failure");
-        final List<Try<String>> tries = Arrays.asList(Try.failure(t), Try.failure(t), Try.failure(t));
+        final Throwable t0 = new RuntimeException("failure1");
+        final Throwable t1 = new RuntimeException("failure2");
+        final Throwable t2 = new RuntimeException("failure3");
+        final List<Try<String>> tries = Arrays.asList(Try.failure(t0), Try.failure(t1), Try.failure(t2));
         final Try<Seq<String>> reducedTry = Try.sequence(tries);
         assertThat(reducedTry instanceof Try.Failure).isTrue();
+        assertThat(reducedTry.getCause()).isSameAs(t0);
+        assertThat(reducedTry.getCause().getSuppressed()[0]).isSameAs(t1);
+        assertThat(reducedTry.getCause().getSuppressed()[1]).isSameAs(t2);
     }
 
     @Test
@@ -1268,10 +1273,15 @@ public class TryTest extends AbstractValueTest {
 
     @Test
     public void shouldTraverseListOfFailureToTryOfList() {
-        final Throwable t = new RuntimeException("failure");
-        final List<Throwable> tries = Arrays.asList(t, t, t);
+        final Throwable t0 = new RuntimeException("failure1");
+        final Throwable t1 = new RuntimeException("failure2");
+        final Throwable t2 = new RuntimeException("failure3");
+        final List<Throwable> tries = Arrays.asList(t0, t1, t2);
         final Try<Seq<String>> reducedTry = Try.traverse(tries, Try::failure);
         assertThat(reducedTry instanceof Try.Failure).isTrue();
+        assertThat(reducedTry.getCause()).isSameAs(t0);
+        assertThat(reducedTry.getCause().getSuppressed()[0]).isSameAs(t1);
+        assertThat(reducedTry.getCause().getSuppressed()[1]).isSameAs(t2);
     }
 
     @Test


### PR DESCRIPTION
This is just a proposal.

The current implementation swallows exceptions in two places:

- `sequence()` / `traverse()`: only the first failure is taken into account, more failures are silently ignored
- `null` checks

This pull request fixes this. It adds a method `failWith()` and uses it in `sequence()` to collect all failures (the first encountered failure is the main failure, further failures will be added as suppressed exceptions).

It also introduces a new `requireNonNull()` method in `TryModule` that throws the NullPointerException just like `Objects.requireNonNull()`, but in case of a failure, it adds the cause of the failure as suppressed to the NPE.

**Issues with this proposal:**

1. *(Major)* It modifies the exception (`addSuppressed()`) → that's a side-effect and it's not thread safe due to the implementation in Java. However, silently swallowing exceptions is a complete no-go, that's a killer – I'd rather delete these methods. Another possible solution would be to introduce some `MultipleFailuresException`. This, however, would make proper exception handling more difficult because it introduces a new exception that wouldn't be thrown otherwise.

2. It's disputable whether `failWith()` should be exposed as public API.