### PR TITLE
Undeprecated commonly used methods like {Try, Option, Either}.get()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 ext.jmhVersion = '1.21'
-ext.junitVersion = '5.4.0-M1'
+ext.junitVersion = '5.5.0-M1'
 
 repositories {
     mavenLocal()

--- a/src/main/java/io/vavr/control/Either.java
+++ b/src/main/java/io/vavr/control/Either.java
@@ -160,28 +160,27 @@ public abstract class Either<L, R> implements io.vavr.Iterable<R>, Serializable 
     
     /**
      * Gets the right value if this is a {@code Right} or throws if this is a {@code Left}.
+     * <p>
+     * <strong>Warning:</strong> Please note that this operation is considered unsafe.
+     * Alternatives are {@link #fold(Function, Function)}, {@link #getOrElse(Object)}, {@link #getOrElseGet(Function)}
+     * or {@link #getOrElseThrow(Function)}.
+     * Other alternatives are {@link #onRight(Consumer)}, {@link #forEach(Consumer)} or iteration using a for-loop.
      *
      * @return the right value
      * @throws NoSuchElementException if this is a {@code Left}.
-     * @deprecated Unsafe operation (but not marked for removal).
-     *             Use {@link #fold(Function, Function)}, {@link #getOrElse(Object)}, {@link #getOrElseGet(Function)} or {@link #getOrElseThrow(Function)} instead.
-     *             Other alternatives are {@link #onRight(Consumer)}, {@link #forEach(Consumer)} or iteration using a for-loop.
      */
-    @Deprecated
     public abstract R get();
 
     /**
      * Gets the left value if this is a {@code Left} or throws if this is a {@code Right}.
+     * <p>
+     * <strong>Warning:</strong> Please note that this operation is considered unsafe.
+     * Alternatives are {@link #fold(Function, Function)} or  {@link #onLeft(Consumer)}.
      *
      * @return The left value.
      * @throws NoSuchElementException if this is a {@code Right}.
-     * @deprecated Unsafe operation (but not marked for removal).
-     *             Use {@link #fold(Function, Function)} instead.
-     *             An alternative is {@link #onLeft(Consumer)}.
      */
-    @Deprecated
     public abstract L getLeft();
-
 
     /**
      * Gets the Right value or an alternate value, if the Either is a Left.

--- a/src/main/java/io/vavr/control/Option.java
+++ b/src/main/java/io/vavr/control/Option.java
@@ -198,14 +198,14 @@ public abstract class Option<T> implements io.vavr.Iterable<T>, Serializable {
 
     /**
      * Gets the value if this is a {@code Some} or throws if this is a {@code None}.
+     * <p>
+     * <strong>Warning:</strong> Please note that this operation is considered unsafe.
+     * Alternatives are {@link #getOrElse(Object)}, {@link #getOrElseGet(Supplier)} or {@link #getOrElseThrow(Supplier)}.
+     * Other alternatives are {@link #onDefined(Consumer)}, {@link #forEach(Consumer)} or iteration using a for-loop.
      *
      * @return the value
      * @throws NoSuchElementException if this is a {@code None}.
-     * @deprecated Unsafe operation (but not marked for removal).
-     *             User {@link #getOrElse(Object)}, {@link #getOrElseGet(Supplier)} or {@link #getOrElseThrow(Supplier)} instead.
-     *             Other alternatives are {@link #onDefined(Consumer)}, {@link #forEach(Consumer)} or iteration using a for-loop.
      */
-    @Deprecated
     public abstract T get() throws NoSuchElementException;
 
     /**

--- a/src/main/java/io/vavr/control/Try.java
+++ b/src/main/java/io/vavr/control/Try.java
@@ -306,31 +306,33 @@ public abstract class Try<T> implements io.vavr.Iterable<T>, Serializable {
      * Gets the result of this Try if this is a {@code Success} or throws if this is a {@code Failure}.
      * <p>
      * If this is a {@code Failure} the cause is thrown using the following strategy:, it will <em>rethrow</em> the original cause if it is an {@link Error} or a {@link RuntimeException}.
+     *
      * <ul>
      *   <li>The original cause is <em>rethrown</em>, if it is an unchecked exception (namely an {@link Error} or a {@link RuntimeException}).</li>
      *   <li>If the cause is a checked exception, it is <em>wrapped</em> in an unchecked {@link NonFatalException} and thrown.</li>
      * </ul>
+     *
+     * <strong>Warning:</strong> Please note that this operation is considered unsafe.
+     * Alternatives are {@link #fold(Function, Function)}, {@link #getOrElse(Object)}, {@link #getOrElseGet(Supplier)}
+     * or {@link #getOrElseThrow(Function)}.
+     * Other alternatives are {@link #onSuccess(Consumer)}, {@link #forEach(Consumer)} or iteration using a for-loop.
+     *
      * @return The computation result if this is a {@code Success}
      * @throws Error if this is a {@code Failure} and the cause is an {@code Error}
      * @throws RuntimeException if this is a {@code Failure} and the cause is a {@code RuntimeException}
      * @throws NonFatalException if this is a {@code Failure} and the cause is a checked {@code Exception}
-     * @deprecated Unsafe operation (but not marked for removal).
-     *             Use {@link #fold(Function, Function)}, {@link #getOrElse(Object)}, {@link #getOrElseGet(Supplier)} or {@link #getOrElseThrow(Function)} instead.
-     *             Other alternatives are {@link #onSuccess(Consumer)}, {@link #forEach(Consumer)} or iteration using a for-loop.
      */
-    @Deprecated
     public abstract T get() throws Error, RuntimeException;
 
     /**
      * Gets the cause if this is a Failure or throws if this is a Success.
+     * <p>
+     * <strong>Warning:</strong> Please note that this operation is considered unsafe.
+     * Alternatives are {@link #fold(Function, Function)} and {@link #onFailure(Consumer)}.
      *
      * @return The cause if this is a Failure
      * @throws UnsupportedOperationException if this is a Success
-     * @deprecated Unsafe operation (but not marked for removal).
-     *             Use {@link #fold(Function, Function)} instead.
-     *             An alternative is {@link #onFailure(Consumer)}.
      */
-    @Deprecated
     public abstract Throwable getCause() throws UnsupportedOperationException;
 
     /**

--- a/src/test/java/io/vavr/control/EitherTest.java
+++ b/src/test/java/io/vavr/control/EitherTest.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SuppressWarnings("deprecation")
 class EitherTest {
 
     // -- Testees

--- a/src/test/java/io/vavr/control/OptionTest.java
+++ b/src/test/java/io/vavr/control/OptionTest.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SuppressWarnings("deprecation")
 class OptionTest {
 
     // -- Testees

--- a/src/test/java/io/vavr/control/TryTest.java
+++ b/src/test/java/io/vavr/control/TryTest.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SuppressWarnings("deprecation")
 class TryTest {
 
     // -- Testees


### PR DESCRIPTION
VAVR 1.0 deserves a clean start. Deprecating these methods in order to tag them as unsafe makes life unnecessary hard for the users. There exist safe and valid uses-cases. Internally, we also make use of them.