### PR TITLE
Adds openjdk13 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ matrix:
   - jdk: openjdk11
   - jdk: openjdk12
     env: DEPLOY=true
+  - jdk: openjdk-13
   - jdk: openjdk-ea
   allow_failures:
+  - jdk: openjdk-13
   - jdk: openjdk-ea
 
 before_cache:


### PR DESCRIPTION
We are allowing failures because of a compiler warning that 'yield' might be reserved.