### PR TITLE
Implement deterministic shuffling

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -1215,6 +1215,11 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    public Array<T> shuffle(Random random) {
+        return io.vavr.collection.Collections.shuffle(this, random, Array::ofAll);
+    }
+
+    @Override
     public Array<T> slice(int beginIndex, int endIndex) {
         if (beginIndex >= endIndex || beginIndex >= length() || isEmpty()) {
             return empty();

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -959,6 +959,11 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
+    public CharSeq shuffle(Random random) {
+        return io.vavr.collection.Collections.shuffle(this, random, CharSeq::ofAll);
+    }
+
+    @Override
     public CharSeq slice(int beginIndex, int endIndex) {
         final int from = beginIndex < 0 ? 0 : beginIndex;
         final int to = endIndex > length() ? length() : endIndex;

--- a/vavr/src/main/java/io/vavr/collection/Collections.java
+++ b/vavr/src/main/java/io/vavr/collection/Collections.java
@@ -426,6 +426,16 @@ final class Collections {
         return ofAll.apply(list);
     }
 
+    static <T, S extends Seq<T>> S shuffle(S source, Random random, Function<? super Iterable<T>, S> ofAll) {
+        if (source.length() <= 1) {
+            return source;
+        }
+
+        final java.util.List<T> list = source.toJavaList();
+        java.util.Collections.shuffle(list, random);
+        return ofAll.apply(list);
+    }
+
     static void subSequenceRangeCheck(int beginIndex, int endIndex, int length) {
         if (beginIndex < 0 || endIndex > length) {
             throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + "), length = " + length);

--- a/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
@@ -27,6 +27,7 @@ import io.vavr.control.Option;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Random;
 import java.util.function.*;
 
 /**
@@ -336,6 +337,9 @@ public interface IndexedSeq<T> extends Seq<T> {
 
     @Override
     IndexedSeq<T> shuffle();
+
+    @Override
+    IndexedSeq<T> shuffle(Random random);
 
     @Override
     IndexedSeq<T> slice(int beginIndex, int endIndex);

--- a/vavr/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/LinearSeq.java
@@ -26,6 +26,7 @@ import io.vavr.control.Option;
 
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.Random;
 import java.util.function.*;
 
 /**
@@ -286,6 +287,9 @@ public interface LinearSeq<T> extends Seq<T> {
 
     @Override
     LinearSeq<T> shuffle();
+
+    @Override
+    LinearSeq<T> shuffle(Random random);
 
     @Override
     LinearSeq<T> scan(T zero, BiFunction<? super T, ? super T, ? extends T> operation);

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -1416,6 +1416,11 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
+    default List<T> shuffle(Random random) {
+        return Collections.shuffle(this, random, List::ofAll);
+    }
+
+    @Override
     default List<T> slice(int beginIndex, int endIndex) {
         if (beginIndex >= endIndex || beginIndex >= length() || isEmpty()) {
             return empty();

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -1130,6 +1130,11 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
+    public Queue<T> shuffle(Random random) {
+        return io.vavr.collection.Collections.shuffle(this, random, Queue::ofAll);
+    }
+
+    @Override
     public Queue<T> slice(int beginIndex, int endIndex) {
         return ofAll(toList().slice(beginIndex, endIndex));
     }

--- a/vavr/src/main/java/io/vavr/collection/Seq.java
+++ b/vavr/src/main/java/io/vavr/collection/Seq.java
@@ -25,6 +25,7 @@ import io.vavr.control.Option;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.Random;
 import java.util.function.*;
 
 /**
@@ -891,6 +892,16 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
      * @return a sequence with the same elements as the current sequence in a random order.
      */
     Seq<T> shuffle();
+
+    /**
+     * Randomize the order of the elements in the current sequence using the given source
+     * of randomness.
+     *
+     * @param random A random number generator
+     *
+     * @return a sequence with the same elements as the current sequence in a random order.
+     */
+    Seq<T> shuffle(Random random);
 
     /**
      * Returns a Seq that is a <em>slice</em> of this. The slice begins with the element at the specified

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -1451,6 +1451,11 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
+    default Stream<T> shuffle(Random random) {
+        return io.vavr.collection.Collections.shuffle(this, random, Stream::ofAll);
+    }
+
+    @Override
     default Stream<T> slice(int beginIndex, int endIndex) {
         if (beginIndex >= endIndex || isEmpty()) {
             return empty();

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -1076,6 +1076,11 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    public Vector<T> shuffle(Random random) {
+        return io.vavr.collection.Collections.shuffle(this, random, Vector::ofAll);
+    }
+
+    @Override
     public Vector<T> slice(int beginIndex, int endIndex) {
         if ((beginIndex >= endIndex) || (beginIndex >= size()) || isEmpty()) {
             return empty();

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Random;
 import java.util.Spliterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -1584,6 +1585,25 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldShuffleHaveSameElements() {
         final Seq<Integer> shuffled = of(1, 2, 3).shuffle();
+        assertThat(shuffled.indexOf(1)).isNotEqualTo(-1);
+        assertThat(shuffled.indexOf(2)).isNotEqualTo(-1);
+        assertThat(shuffled.indexOf(3)).isNotEqualTo(-1);
+        assertThat(shuffled.indexOf(4)).isEqualTo(-1);
+    }
+
+    @Test
+    public void shouldShuffleEmptyDeterministic() {
+        assertThat(empty().shuffle(new Random(514662720L)).isEmpty());
+    }
+
+    @Test
+    public void shouldShuffleHaveSameLengthDeterministic() {
+        assertThat(of(1, 2, 3).shuffle(new Random(514662720L)).size()).isEqualTo(of(1, 2, 3).size());
+    }
+
+    @Test
+    public void shouldShuffleHaveSameElementsDeterministic() {
+        final Seq<Integer> shuffled = of(1, 2, 3).shuffle(new Random(514662720L));
         assertThat(shuffled.indexOf(1)).isNotEqualTo(-1);
         assertThat(shuffled.indexOf(2)).isNotEqualTo(-1);
         assertThat(shuffled.indexOf(3)).isNotEqualTo(-1);

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -1529,6 +1529,25 @@ public class CharSeqTest {
         assertThat(shuffled.indexOf(4)).isEqualTo(-1);
     }
 
+    @Test
+    public void shouldShuffleEmptyDeterministic() {
+        assertThat(CharSeq.empty().shuffle(new Random(514662720L)).isEmpty());
+    }
+
+    @Test
+    public void shouldShuffleHaveSameLengthDeterministic() {
+        final CharSeq actual = CharSeq.of('1', '2', '3');
+        assertThat(actual.shuffle(new Random(514662720L)).size()).isEqualTo(actual.size());
+    }
+
+    @Test
+    public void shouldShuffleHaveSameElementsDeterministic() {
+        final CharSeq actual = CharSeq.of('1', '2', '3');
+        final CharSeq shuffled = actual.shuffle(new Random(514662720L));
+        assertThat(shuffled.containsAll(actual)).isTrue();
+        assertThat(shuffled.indexOf(4)).isEqualTo(-1);
+    }
+
     // -- slideBy(classifier)
 
     @Test


### PR DESCRIPTION
This adds an overload of the shuffle() method on sequences that takes
an explicit Random source.

Fix: https://github.com/vavr-io/vavr/issues/1318