### PR TITLE
Added filterNot and test cases to Option, Either, and Try (#2402)

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Either.java
+++ b/vavr/src/main/java/io/vavr/control/Either.java
@@ -449,6 +449,19 @@ public interface Either<L, R> extends Value<R>, Serializable {
     }
 
     /**
+     * Filters this right-biased {@code Either} by testing for failure of a predicate.
+     * <p>
+     *
+     * @param predicate A predicate to fail
+     * @return a new {@code Option} instance
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    default Option<Either<L, R>> filterNot(Predicate<? super R> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return isLeft() || predicate.negate().test(get()) ? Option.some(this) : Option.none();
+    }
+
+    /**
      * Filters this right-biased {@code Either} by testing a predicate.
      * If the {@code Either} is a {@code Right} and the predicate doesn't match, the
      * {@code Either} will be turned into a {@code Left} with contents computed by applying

--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -367,6 +367,17 @@ public interface Option<T> extends Value<T>, Serializable {
     }
 
     /**
+     * Returns {@code Some(value)} if this is a {@code Some}} and the value violates the given predicate.
+     * Otherwise {@code None} is returned.
+     * @param predicate A predicate which is used to test against an optional value
+     * @return {@code Some(value)} or {@code None} as specified
+     */
+    default Option<T> filterNot(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return isEmpty() || predicate.test(get()) ? none() : this;
+    }
+
+    /**
      * Maps the value to a new {@code Option} if this is a {@code Some}, otherwise returns {@code None}.
      *
      * @param mapper A mapper

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -369,6 +369,21 @@ public interface Try<T> extends Value<T>, Serializable {
     }
 
     /**
+     * Shortcut for {@code filterTry(predicate::test, throwableSupplier)}, see
+     * {@link #filterTry(CheckedPredicate, Supplier)}}.
+     *
+     * @param predicate         A predicate that should fail
+     * @param throwableSupplier A supplier of a throwable
+     * @return a {@code Try} instance
+     * @throws NullPointerException if {@code predicate} or {@code throwableSupplier} is null
+     */
+    default Try<T> filterNot(Predicate<? super T> predicate, Supplier<? extends Throwable> throwableSupplier) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        Objects.requireNonNull(throwableSupplier, "throwableSupplier is null");
+        return filterTry(t -> predicate.negate().test(t), throwableSupplier);
+    }
+
+    /**
      * Shortcut for {@code filterTry(predicate::test, errorProvider::apply)}, see
      * {@link #filterTry(CheckedPredicate, CheckedFunction1)}}.
      *
@@ -384,6 +399,21 @@ public interface Try<T> extends Value<T>, Serializable {
     }
 
     /**
+     * Shortcut for {@code filterTry(predicate::test, errorProvider::apply)}, see
+     * {@link #filterTry(CheckedPredicate, CheckedFunction1)}}.
+     *
+     * @param predicate A predicate that should fail
+     * @param errorProvider A function that provides some kind of Throwable for T
+     * @return a {@code Try} instance
+     * @throws NullPointerException if {@code predicate} or {@code errorProvider} is null
+     */
+    default Try<T> filterNot(Predicate<? super T> predicate, Function<? super T, ? extends Throwable> errorProvider) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        Objects.requireNonNull(errorProvider, "errorProvider is null");
+        return filterTry(t -> predicate.negate().test(t), errorProvider::apply);
+    }
+
+    /**
      * Shortcut for {@code filterTry(predicate::test)}, see {@link #filterTry(CheckedPredicate)}}.
      *
      * @param predicate A predicate
@@ -393,6 +423,18 @@ public interface Try<T> extends Value<T>, Serializable {
     default Try<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filterTry(predicate::test);
+    }
+
+    /**
+     * Shortcut for {@code filterTry(predicate::test)}, see {@link #filterTry(CheckedPredicate)}}.
+     *
+     * @param predicate A predicate that should fail
+     * @return a {@code Try} instance
+     * @throws NullPointerException if {@code predicate} is null
+     */
+    default Try<T> filterNot(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return filterTry(t -> predicate.negate().test(t));
     }
 
     /**

--- a/vavr/src/test/java/io/vavr/control/EitherTest.java
+++ b/vavr/src/test/java/io/vavr/control/EitherTest.java
@@ -358,6 +358,22 @@ public class EitherTest extends AbstractValueTest {
         assertThat(either.filter(i -> false).get()).isSameAs(either);
     }
 
+    // -- filterNot
+
+    @Test
+    public void shouldFilterNotRight() {
+        Either<String, Integer> either = Either.right(42);
+        assertThat(either.filterNot(i -> false).get()).isSameAs(either);
+        assertThat(either.filterNot(i -> true)).isSameAs(Option.none());
+    }
+
+    @Test
+    public void shouldFilterNotLeft() {
+        Either<String, Integer> either = Either.left("vavr");
+        assertThat(either.filterNot(i -> false).get()).isSameAs(either);
+        assertThat(either.filterNot(i -> true).get()).isSameAs(either);
+    }
+
     // -- filterOrElse
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/OptionTest.java
+++ b/vavr/src/test/java/io/vavr/control/OptionTest.java
@@ -348,6 +348,23 @@ public class OptionTest extends AbstractValueTest {
         assertThat(Option.<Integer> none().filter(i -> i == 1)).isEqualTo(Option.none());
     }
 
+    // -- filterNot
+
+    @Test
+    public void shouldReturnNoneOnFilterWhenValueIsDefinedAndNotPredicateMatches() {
+        assertThat(Option.of(1).filterNot(i -> i == 1)).isEqualTo(Option.none());
+    }
+
+    @Test
+    public void shouldReturnSomeOnFilterWhenValueIsDefinedAndNotPredicateNotMatches() {
+        assertThat(Option.of(1).filterNot(i -> i == 2)).isEqualTo((Option.of(1)));
+    }
+
+    @Test
+    public void shouldReturnNoneOnFilterWhenValueIsNotDefinedAndNotPredicateNotMatches() {
+        assertThat(Option.<Integer> none().filterNot(i -> i == 1)).isEqualTo(Option.none());
+    }
+
     // -- map
 
     @Test

--- a/vavr/src/test/java/io/vavr/control/TryTest.java
+++ b/vavr/src/test/java/io/vavr/control/TryTest.java
@@ -1059,6 +1059,39 @@ public class TryTest extends AbstractValueTest {
         assertThat(identity.filter(s -> false, ignored -> new IllegalArgumentException())).isEqualTo(identity);
     }
 
+    // -- filterNot
+
+    @Test
+    public void shouldFilterNotMatchingPredicateOnFailure() {
+        final Try<String> actual = failure();
+        assertThat(actual.filterNot(s -> false)).isEqualTo(actual);
+    }
+
+    @Test
+    public void shouldFilterNotNonMatchingPredicateOnFailure() {
+        final Try<String> actual = failure();
+        assertThat(actual.filterNot(s -> true)).isEqualTo(actual);
+    }
+
+    @Test
+    public void shouldFilterNotWithExceptionOnFailure() {
+        final Try<String> actual = failure();
+        assertThat(actual.filterNot(this::filter)).isEqualTo(actual);
+    }
+
+    @Test
+    public void shouldReturnIdentityWhenFilterNotOnFailure() {
+        final Try<String> identity = failure();
+        assertThat(identity.filterNot(s -> false)).isEqualTo(identity);
+    }
+
+    @Test
+    public void shouldReturnIdentityWhenFilterNotWithErrorProviderOnFailure() {
+        final Try<String> identity = failure();
+        assertThat(identity.filterNot(s -> true, ignored -> new IllegalArgumentException())).isEqualTo(identity);
+    }
+
+
     // -- flatMap
 
     @Test


### PR DESCRIPTION
This is my first PR to vavr, so please excuse me if I make any mistakes.

As per #2402, it was suggested that `filterNot` be added to `Option`, `Either`, and `Try`; I added these methods and unit test cases.

I will push another commit to deprecate `reject` and replace it with `filterNot`. Since this second part is a fairly big commit, I thought I would elicit PR comments first; should I deprecate all the `reject` methods and essentially copy them to `filterNot`?