### PR TITLE
Introducing Iterable, deprecating Value

### DIFF
--- a/src-gen/main/java/io/vavr/API.java
+++ b/src-gen/main/java/io/vavr/API.java
@@ -31,6 +31,7 @@ import io.vavr.control.Option;
 import io.vavr.control.Try;
 import io.vavr.control.Validation;
 import java.io.PrintStream;
+import java.lang.Iterable;
 import java.util.Comparator;
 import java.util.Formatter;
 import java.util.Objects;
@@ -2328,7 +2329,7 @@ public final class API {
      *             .yield(reply -&gt; person + ", " + tweet + ", " + reply)));
      * </code></pre>
      *
-     * @param ts An iterable
+     * @param ts A {@link Iterable}
      * @param f A function {@code T -> Iterable<U>}
      * @param <T> element type of {@code ts}
      * @param <U> component type of the resulting {@code Iterator}

--- a/src-gen/main/java/io/vavr/Tuple.java
+++ b/src-gen/main/java/io/vavr/Tuple.java
@@ -26,6 +26,7 @@ package io.vavr;
 
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
+import java.lang.Iterable;
 import java.util.Map;
 import java.util.Objects;
 
@@ -502,7 +503,7 @@ public interface Tuple {
      * Turns a sequence of {@code Tuple1} into a Tuple1 of {@code Seq}.
      *
      * @param <T1> 1st component type
-     * @param tuples an {@code Iterable} of tuples
+     * @param tuples a {@link Iterable} of tuples
      * @return a tuple of one {@link Seq}.
      */
     static <T1> Tuple1<Seq<T1>> sequence1(Iterable<? extends Tuple1<? extends T1>> tuples) {
@@ -516,7 +517,7 @@ public interface Tuple {
      *
      * @param <T1> 1st component type
      * @param <T2> 2nd component type
-     * @param tuples an {@code Iterable} of tuples
+     * @param tuples a {@link Iterable} of tuples
      * @return a tuple of two {@link Seq}s.
      */
     static <T1, T2> Tuple2<Seq<T1>, Seq<T2>> sequence2(Iterable<? extends Tuple2<? extends T1, ? extends T2>> tuples) {
@@ -531,7 +532,7 @@ public interface Tuple {
      * @param <T1> 1st component type
      * @param <T2> 2nd component type
      * @param <T3> 3rd component type
-     * @param tuples an {@code Iterable} of tuples
+     * @param tuples a {@link Iterable} of tuples
      * @return a tuple of three {@link Seq}s.
      */
     static <T1, T2, T3> Tuple3<Seq<T1>, Seq<T2>, Seq<T3>> sequence3(Iterable<? extends Tuple3<? extends T1, ? extends T2, ? extends T3>> tuples) {
@@ -547,7 +548,7 @@ public interface Tuple {
      * @param <T2> 2nd component type
      * @param <T3> 3rd component type
      * @param <T4> 4th component type
-     * @param tuples an {@code Iterable} of tuples
+     * @param tuples a {@link Iterable} of tuples
      * @return a tuple of 4 {@link Seq}s.
      */
     static <T1, T2, T3, T4> Tuple4<Seq<T1>, Seq<T2>, Seq<T3>, Seq<T4>> sequence4(Iterable<? extends Tuple4<? extends T1, ? extends T2, ? extends T3, ? extends T4>> tuples) {
@@ -564,7 +565,7 @@ public interface Tuple {
      * @param <T3> 3rd component type
      * @param <T4> 4th component type
      * @param <T5> 5th component type
-     * @param tuples an {@code Iterable} of tuples
+     * @param tuples a {@link Iterable} of tuples
      * @return a tuple of 5 {@link Seq}s.
      */
     static <T1, T2, T3, T4, T5> Tuple5<Seq<T1>, Seq<T2>, Seq<T3>, Seq<T4>, Seq<T5>> sequence5(Iterable<? extends Tuple5<? extends T1, ? extends T2, ? extends T3, ? extends T4, ? extends T5>> tuples) {
@@ -582,7 +583,7 @@ public interface Tuple {
      * @param <T4> 4th component type
      * @param <T5> 5th component type
      * @param <T6> 6th component type
-     * @param tuples an {@code Iterable} of tuples
+     * @param tuples a {@link Iterable} of tuples
      * @return a tuple of 6 {@link Seq}s.
      */
     static <T1, T2, T3, T4, T5, T6> Tuple6<Seq<T1>, Seq<T2>, Seq<T3>, Seq<T4>, Seq<T5>, Seq<T6>> sequence6(Iterable<? extends Tuple6<? extends T1, ? extends T2, ? extends T3, ? extends T4, ? extends T5, ? extends T6>> tuples) {
@@ -601,7 +602,7 @@ public interface Tuple {
      * @param <T5> 5th component type
      * @param <T6> 6th component type
      * @param <T7> 7th component type
-     * @param tuples an {@code Iterable} of tuples
+     * @param tuples a {@link Iterable} of tuples
      * @return a tuple of 7 {@link Seq}s.
      */
     static <T1, T2, T3, T4, T5, T6, T7> Tuple7<Seq<T1>, Seq<T2>, Seq<T3>, Seq<T4>, Seq<T5>, Seq<T6>, Seq<T7>> sequence7(Iterable<? extends Tuple7<? extends T1, ? extends T2, ? extends T3, ? extends T4, ? extends T5, ? extends T6, ? extends T7>> tuples) {
@@ -621,7 +622,7 @@ public interface Tuple {
      * @param <T6> 6th component type
      * @param <T7> 7th component type
      * @param <T8> 8th component type
-     * @param tuples an {@code Iterable} of tuples
+     * @param tuples a {@link Iterable} of tuples
      * @return a tuple of 8 {@link Seq}s.
      */
     static <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<Seq<T1>, Seq<T2>, Seq<T3>, Seq<T4>, Seq<T5>, Seq<T6>, Seq<T7>, Seq<T8>> sequence8(Iterable<? extends Tuple8<? extends T1, ? extends T2, ? extends T3, ? extends T4, ? extends T5, ? extends T6, ? extends T7, ? extends T8>> tuples) {

--- a/src-gen/main/java/io/vavr/collection/ArrayType.java
+++ b/src-gen/main/java/io/vavr/collection/ArrayType.java
@@ -123,7 +123,7 @@ interface ArrayType<T> {
         return result;
     }
 
-    /** Store the content of an iterable in an array */
+    /** Store the content of an iterator in an array */
     static Object[] asArray(java.util.Iterator<?> it, int length) {
         final Object[] array = new Object[length];
         for (int i = 0; i < length; i++) {
@@ -133,7 +133,7 @@ interface ArrayType<T> {
     }
 
     @SuppressWarnings("unchecked")
-    static <T> T asPrimitives(Class<?> primitiveClass, Iterable<?> values) {
+    static <T> T asPrimitives(Class<?> primitiveClass, java.lang.Iterable<?> values) {
         final Object[] array = Array.ofAll(values).toJavaArray();
         final ArrayType<T> type = of((Class<T>) primitiveClass);
         final Object results = type.newInstance(array.length);

--- a/src-gen/test/java/io/vavr/APITest.java
+++ b/src-gen/test/java/io/vavr/APITest.java
@@ -36,6 +36,7 @@ import io.vavr.concurrent.Future;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
+import java.lang.Iterable;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.concurrent.Executors;

--- a/src/main/java/io/vavr/Iterable.java
+++ b/src/main/java/io/vavr/Iterable.java
@@ -1,0 +1,59 @@
+/* ____  ______________  ________________________  __________
+ * \   \/   /      \   \/   /   __/   /      \   \/   /      \
+ *  \______/___/\___\______/___/_____/___/\___\______/___/\___\
+ *
+ * Copyright 2019 Vavr, http://vavr.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vavr;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Extension of the well-known Java {@link java.lang.Iterable} in the sense that a rich
+ * Vavr {@link io.vavr.collection.Iterator} is returned by {@link #iterator()}.
+ *
+ * @param <T> the element type
+ */
+public interface Iterable<T> extends java.lang.Iterable<T> {
+
+    /**
+     * Returns a rich {@code Iterator} that allows us to perform intermediate, sequential
+     * operations known from Vavr's collection library.
+     *
+     * @return an {@link io.vavr.collection.Iterator} instance (that might be a singleton in the empty case)
+     */
+    @Override
+    io.vavr.collection.Iterator<T> iterator();
+
+    /**
+     * A generic conversion function.
+     * <p>
+     * Example:
+     * <pre>{@code
+     * List<Integer> list = Option.some(1).to(List::ofAll);
+     * }</pre>
+     *
+     * @param fromIterable A function that converts a {@link java.lang.Iterable} to some type {@code C}.
+     * @param <C> the target type of the conversion
+     * @return a new instance of type {@code C} that must not be {@code null} per contract
+     */
+    // `Iterable<T>` must not have a generic type bound, see TraversableTest ShouldJustCompile
+    default <C> C to(Function<? super java.lang.Iterable<T>, C> fromIterable) {
+        Objects.requireNonNull(fromIterable, "fromIterable is null");
+        return fromIterable.apply(this);
+    }
+
+}

--- a/src/main/java/io/vavr/Lazy.java
+++ b/src/main/java/io/vavr/Lazy.java
@@ -26,6 +26,7 @@ import io.vavr.control.Option;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.Objects;
@@ -54,6 +55,7 @@ import java.util.function.Supplier;
  */
 // DEV-NOTE: No flatMap and orElse because this more like a Functor than a Monad.
 //           It represents a value rather than capturing a specific state.
+@SuppressWarnings("deprecation")
 public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/vavr/PartialFunction.java
+++ b/src/main/java/io/vavr/PartialFunction.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
  * @param <T> type of the function input, called <em>domain</em> of the function
  * @param <R> type of the function output, called <em>codomain</em> of the function
  */
+@SuppressWarnings("deprecation")
 public interface PartialFunction<T, R> extends Function1<T, R> {
 
     /**

--- a/src/main/java/io/vavr/Patterns.java
+++ b/src/main/java/io/vavr/Patterns.java
@@ -20,22 +20,10 @@
 // CHECKSTYLE:OFF
 package io.vavr;
 
-import io.vavr.API.Match.Pattern;
-import io.vavr.API.Match.Pattern0;
-import io.vavr.API.Match.Pattern1;
-import io.vavr.API.Match.Pattern2;
-import io.vavr.API.Match.Pattern3;
-import io.vavr.API.Match.Pattern4;
-import io.vavr.API.Match.Pattern5;
-import io.vavr.API.Match.Pattern6;
-import io.vavr.API.Match.Pattern7;
-import io.vavr.API.Match.Pattern8;
+import io.vavr.API.Match.*;
 import io.vavr.collection.List;
 import io.vavr.concurrent.Future;
-import io.vavr.control.Either;
-import io.vavr.control.Option;
-import io.vavr.control.Try;
-import io.vavr.control.Validation;
+import io.vavr.control.*;
 
 /**
  * @deprecated Will be removed in the next major version, along with VAVR's pattern matching, in favor of Java's native pattern matching.

--- a/src/main/java/io/vavr/Predicates.java
+++ b/src/main/java/io/vavr/Predicates.java
@@ -21,6 +21,7 @@ package io.vavr;
 import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 
+import java.lang.Iterable;
 import java.util.Objects;
 import java.util.function.Predicate;
 

--- a/src/main/java/io/vavr/Value.java
+++ b/src/main/java/io/vavr/Value.java
@@ -37,7 +37,6 @@ import io.vavr.collection.Stream;
 import io.vavr.collection.TreeMap;
 import io.vavr.collection.TreeSet;
 import io.vavr.collection.Vector;
-import io.vavr.concurrent.Future;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
@@ -45,6 +44,7 @@ import io.vavr.control.Validation;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.lang.Iterable;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.*;
@@ -171,13 +171,15 @@ import static io.vavr.API.*;
  * <strong>Please note:</strong> flatMap signatures are manifold and have to be declared by subclasses of Value.
  *
  * @param <T> The type of the wrapped value.
+ * @deprecated Superseded by io.vavr.Iterable
  */
+@Deprecated
 public interface Value<T> extends Iterable<T> {
 
     /**
      * Narrows a widened {@code Value<? extends T>} to {@code Value<T>}
      * by performing a type-safe cast. This is eligible because immutable/read-only
-     * collections are covariant.
+     * types are covariant.
      *
      * @param value A {@code Value}.
      * @param <T>   Component type of the {@code Value}.
@@ -1514,6 +1516,7 @@ public interface Value<T> extends Iterable<T> {
 
 }
 
+@SuppressWarnings("deprecation")
 interface ValueModule {
     
     static <T, R extends Traversable<T>> R toTraversable(

--- a/src/main/java/io/vavr/collection/AbstractMultimap.java
+++ b/src/main/java/io/vavr/collection/AbstractMultimap.java
@@ -18,11 +18,11 @@
  */
 package io.vavr.collection;
 
-import io.vavr.Tuple;
-import io.vavr.Tuple2;
+import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Objects;

--- a/src/main/java/io/vavr/collection/AbstractQueue.java
+++ b/src/main/java/io/vavr/collection/AbstractQueue.java
@@ -18,10 +18,10 @@
  */
 package io.vavr.collection;
 
-import io.vavr.Tuple;
-import io.vavr.Tuple2;
+import io.vavr.*;
 import io.vavr.control.Option;
 
+import java.lang.Iterable;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Consumer;

--- a/src/main/java/io/vavr/collection/Array.java
+++ b/src/main/java/io/vavr/collection/Array.java
@@ -23,6 +23,7 @@ import io.vavr.collection.ArrayModule.Combinations;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;

--- a/src/main/java/io/vavr/collection/BitSet.java
+++ b/src/main/java/io/vavr/collection/BitSet.java
@@ -18,13 +18,11 @@
  */
 package io.vavr.collection;
 
-import io.vavr.Function1;
-import io.vavr.PartialFunction;
-import io.vavr.Tuple3;
-import io.vavr.Tuple2;
+import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
@@ -35,6 +33,7 @@ import java.util.stream.Collector;
 /**
  * An immutable {@code BitSet} implementation.
  */
+@SuppressWarnings("deprecation")
 public interface BitSet<T> extends SortedSet<T> {
 
     long serialVersionUID = 1L;
@@ -637,6 +636,7 @@ public interface BitSet<T> extends SortedSet<T> {
     }
 }
 
+@SuppressWarnings("deprecation")
 interface BitSetModule {
 
     int ADDRESS_BITS_PER_WORD = 6;

--- a/src/main/java/io/vavr/collection/CharSeq.java
+++ b/src/main/java/io/vavr/collection/CharSeq.java
@@ -24,6 +24,7 @@ import io.vavr.control.Option;
 
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
+import java.lang.Iterable;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.function.*;

--- a/src/main/java/io/vavr/collection/HashArrayMappedTrie.java
+++ b/src/main/java/io/vavr/collection/HashArrayMappedTrie.java
@@ -24,6 +24,7 @@ import io.vavr.collection.HashArrayMappedTrieModule.EmptyNode;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 

--- a/src/main/java/io/vavr/collection/HashMap.java
+++ b/src/main/java/io/vavr/collection/HashMap.java
@@ -23,6 +23,7 @@ import io.vavr.Tuple2;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.NoSuchElementException;

--- a/src/main/java/io/vavr/collection/HashMultimap.java
+++ b/src/main/java/io/vavr/collection/HashMultimap.java
@@ -21,6 +21,7 @@ package io.vavr.collection;
 import io.vavr.Tuple2;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Objects;

--- a/src/main/java/io/vavr/collection/HashSet.java
+++ b/src/main/java/io/vavr/collection/HashSet.java
@@ -22,6 +22,7 @@ import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.*;
+import java.lang.Iterable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
@@ -34,6 +35,7 @@ import java.util.stream.Collector;
  *
  * @param <T> Component type
  */
+@SuppressWarnings("deprecation")
 public final class HashSet<T> implements Set<T>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/vavr/collection/IndexedSeq.java
+++ b/src/main/java/io/vavr/collection/IndexedSeq.java
@@ -18,11 +18,10 @@
  */
 package io.vavr.collection;
 
-import io.vavr.PartialFunction;
-import io.vavr.Tuple3;
-import io.vavr.Tuple2;
+import io.vavr.*;
 import io.vavr.control.Option;
 
+import java.lang.Iterable;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.Objects;

--- a/src/main/java/io/vavr/collection/Iterator.java
+++ b/src/main/java/io/vavr/collection/Iterator.java
@@ -21,9 +21,12 @@ package io.vavr.collection;
 import io.vavr.*;
 import io.vavr.control.Option;
 
+import java.lang.Iterable;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.function.*;
+import java.util.stream.Collector;
+import java.util.stream.StreamSupport;
 
 import static io.vavr.collection.BigDecimalHelper.areEqual;
 import static io.vavr.collection.BigDecimalHelper.asDecimal;
@@ -150,7 +153,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     }
 
     /**
-     * Creates an Iterator based on the given Iterable. This is a convenience method for
+     * Creates a {@link io.vavr.collection.Iterator} based on the given {@link Iterable}. This is a convenience method for
      * {@code Iterator.ofAll(iterable.iterator()}.
      *
      * @param iterable A {@link Iterable}
@@ -1268,7 +1271,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
         if (!hasNext()) {
             return Tuple.of(empty(), empty());
         } else {
-            final Stream<Tuple2<? extends T1, ? extends T2>> source = Stream.ofAll(this.map(unzipper));
+            final Stream<Tuple2<? extends T1, ? extends T2>> source = Stream.ofAll(() -> map(unzipper));
             return Tuple.of(source.map(t -> (T1) t._1).iterator(), source.map(t -> (T2) t._2).iterator());
         }
     }
@@ -1280,7 +1283,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
         if (!hasNext()) {
             return Tuple.of(empty(), empty(), empty());
         } else {
-            final Stream<Tuple3<? extends T1, ? extends T2, ? extends T3>> source = Stream.ofAll(this.map(unzipper));
+            final Stream<Tuple3<? extends T1, ? extends T2, ? extends T3>> source = Stream.ofAll(map(unzipper));
             return Tuple.of(source.map(t -> (T1) t._1).iterator(), source.map(t -> (T2) t._2).iterator(), source.map(t -> (T3) t._3).iterator());
         }
     }
@@ -1587,12 +1590,13 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     }
 
     /**
-     * FlatMaps the elements of this Iterator to Iterables, which are iterated in the order of occurrence.
+     * Maps the elements of this Iterator to Iterables and concats their iterators.
      *
      * @param mapper A mapper
-     * @param <U>    Component type
-     * @return A new Iterable
+     * @param <U>    Component type of the resulting Iterator
+     * @return A new Iterator
      */
+    // DEV-NOTE: the shorter implementation `concat(map(mapper))` does not perform well
     @Override
     default <U> Iterator<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");

--- a/src/main/java/io/vavr/collection/JavaConverters.java
+++ b/src/main/java/io/vavr/collection/JavaConverters.java
@@ -98,6 +98,7 @@ class JavaConverters {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @GwtIncompatible("reflection is not supported")
     static class ListView<T, C extends Seq<T>> extends HasDelegate<C> implements java.util.List<T> {
 

--- a/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/src/main/java/io/vavr/collection/LinearSeq.java
@@ -18,11 +18,10 @@
  */
 package io.vavr.collection;
 
-import io.vavr.PartialFunction;
-import io.vavr.Tuple;
-import io.vavr.Tuple2;
+import io.vavr.*;
 import io.vavr.control.Option;
 
+import java.lang.Iterable;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.Random;

--- a/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -18,11 +18,11 @@
  */
 package io.vavr.collection;
 
-import io.vavr.Tuple;
-import io.vavr.Tuple2;
+import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Objects;

--- a/src/main/java/io/vavr/collection/LinkedHashMultimap.java
+++ b/src/main/java/io/vavr/collection/LinkedHashMultimap.java
@@ -21,6 +21,7 @@ package io.vavr.collection;
 import io.vavr.Tuple2;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Objects;

--- a/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -22,6 +22,7 @@ import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.*;
+import java.lang.Iterable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
@@ -34,6 +35,7 @@ import java.util.stream.Collector;
  *
  * @param <T> Component type
  */
+@SuppressWarnings("deprecation")
 public final class LinkedHashSet<T> implements Set<T>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/vavr/collection/List.java
+++ b/src/main/java/io/vavr/collection/List.java
@@ -18,16 +18,14 @@
  */
 package io.vavr.collection;
 
-import io.vavr.PartialFunction;
-import io.vavr.Tuple;
-import io.vavr.Tuple2;
-import io.vavr.Tuple3;
+import io.vavr.*;
 import io.vavr.collection.List.Nil;
 import io.vavr.collection.ListModule.Combinations;
 import io.vavr.collection.ListModule.SplitAt;
 import io.vavr.control.Option;
 
 import java.io.*;
+import java.lang.Iterable;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
@@ -1143,7 +1141,7 @@ public interface List<T> extends LinearSeq<T> {
         } else {
             final List<T> tail = tail();
             if (tail.isEmpty()) {
-                return of(this);
+                return List.of(this);
             } else {
                 final List<List<T>> zero = Nil.instance();
                 return distinct().foldLeft(zero, (xs, x) -> {

--- a/src/main/java/io/vavr/collection/Map.java
+++ b/src/main/java/io/vavr/collection/Map.java
@@ -22,6 +22,7 @@ import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.*;
 import java.util.function.*;
 
@@ -93,6 +94,7 @@ import java.util.function.*;
  * @param <K> Key type
  * @param <V> Value type
  */
+@SuppressWarnings("deprecation")
 public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K, V>, Serializable {
 
     long serialVersionUID = 1L;

--- a/src/main/java/io/vavr/collection/Maps.java
+++ b/src/main/java/io/vavr/collection/Maps.java
@@ -22,6 +22,7 @@ import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.control.Option;
 
+import java.lang.Iterable;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.function.*;

--- a/src/main/java/io/vavr/collection/Multimap.java
+++ b/src/main/java/io/vavr/collection/Multimap.java
@@ -22,6 +22,7 @@ import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.*;
 import java.util.function.*;
 
@@ -85,6 +86,7 @@ import java.util.function.*;
  * @param <K> Key type
  * @param <V> Value type
  */
+@SuppressWarnings("deprecation")
 public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K, Traversable<V>>, Serializable {
 
     long serialVersionUID = 1L;

--- a/src/main/java/io/vavr/collection/PriorityQueue.java
+++ b/src/main/java/io/vavr/collection/PriorityQueue.java
@@ -22,6 +22,7 @@ import io.vavr.*;
 import io.vavr.collection.PriorityQueueBase.*;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;

--- a/src/main/java/io/vavr/collection/Queue.java
+++ b/src/main/java/io/vavr/collection/Queue.java
@@ -21,6 +21,7 @@ package io.vavr.collection;
 import io.vavr.*;
 import io.vavr.control.Option;
 
+import java.lang.Iterable;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;

--- a/src/main/java/io/vavr/collection/RedBlackTree.java
+++ b/src/main/java/io/vavr/collection/RedBlackTree.java
@@ -18,14 +18,13 @@
  */
 package io.vavr.collection;
 
-import io.vavr.Tuple;
-import io.vavr.Tuple2;
-import io.vavr.Tuple3;
+import io.vavr.*;
 import io.vavr.collection.RedBlackTreeModule.Empty;
 import io.vavr.collection.RedBlackTreeModule.Node;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.Objects;

--- a/src/main/java/io/vavr/collection/Seq.java
+++ b/src/main/java/io/vavr/collection/Seq.java
@@ -22,6 +22,7 @@ import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.Random;

--- a/src/main/java/io/vavr/collection/Set.java
+++ b/src/main/java/io/vavr/collection/Set.java
@@ -18,13 +18,11 @@
  */
 package io.vavr.collection;
 
-import io.vavr.Function1;
-import io.vavr.PartialFunction;
-import io.vavr.Tuple3;
-import io.vavr.Tuple2;
+import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.Comparator;
 import java.util.function.*;
 
@@ -80,6 +78,7 @@ import java.util.function.*;
  *
  * @param <T> Component type
  */
+@SuppressWarnings("deprecation")
 public interface Set<T> extends Traversable<T>, Function1<T, Boolean>, Serializable {
 
     long serialVersionUID = 1L;

--- a/src/main/java/io/vavr/collection/SortedMap.java
+++ b/src/main/java/io/vavr/collection/SortedMap.java
@@ -21,6 +21,7 @@ package io.vavr.collection;
 import io.vavr.Tuple2;
 import io.vavr.control.Option;
 
+import java.lang.Iterable;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.function.*;

--- a/src/main/java/io/vavr/collection/SortedMultimap.java
+++ b/src/main/java/io/vavr/collection/SortedMultimap.java
@@ -18,9 +18,10 @@
  */
 package io.vavr.collection;
 
-import io.vavr.control.Option;
 import io.vavr.Tuple2;
+import io.vavr.control.Option;
 
+import java.lang.Iterable;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.function.*;

--- a/src/main/java/io/vavr/collection/SortedSet.java
+++ b/src/main/java/io/vavr/collection/SortedSet.java
@@ -18,11 +18,10 @@
  */
 package io.vavr.collection;
 
-import io.vavr.PartialFunction;
-import io.vavr.Tuple2;
-import io.vavr.Tuple3;
+import io.vavr.*;
 import io.vavr.control.Option;
 
+import java.lang.Iterable;
 import java.util.Comparator;
 import java.util.function.*;
 

--- a/src/main/java/io/vavr/collection/Stream.java
+++ b/src/main/java/io/vavr/collection/Stream.java
@@ -25,6 +25,7 @@ import io.vavr.collection.StreamModule.*;
 import io.vavr.control.Option;
 
 import java.io.*;
+import java.lang.Iterable;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;

--- a/src/main/java/io/vavr/collection/Traversable.java
+++ b/src/main/java/io/vavr/collection/Traversable.java
@@ -18,17 +18,17 @@
  */
 package io.vavr.collection;
 
-import io.vavr.PartialFunction;
-import io.vavr.Tuple2;
-import io.vavr.Tuple3;
-import io.vavr.Value;
+import io.vavr.*;
 import io.vavr.control.Option;
 
+import java.lang.Iterable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.function.*;
+import java.util.stream.Collector;
 import java.util.stream.DoubleStream;
+import java.util.stream.StreamSupport;
 
 /**
  * An interface for inherently recursive, multi-valued data structures. The order of elements is determined by
@@ -152,7 +152,7 @@ import java.util.stream.DoubleStream;
  * @param <T> Component type
  */
 @SuppressWarnings("deprecation")
-public interface Traversable<T> extends Foldable<T>, Value<T> {
+public interface Traversable<T> extends io.vavr.Iterable<T>, Foldable<T>, io.vavr.Value<T> {
 
     /**
      * Narrows a widened {@code Traversable<? extends T>} to {@code Traversable<T>}

--- a/src/main/java/io/vavr/collection/Tree.java
+++ b/src/main/java/io/vavr/collection/Tree.java
@@ -25,6 +25,7 @@ import io.vavr.collection.Tree.Node;
 import io.vavr.control.Option;
 
 import java.io.*;
+import java.lang.Iterable;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;

--- a/src/main/java/io/vavr/collection/TreeMap.java
+++ b/src/main/java/io/vavr/collection/TreeMap.java
@@ -23,6 +23,7 @@ import io.vavr.Tuple2;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.NoSuchElementException;

--- a/src/main/java/io/vavr/collection/TreeMultimap.java
+++ b/src/main/java/io/vavr/collection/TreeMultimap.java
@@ -21,6 +21,7 @@ package io.vavr.collection;
 import io.vavr.Tuple2;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;

--- a/src/main/java/io/vavr/collection/TreeSet.java
+++ b/src/main/java/io/vavr/collection/TreeSet.java
@@ -22,6 +22,7 @@ import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
@@ -35,6 +36,7 @@ import java.util.stream.Collector;
  * @param <T> Component type
  */
 // DEV-NOTE: it is not possible to create an EMPTY TreeSet without a Comparator type in scope
+@SuppressWarnings("deprecation")
 public final class TreeSet<T> implements SortedSet<T>, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/vavr/collection/Vector.java
+++ b/src/main/java/io/vavr/collection/Vector.java
@@ -23,6 +23,7 @@ import io.vavr.collection.VectorModule.Combinations;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;

--- a/src/main/java/io/vavr/concurrent/Future.java
+++ b/src/main/java/io/vavr/concurrent/Future.java
@@ -26,6 +26,7 @@ import io.vavr.control.Option;
 import io.vavr.control.Try;
 import io.vavr.collection.List;
 
+import java.lang.Iterable;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.*;
@@ -52,7 +53,7 @@ import java.util.function.*;
  * @param <T> Type of the computation result.
  */
 @SuppressWarnings("deprecation")
-public interface Future<T> extends Value<T> {
+public interface Future<T> extends io.vavr.Iterable<T>, Value<T> {
 
     /**
      * The default executor service is {@link ForkJoinPool#commonPool()}.

--- a/src/main/java/io/vavr/control/Either.java
+++ b/src/main/java/io/vavr/control/Either.java
@@ -18,12 +18,12 @@
  */
 package io.vavr.control;
 
-import io.vavr.Value;
 import io.vavr.collection.Iterator;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Vector;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -55,7 +55,8 @@ import java.util.function.Supplier;
  * @param <L> The type of the Left value of an Either.
  * @param <R> The type of the Right value of an Either.
  */
-public interface Either<L, R> extends Value<R>, Serializable {
+@SuppressWarnings("deprecation")
+public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Serializable {
 
     long serialVersionUID = 1L;
 
@@ -602,7 +603,7 @@ public interface Either<L, R> extends Value<R>, Serializable {
      * @deprecated Either is right-biased. Use {@link #swap()} instead of projections.
      */
     @Deprecated
-    final class LeftProjection<L, R> implements Value<L> {
+    final class LeftProjection<L, R> implements io.vavr.Value<L> {
 
         private final Either<L, R> either;
 
@@ -857,7 +858,7 @@ public interface Either<L, R> extends Value<R>, Serializable {
      * @deprecated Either is right-biased. Use {@link #swap()} instead of projections.
      */
     @Deprecated
-    final class RightProjection<L, R> implements Value<R> {
+    final class RightProjection<L, R> implements io.vavr.Value<R> {
 
         private final Either<L, R> either;
 

--- a/src/main/java/io/vavr/control/Option.java
+++ b/src/main/java/io/vavr/control/Option.java
@@ -19,12 +19,12 @@
 package io.vavr.control;
 
 import io.vavr.PartialFunction;
-import io.vavr.Value;
 import io.vavr.collection.Iterator;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Vector;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -46,7 +46,8 @@ import java.util.function.Supplier;
  *
  * @param <T> The type of the optional value.
  */
-public interface Option<T> extends Value<T>, Serializable {
+@SuppressWarnings("deprecation")
+public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializable {
 
     long serialVersionUID = 1L;
 

--- a/src/main/java/io/vavr/control/Try.java
+++ b/src/main/java/io/vavr/control/Try.java
@@ -24,6 +24,7 @@ import io.vavr.collection.Seq;
 import io.vavr.collection.Vector;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -52,7 +53,8 @@ import static io.vavr.control.TryModule.sneakyThrow;
  *
  * @param <T> Value type in the case of success.
  */
-public interface Try<T> extends Value<T>, Serializable {
+@SuppressWarnings("deprecation")
+public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializable {
 
     long serialVersionUID = 1L;
 

--- a/src/main/java/io/vavr/control/Validation.java
+++ b/src/main/java/io/vavr/control/Validation.java
@@ -24,6 +24,7 @@ import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -72,7 +73,8 @@ import java.util.function.Supplier;
  * @param <T> value type in the case of valid
  * @see <a href="https://github.com/scalaz/scalaz/blob/series/7.3.x/core/src/main/scala/scalaz/Validation.scala">Validation</a>
  */
-public interface Validation<E, T> extends Value<T>, Serializable {
+@SuppressWarnings("deprecation")
+public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Serializable {
 
     long serialVersionUID = 1L;
 

--- a/src/test/java/io/vavr/AbstractValueTest.java
+++ b/src/test/java/io/vavr/AbstractValueTest.java
@@ -31,6 +31,7 @@ import org.assertj.core.api.*;
 import org.junit.Test;
 
 import java.io.Serializable;
+import java.lang.Iterable;
 import java.util.*;
 import java.util.Collections;
 import java.util.function.Function;

--- a/src/test/java/io/vavr/collection/AbstractMapTest.java
+++ b/src/test/java/io/vavr/collection/AbstractMapTest.java
@@ -23,6 +23,7 @@ import io.vavr.control.Option;
 import org.assertj.core.api.IterableAssert;
 import org.junit.Test;
 
+import java.lang.Iterable;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;

--- a/src/test/java/io/vavr/collection/AbstractSortedSetTest.java
+++ b/src/test/java/io/vavr/collection/AbstractSortedSetTest.java
@@ -18,19 +18,16 @@
  */
 package io.vavr.collection;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.util.Comparator;
-import java.util.NoSuchElementException;
 import java.util.Spliterator;
 
 import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.reverseOrder;
 import static io.vavr.TestComparators.toStringComparator;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public abstract class AbstractSortedSetTest extends AbstractSetTest {
 

--- a/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -23,6 +23,7 @@ import io.vavr.control.Option;
 import org.junit.Test;
 
 import java.io.*;
+import java.lang.Iterable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;

--- a/src/test/java/io/vavr/collection/ArrayTest.java
+++ b/src/test/java/io/vavr/collection/ArrayTest.java
@@ -18,11 +18,11 @@
  */
 package io.vavr.collection;
 
-import io.vavr.Value;
 import io.vavr.Tuple2;
 import io.vavr.control.Option;
 import org.junit.Test;
 
+import java.lang.Iterable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.function.Function;
@@ -283,7 +283,7 @@ public class ArrayTest extends AbstractIndexedSeqTest {
 
     @Test
     public void shouldReturnSelfOnConvertToArray() {
-        Value<Integer> value = of(1, 2, 3);
+        Array<Integer> value = of(1, 2, 3);
         assertThat(value.toArray()).isSameAs(value);
     }
 }

--- a/src/test/java/io/vavr/collection/BitSetTest.java
+++ b/src/test/java/io/vavr/collection/BitSetTest.java
@@ -3,7 +3,6 @@ package io.vavr.collection;
 import io.vavr.Function1;
 import io.vavr.Tuple2;
 import io.vavr.Tuple3;
-import io.vavr.Value;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.IterableAssert;
 import org.assertj.core.api.ObjectAssert;
@@ -18,8 +17,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
-import static java.util.Comparator.naturalOrder;
-import static java.util.Comparator.reverseOrder;
 import static java.util.stream.Collectors.toList;
 import static io.vavr.Serializables.deserialize;
 import static io.vavr.Serializables.serialize;
@@ -509,7 +506,7 @@ public class BitSetTest extends AbstractSortedSetTest {
     @Override
     @Test
     public void shouldConvertToSortedSetWithoutComparatorOnComparable() {
-        final Value<Integer> value = BitSet.of(3, 7, 1, 15, 0);
+        final BitSet<Integer> value = BitSet.of(3, 7, 1, 15, 0);
         final Set<Integer> set = value.toSortedSet();
         if (value.isSingleValued()) {
             assertThat(set).isEqualTo(TreeSet.of(3));
@@ -523,7 +520,7 @@ public class BitSetTest extends AbstractSortedSetTest {
     @Test
     @Override
     public void shouldConvertToPriorityQueueUsingImplicitComparator() {
-        final Value<Integer> value = BitSet.of(1, 3, 2);
+        final BitSet<Integer> value = BitSet.of(1, 3, 2);
         final PriorityQueue<Integer> queue = value.toPriorityQueue();
         if (value.isSingleValued()) {
             assertThat(queue).isEqualTo(PriorityQueue.of(1));
@@ -536,7 +533,7 @@ public class BitSetTest extends AbstractSortedSetTest {
     @Override
     public void shouldConvertToPriorityQueueUsingExplicitComparator() {
         final Comparator<Integer> comparator = Comparator.naturalOrder();
-        final Value<Integer> value = BitSet.of(1, 3, 2);
+        final BitSet<Integer> value = BitSet.of(1, 3, 2);
         final PriorityQueue<Integer> queue = value.toPriorityQueue(comparator);
         if (value.isSingleValued()) {
             assertThat(queue).isEqualTo(PriorityQueue.of(comparator, 1));

--- a/src/test/java/io/vavr/collection/HashSetTest.java
+++ b/src/test/java/io/vavr/collection/HashSetTest.java
@@ -19,7 +19,6 @@
 package io.vavr.collection;
 
 import io.vavr.Tuple;
-import io.vavr.Value;
 import io.vavr.Tuple2;
 import org.assertj.core.api.*;
 import org.junit.Test;
@@ -475,7 +474,7 @@ public class HashSetTest extends AbstractSetTest {
 
     @Test
     public void shouldReturnSelfOnConvertToSet() {
-        final Value<Integer> value = of(1, 2, 3);
+        final HashSet<Integer> value = of(1, 2, 3);
         assertThat(value.toSet()).isSameAs(value);
     }
 

--- a/src/test/java/io/vavr/collection/LinkedHashSetTest.java
+++ b/src/test/java/io/vavr/collection/LinkedHashSetTest.java
@@ -1,6 +1,5 @@
 package io.vavr.collection;
 
-import io.vavr.Value;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -242,7 +241,7 @@ public class LinkedHashSetTest extends AbstractSetTest {
 
     @Test
     public void shouldReturnSelfOnConvertToLinkedSet() {
-        final Value<Integer> value = of(1, 2, 3);
+        final LinkedHashSet<Integer> value = of(1, 2, 3);
         assertThat(value.toLinkedSet()).isSameAs(value);
     }
 

--- a/src/test/java/io/vavr/collection/ListTest.java
+++ b/src/test/java/io/vavr/collection/ListTest.java
@@ -20,7 +20,6 @@ package io.vavr.collection;
 
 import io.vavr.Serializables;
 import io.vavr.Tuple;
-import io.vavr.Value;
 import io.vavr.Tuple2;
 import io.vavr.control.Option;
 import org.junit.Test;
@@ -419,7 +418,7 @@ public class ListTest extends AbstractLinearSeqTest {
 
     @Test
     public void shouldReturnSelfOnConvertToList() {
-        final Value<Integer> value = of(1, 2, 3);
+        final List<Integer> value = of(1, 2, 3);
         assertThat(value.toList()).isSameAs(value);
     }
 

--- a/src/test/java/io/vavr/collection/QueueTest.java
+++ b/src/test/java/io/vavr/collection/QueueTest.java
@@ -18,7 +18,6 @@
  */
 package io.vavr.collection;
 
-import io.vavr.Value;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.control.Option;
@@ -416,7 +415,7 @@ public class QueueTest extends AbstractLinearSeqTest {
 
     @Test
     public void shouldReturnSelfOnConvertToQueue() {
-        final Value<Integer> value = of(1, 2, 3);
+        final Queue<Integer> value = of(1, 2, 3);
         assertThat(value.toQueue()).isSameAs(value);
     }
 

--- a/src/test/java/io/vavr/collection/StreamTest.java
+++ b/src/test/java/io/vavr/collection/StreamTest.java
@@ -25,6 +25,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.InvalidObjectException;
+import java.lang.Iterable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Spliterator;

--- a/src/test/java/io/vavr/collection/TreeSetTest.java
+++ b/src/test/java/io/vavr/collection/TreeSetTest.java
@@ -18,7 +18,6 @@
  */
 package io.vavr.collection;
 
-import io.vavr.Value;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -356,7 +355,7 @@ public class TreeSetTest extends AbstractSortedSetTest {
 
     @Test
     public void shouldReturnSelfOnConvertToSortedSet() {
-        final Value<Integer> value = of(1, 2, 3);
+        final TreeSet<Integer> value = of(1, 2, 3);
         assertThat(value.toSortedSet()).isSameAs(value);
     }
 
@@ -368,13 +367,13 @@ public class TreeSetTest extends AbstractSortedSetTest {
 
     @Test
     public void shouldNotReturnSelfOnConvertToSortedSetWithDifferentComparator() {
-        final Value<Integer> value = of(1, 2, 3);
+        final TreeSet<Integer> value = of(1, 2, 3);
         assertThat(value.toSortedSet(Integer::compareTo)).isNotSameAs(value);
     }
 
     @Test
     public void shouldPreserveComparatorOnConvertToSortedSetWithoutDistinctComparator() {
-        final Value<Integer> value = TreeSet.of(Comparators.naturalComparator().reversed(), 1, 2, 3);
+        final TreeSet<Integer> value = TreeSet.of(Comparators.naturalComparator().reversed(), 1, 2, 3);
         assertThat(value.toSortedSet().mkString(",")).isEqualTo("3,2,1");
     }
 

--- a/src/test/java/io/vavr/collection/TreeTest.java
+++ b/src/test/java/io/vavr/collection/TreeTest.java
@@ -27,6 +27,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.InvalidObjectException;
+import java.lang.Iterable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.NoSuchElementException;

--- a/src/test/java/io/vavr/collection/VectorTest.java
+++ b/src/test/java/io/vavr/collection/VectorTest.java
@@ -19,7 +19,6 @@
 package io.vavr.collection;
 
 import io.vavr.Serializables;
-import io.vavr.Value;
 import io.vavr.Tuple2;
 import io.vavr.control.Option;
 import org.junit.Test;
@@ -340,7 +339,7 @@ public class VectorTest extends AbstractIndexedSeqTest {
 
     @Test
     public void shouldReturnSelfOnConvertToVector() {
-        final Value<Integer> value = of(1, 2, 3);
+        final Vector<Integer> value = of(1, 2, 3);
         assertThat(value.toVector()).isSameAs(value);
     }
 }

--- a/src/test/java/io/vavr/concurrent/FutureTest.java
+++ b/src/test/java/io/vavr/concurrent/FutureTest.java
@@ -34,6 +34,7 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import java.io.IOException;
+import java.lang.Iterable;
 import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;

--- a/src/test/java/io/vavr/control/ValidationTest.java
+++ b/src/test/java/io/vavr/control/ValidationTest.java
@@ -19,7 +19,6 @@
 package io.vavr.control;
 
 import io.vavr.AbstractValueTest;
-import io.vavr.Value;
 import io.vavr.collection.CharSeq;
 import io.vavr.collection.Seq;
 import io.vavr.collection.List;
@@ -48,7 +47,7 @@ public class ValidationTest extends AbstractValueTest {
 
     @SafeVarargs
     @Override
-    protected final <T> Value<T> of(T... elements) {
+    protected final <T> Validation<Object, T> of(T... elements) {
         return Validation.valid(elements[0]);
     }
 


### PR DESCRIPTION
Towards #2431

This is one of the bigger-ones. The type hierarchy evolves in a backward compatible way such that io.vavr.Iterable supersedes io.vavr.Value.

<img width="1532" alt="Screenshot 2019-07-17 at 02 43 55" src="https://user-images.githubusercontent.com/743833/61339161-c352d300-a83c-11e9-80d5-c9556973778d.png">
