### PR TITLE
Sealed ADTs

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -463,11 +463,10 @@ def generateMainClasses(): Unit = {
            * @param <L>   Type of left value.
            * @param <R>   Type of right value.
            * @param right The value.
-           * @return A new {@link $EitherType.Right} instance.
+           * @return A new {@link $EitherType} instance.
            */
-          @SuppressWarnings("unchecked")
-          public static <L, R> $EitherType.Right<L, R> Right(R right) {
-              return ($EitherType.Right<L, R>) $EitherType.right(right);
+          public static <L, R> $EitherType<L, R> Right(R right) {
+              return $EitherType.right(right);
           }
 
           /$javadoc
@@ -476,11 +475,10 @@ def generateMainClasses(): Unit = {
            * @param <L>  Type of left value.
            * @param <R>  Type of right value.
            * @param left The value.
-           * @return A new {@link $EitherType.Left} instance.
+           * @return A new {@link $EitherType} instance.
            */
-          @SuppressWarnings("unchecked")
-          public static <L, R> $EitherType.Left<L, R> Left(L left) {
-              return ($EitherType.Left<L, R>) $EitherType.left(left);
+          public static <L, R> $EitherType<L, R> Left(L left) {
+              return $EitherType.left(left);
           }
 
           // -- Future
@@ -565,22 +563,20 @@ def generateMainClasses(): Unit = {
            *
            * @param <T>   type of the value
            * @param value A value
-           * @return {@link $OptionType.Some}
+           * @return {@link $OptionType}
            */
-          @SuppressWarnings("unchecked")
-          public static <T> $OptionType.Some<T> Some(T value) {
-              return ($OptionType.Some<T>) $OptionType.some(value);
+          public static <T> $OptionType<T> Some(T value) {
+              return $OptionType.some(value);
           }
 
           /$javadoc
            * Alias for {@link $OptionType#none()}
            *
            * @param <T> component type
-           * @return the singleton instance of {@link $OptionType.None}
+           * @return the singleton instance of {@link $OptionType}
            */
-          @SuppressWarnings("unchecked")
-          public static <T> $OptionType.None<T> None() {
-              return ($OptionType.None<T>) $OptionType.none();
+          public static <T> $OptionType<T> None() {
+              return $OptionType.none();
           }
 
           // -- Try
@@ -602,11 +598,10 @@ def generateMainClasses(): Unit = {
            *
            * @param <T>   Type of the given {@code value}.
            * @param value A value.
-           * @return A new {@link $TryType.Success}.
+           * @return A new {@link $TryType}.
            */
-          @SuppressWarnings("unchecked")
-          public static <T> $TryType.Success<T> Success(T value) {
-              return ($TryType.Success<T>) $TryType.success(value);
+          public static <T> $TryType<T> Success(T value) {
+              return $TryType.success(value);
           }
 
           /$javadoc
@@ -614,11 +609,10 @@ def generateMainClasses(): Unit = {
            *
            * @param <T>       Component type of the {@code Try}.
            * @param exception An exception.
-           * @return A new {@link $TryType.Failure}.
+           * @return A new {@link $TryType}.
            */
-          @SuppressWarnings("unchecked")
-          public static <T> $TryType.Failure<T> Failure(Throwable exception) {
-              return ($TryType.Failure<T>) $TryType.failure(exception);
+          public static <T> $TryType<T> Failure(Throwable exception) {
+              return $TryType.failure(exception);
           }
 
           // -- Validation
@@ -629,12 +623,11 @@ def generateMainClasses(): Unit = {
            * @param <E>   type of the error
            * @param <T>   type of the given {@code value}
            * @param value A value
-           * @return {@link $ValidationType.Valid}
+           * @return {@link $ValidationType}
            * @throws NullPointerException if value is null
            */
-          @SuppressWarnings("unchecked")
-          public static <E, T> $ValidationType.Valid<E, T> Valid(T value) {
-              return ($ValidationType.Valid<E, T>) $ValidationType.valid(value);
+          public static <E, T> $ValidationType<E, T> Valid(T value) {
+              return $ValidationType.valid(value);
           }
 
           /$javadoc
@@ -643,12 +636,11 @@ def generateMainClasses(): Unit = {
            * @param <E>   type of the given {@code error}
            * @param <T>   type of the value
            * @param error An error
-           * @return {@link $ValidationType.Invalid}
+           * @return {@link $ValidationType}
            * @throws NullPointerException if error is null
            */
-          @SuppressWarnings("unchecked")
-          public static <E, T> $ValidationType.Invalid<E, T> Invalid(E error) {
-              return ($ValidationType.Invalid<E, T>) $ValidationType.invalid(error);
+          public static <E, T> $ValidationType<E, T> Invalid(E error) {
+              return $ValidationType.invalid(error);
           }
 
           // -- CharSeq

--- a/src-gen/main/java/io/vavr/API.java
+++ b/src-gen/main/java/io/vavr/API.java
@@ -791,11 +791,10 @@ public final class API {
      * @param <L>   Type of left value.
      * @param <R>   Type of right value.
      * @param right The value.
-     * @return A new {@link Either.Right} instance.
+     * @return A new {@link Either} instance.
      */
-    @SuppressWarnings("unchecked")
-    public static <L, R> Either.Right<L, R> Right(R right) {
-        return (Either.Right<L, R>) Either.right(right);
+    public static <L, R> Either<L, R> Right(R right) {
+        return Either.right(right);
     }
 
     /**
@@ -804,11 +803,10 @@ public final class API {
      * @param <L>  Type of left value.
      * @param <R>  Type of right value.
      * @param left The value.
-     * @return A new {@link Either.Left} instance.
+     * @return A new {@link Either} instance.
      */
-    @SuppressWarnings("unchecked")
-    public static <L, R> Either.Left<L, R> Left(L left) {
-        return (Either.Left<L, R>) Either.left(left);
+    public static <L, R> Either<L, R> Left(L left) {
+        return Either.left(left);
     }
 
     // -- Future
@@ -893,22 +891,20 @@ public final class API {
      *
      * @param <T>   type of the value
      * @param value A value
-     * @return {@link Option.Some}
+     * @return {@link Option}
      */
-    @SuppressWarnings("unchecked")
-    public static <T> Option.Some<T> Some(T value) {
-        return (Option.Some<T>) Option.some(value);
+    public static <T> Option<T> Some(T value) {
+        return Option.some(value);
     }
 
     /**
      * Alias for {@link Option#none()}
      *
      * @param <T> component type
-     * @return the singleton instance of {@link Option.None}
+     * @return the singleton instance of {@link Option}
      */
-    @SuppressWarnings("unchecked")
-    public static <T> Option.None<T> None() {
-        return (Option.None<T>) Option.none();
+    public static <T> Option<T> None() {
+        return Option.none();
     }
 
     // -- Try
@@ -930,11 +926,10 @@ public final class API {
      *
      * @param <T>   Type of the given {@code value}.
      * @param value A value.
-     * @return A new {@link Try.Success}.
+     * @return A new {@link Try}.
      */
-    @SuppressWarnings("unchecked")
-    public static <T> Try.Success<T> Success(T value) {
-        return (Try.Success<T>) Try.success(value);
+    public static <T> Try<T> Success(T value) {
+        return Try.success(value);
     }
 
     /**
@@ -942,11 +937,10 @@ public final class API {
      *
      * @param <T>       Component type of the {@code Try}.
      * @param exception An exception.
-     * @return A new {@link Try.Failure}.
+     * @return A new {@link Try}.
      */
-    @SuppressWarnings("unchecked")
-    public static <T> Try.Failure<T> Failure(Throwable exception) {
-        return (Try.Failure<T>) Try.failure(exception);
+    public static <T> Try<T> Failure(Throwable exception) {
+        return Try.failure(exception);
     }
 
     // -- Validation
@@ -957,12 +951,11 @@ public final class API {
      * @param <E>   type of the error
      * @param <T>   type of the given {@code value}
      * @param value A value
-     * @return {@link Validation.Valid}
+     * @return {@link Validation}
      * @throws NullPointerException if value is null
      */
-    @SuppressWarnings("unchecked")
-    public static <E, T> Validation.Valid<E, T> Valid(T value) {
-        return (Validation.Valid<E, T>) Validation.valid(value);
+    public static <E, T> Validation<E, T> Valid(T value) {
+        return Validation.valid(value);
     }
 
     /**
@@ -971,12 +964,11 @@ public final class API {
      * @param <E>   type of the given {@code error}
      * @param <T>   type of the value
      * @param error An error
-     * @return {@link Validation.Invalid}
+     * @return {@link Validation}
      * @throws NullPointerException if error is null
      */
-    @SuppressWarnings("unchecked")
-    public static <E, T> Validation.Invalid<E, T> Invalid(E error) {
-        return (Validation.Invalid<E, T>) Validation.invalid(error);
+    public static <E, T> Validation<E, T> Invalid(E error) {
+        return Validation.invalid(error);
     }
 
     // -- CharSeq

--- a/src/main/java/io/vavr/collection/List.java
+++ b/src/main/java/io/vavr/collection/List.java
@@ -19,9 +19,6 @@
 package io.vavr.collection;
 
 import io.vavr.*;
-import io.vavr.collection.List.Nil;
-import io.vavr.collection.ListModule.Combinations;
-import io.vavr.collection.ListModule.SplitAt;
 import io.vavr.control.Option;
 
 import java.io.*;
@@ -121,9 +118,13 @@ import static io.vavr.collection.JavaConverters.ChangePolicy.MUTABLE;
  *
  * @param <T> Component type of the List
  */
-public interface List<T> extends LinearSeq<T> {
+public abstract class List<T> implements LinearSeq<T> {
 
-    long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
+
+    // sealed
+    private List() {
+    }
 
     /**
      * Returns a {@link java.util.stream.Collector} which may be used in conjunction with
@@ -132,7 +133,7 @@ public interface List<T> extends LinearSeq<T> {
      * @param <T> Component type of the List.
      * @return A io.vavr.collection.List Collector.
      */
-    static <T> Collector<T, ArrayList<T>, List<T>> collector() {
+    public static <T> Collector<T, ArrayList<T>, List<T>> collector() {
         final Supplier<ArrayList<T>> supplier = ArrayList::new;
         final BiConsumer<ArrayList<T>, T> accumulator = ArrayList::add;
         final BinaryOperator<ArrayList<T>> combiner = (left, right) -> {
@@ -152,7 +153,7 @@ public interface List<T> extends LinearSeq<T> {
      * @param <T> Component type of Nil, determined by type inference in the particular context.
      * @return The empty list.
      */
-    static <T> List<T> empty() {
+    public static <T> List<T> empty() {
         return Nil.instance();
     }
 
@@ -162,12 +163,12 @@ public interface List<T> extends LinearSeq<T> {
      * @return false
      */
     @Override
-    default boolean isAsync() {
+    public final boolean isAsync() {
         return false;
     }
 
     @Override
-    boolean isEmpty();
+    public abstract boolean isEmpty();
 
     /**
      * A {@code List} is computed eagerly.
@@ -175,7 +176,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return false
      */
     @Override
-    default boolean isLazy() {
+    public final boolean isLazy() {
         return false;
     }
 
@@ -189,7 +190,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return the given {@code list} instance as narrowed type {@code List<T>}.
      */
     @SuppressWarnings("unchecked")
-    static <T> List<T> narrow(List<? extends T> list) {
+    public static <T> List<T> narrow(List<? extends T> list) {
         return (List<T>) list;
     }
 
@@ -200,7 +201,7 @@ public interface List<T> extends LinearSeq<T> {
      * @param <T>     The component type
      * @return A new List instance containing the given element
      */
-    static <T> List<T> of(T element) {
+    public static <T> List<T> of(T element) {
         return new Cons<>(element, Nil.instance());
     }
 
@@ -220,7 +221,7 @@ public interface List<T> extends LinearSeq<T> {
      * @throws NullPointerException if {@code elements} is null
      */
     @SafeVarargs
-    static <T> List<T> of(T... elements) {
+    public static <T> List<T> of(T... elements) {
         Objects.requireNonNull(elements, "elements is null");
         List<T> result = Nil.instance();
         for (int i = elements.length - 1; i >= 0; i--) {
@@ -241,7 +242,7 @@ public interface List<T> extends LinearSeq<T> {
      * @throws NullPointerException if {@code elements} is null
      */
     @SuppressWarnings("unchecked")
-    static <T> List<T> ofAll(Iterable<? extends T> elements) {
+    public static <T> List<T> ofAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         if (elements instanceof List) {
             return (List<T>) elements;
@@ -276,7 +277,7 @@ public interface List<T> extends LinearSeq<T> {
      * @param <T>        Component type of the Stream.
      * @return A List containing the given elements in the same order.
      */
-    static <T> List<T> ofAll(java.util.stream.Stream<? extends T> javaStream) {
+    public static <T> List<T> ofAll(java.util.stream.Stream<? extends T> javaStream) {
         Objects.requireNonNull(javaStream, "javaStream is null");
         final java.util.Iterator<? extends T> iterator = javaStream.iterator();
         List<T> list = List.empty();
@@ -293,7 +294,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return A new List of Boolean values
      * @throws NullPointerException if elements is null
      */
-    static List<Boolean> ofAll(boolean... elements) {
+    public static List<Boolean> ofAll(boolean... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return ofAll(Iterator.ofAll(elements));
     }
@@ -305,7 +306,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return A new List of Byte values
      * @throws NullPointerException if elements is null
      */
-    static List<Byte> ofAll(byte... elements) {
+    public static List<Byte> ofAll(byte... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return ofAll(Iterator.ofAll(elements));
     }
@@ -317,7 +318,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return A new List of Character values
      * @throws NullPointerException if elements is null
      */
-    static List<Character> ofAll(char... elements) {
+    public static List<Character> ofAll(char... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return ofAll(Iterator.ofAll(elements));
     }
@@ -329,7 +330,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return A new List of Double values
      * @throws NullPointerException if elements is null
      */
-    static List<Double> ofAll(double... elements) {
+    public static List<Double> ofAll(double... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return ofAll(Iterator.ofAll(elements));
     }
@@ -341,7 +342,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return A new List of Float values
      * @throws NullPointerException if elements is null
      */
-    static List<Float> ofAll(float... elements) {
+    public static List<Float> ofAll(float... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return ofAll(Iterator.ofAll(elements));
     }
@@ -353,7 +354,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return A new List of Integer values
      * @throws NullPointerException if elements is null
      */
-    static List<Integer> ofAll(int... elements) {
+    public static List<Integer> ofAll(int... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return ofAll(Iterator.ofAll(elements));
     }
@@ -365,7 +366,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return A new List of Long values
      * @throws NullPointerException if elements is null
      */
-    static List<Long> ofAll(long... elements) {
+    public static List<Long> ofAll(long... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return ofAll(Iterator.ofAll(elements));
     }
@@ -377,7 +378,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return A new List of Short values
      * @throws NullPointerException if elements is null
      */
-    static List<Short> ofAll(short... elements) {
+    public static List<Short> ofAll(short... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return ofAll(Iterator.ofAll(elements));
     }
@@ -392,7 +393,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return A List consisting of elements {@code f(0),f(1), ..., f(n - 1)}
      * @throws NullPointerException if {@code f} is null
      */
-    static <T> List<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
+    public static <T> List<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
         return Collections.tabulate(n, f, empty(), List::of);
     }
@@ -406,7 +407,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return A List of size {@code n}, where each element contains the result supplied by {@code s}.
      * @throws NullPointerException if {@code s} is null
      */
-    static <T> List<T> fill(int n, Supplier<? extends T> s) {
+    public static <T> List<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
         return Collections.fill(n, s, empty(), List::of);
     }
@@ -419,20 +420,20 @@ public interface List<T> extends LinearSeq<T> {
      * @param element The element
      * @return A List of size {@code n}, where each element is the given {@code element}.
      */
-    static <T> List<T> fill(int n, T element) {
+    public static <T> List<T> fill(int n, T element) {
         return Collections.fillObject(n, element, empty(), List::of);
     }
 
-    static List<Character> range(char from, char toExclusive) {
+    public static List<Character> range(char from, char toExclusive) {
         return ofAll(Iterator.range(from, toExclusive));
     }
 
-    static List<Character> rangeBy(char from, char toExclusive, int step) {
+    public static List<Character> rangeBy(char from, char toExclusive, int step) {
         return ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
     @GwtIncompatible
-    static List<Double> rangeBy(double from, double toExclusive, double step) {
+    public static List<Double> rangeBy(double from, double toExclusive, double step) {
         return ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
@@ -452,7 +453,7 @@ public interface List<T> extends LinearSeq<T> {
      * @param toExclusive the last number + 1
      * @return a range of int values as specified or the empty range if {@code from >= toExclusive}
      */
-    static List<Integer> range(int from, int toExclusive) {
+    public static List<Integer> range(int from, int toExclusive) {
         return ofAll(Iterator.range(from, toExclusive));
     }
 
@@ -478,7 +479,7 @@ public interface List<T> extends LinearSeq<T> {
      * {@code from <= toInclusive} and {@code step < 0}
      * @throws IllegalArgumentException if {@code step} is zero
      */
-    static List<Integer> rangeBy(int from, int toExclusive, int step) {
+    public static List<Integer> rangeBy(int from, int toExclusive, int step) {
         return ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
@@ -498,7 +499,7 @@ public interface List<T> extends LinearSeq<T> {
      * @param toExclusive the last number + 1
      * @return a range of long values as specified or the empty range if {@code from >= toExclusive}
      */
-    static List<Long> range(long from, long toExclusive) {
+    public static List<Long> range(long from, long toExclusive) {
         return ofAll(Iterator.range(from, toExclusive));
     }
 
@@ -524,20 +525,20 @@ public interface List<T> extends LinearSeq<T> {
      * {@code from <= toInclusive} and {@code step < 0}
      * @throws IllegalArgumentException if {@code step} is zero
      */
-    static List<Long> rangeBy(long from, long toExclusive, long step) {
+    public static List<Long> rangeBy(long from, long toExclusive, long step) {
         return ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
-    static List<Character> rangeClosed(char from, char toInclusive) {
+    public static List<Character> rangeClosed(char from, char toInclusive) {
         return ofAll(Iterator.rangeClosed(from, toInclusive));
     }
 
-    static List<Character> rangeClosedBy(char from, char toInclusive, int step) {
+    public static List<Character> rangeClosedBy(char from, char toInclusive, int step) {
         return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
     @GwtIncompatible
-    static List<Double> rangeClosedBy(double from, double toInclusive, double step) {
+    public static List<Double> rangeClosedBy(double from, double toInclusive, double step) {
         return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
@@ -557,7 +558,7 @@ public interface List<T> extends LinearSeq<T> {
      * @param toInclusive the last number
      * @return a range of int values as specified or the empty range if {@code from > toInclusive}
      */
-    static List<Integer> rangeClosed(int from, int toInclusive) {
+    public static List<Integer> rangeClosed(int from, int toInclusive) {
         return ofAll(Iterator.rangeClosed(from, toInclusive));
     }
 
@@ -583,7 +584,7 @@ public interface List<T> extends LinearSeq<T> {
      * {@code from < toInclusive} and {@code step < 0}
      * @throws IllegalArgumentException if {@code step} is zero
      */
-    static List<Integer> rangeClosedBy(int from, int toInclusive, int step) {
+    public static List<Integer> rangeClosedBy(int from, int toInclusive, int step) {
         return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
@@ -603,7 +604,7 @@ public interface List<T> extends LinearSeq<T> {
      * @param toInclusive the last number
      * @return a range of long values as specified or the empty range if {@code from > toInclusive}
      */
-    static List<Long> rangeClosed(long from, long toInclusive) {
+    public static List<Long> rangeClosed(long from, long toInclusive) {
         return ofAll(Iterator.rangeClosed(from, toInclusive));
     }
 
@@ -629,7 +630,7 @@ public interface List<T> extends LinearSeq<T> {
      * {@code from < toInclusive} and {@code step < 0}
      * @throws IllegalArgumentException if {@code step} is zero
      */
-    static List<Long> rangeClosedBy(long from, long toInclusive, long step) {
+    public static List<Long> rangeClosedBy(long from, long toInclusive, long step) {
         return ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
@@ -645,7 +646,7 @@ public interface List<T> extends LinearSeq<T> {
      * List.transpose(List(List(1,2,3), List(4,5,6))) → List(List(1,4), List(2,5), List(3,6))
      * }
      */
-    static <T> List<List<T>> transpose(List<List<T>> matrix) {
+    public static <T> List<List<T>> transpose(List<List<T>> matrix) {
         return Collections.transpose(matrix, List::ofAll, List::of);
     }
 
@@ -674,7 +675,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return a list with the values built up by the iteration
      * @throws NullPointerException if {@code f} is null
      */
-    static <T, U> List<U> unfoldRight(T seed, Function<? super T, Option<Tuple2<? extends U, ? extends T>>> f) {
+    public static <T, U> List<U> unfoldRight(T seed, Function<? super T, Option<Tuple2<? extends U, ? extends T>>> f) {
         return Iterator.unfoldRight(seed, f).toList();
     }
 
@@ -703,7 +704,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return a list with the values built up by the iteration
      * @throws NullPointerException if {@code f} is null
      */
-    static <T, U> List<U> unfoldLeft(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends U>>> f) {
+    public static <T, U> List<U> unfoldLeft(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends U>>> f) {
         return Iterator.unfoldLeft(seed, f).toList();
     }
 
@@ -731,86 +732,86 @@ public interface List<T> extends LinearSeq<T> {
      * @return a list with the values built up by the iteration
      * @throws NullPointerException if {@code f} is null
      */
-    static <T> List<T> unfold(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends T>>> f) {
+    public static <T> List<T> unfold(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends T>>> f) {
         return Iterator.unfold(seed, f).toList();
     }
 
     @Override
-    default List<T> append(T element) {
+    public final List<T> append(T element) {
         return foldRight(of(element), (x, xs) -> xs.prepend(x));
     }
 
     @Override
-    default List<T> appendAll(Iterable<? extends T> elements) {
+    public final List<T> appendAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         return List.<T> ofAll(elements).prependAll(this);
     }
 
     @GwtIncompatible
     @Override
-    default java.util.List<T> asJava() {
+    public final java.util.List<T> asJava() {
         return JavaConverters.asJava(this, IMMUTABLE);
     }
 
     @GwtIncompatible
     @Override
-    default List<T> asJava(Consumer<? super java.util.List<T>> action) {
+    public final List<T> asJava(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, IMMUTABLE);
     }
 
     @GwtIncompatible
     @Override
-    default java.util.List<T> asJavaMutable() {
+    public final java.util.List<T> asJavaMutable() {
         return JavaConverters.asJava(this, MUTABLE);
     }
 
     @GwtIncompatible
     @Override
-    default List<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
+    public final List<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, MUTABLE);
     }
 
     @Override
-    default <R> List<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
+    public final <R> List<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         return ofAll(iterator().<R> collect(partialFunction));
     }
 
     @Override
-    default List<List<T>> combinations() {
+    public final List<List<T>> combinations() {
         return rangeClosed(0, length()).map(this::combinations).flatMap(Function.identity());
     }
 
     @Override
-    default List<List<T>> combinations(int k) {
+    public final List<List<T>> combinations(int k) {
         return Combinations.apply(this, Math.max(k, 0));
     }
 
     @Override
-    default Iterator<List<T>> crossProduct(int power) {
+    public final Iterator<List<T>> crossProduct(int power) {
         return Collections.crossProduct(empty(), this, power);
     }
 
     @Override
-    default List<T> distinct() {
+    public final List<T> distinct() {
         return distinctBy(Function.identity());
     }
 
     @Override
-    default List<T> distinctBy(Comparator<? super T> comparator) {
+    public final List<T> distinctBy(Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
         final java.util.Set<T> seen = new java.util.TreeSet<>(comparator);
         return filter(seen::add);
     }
 
     @Override
-    default <U> List<T> distinctBy(Function<? super T, ? extends U> keyExtractor) {
+    public final <U> List<T> distinctBy(Function<? super T, ? extends U> keyExtractor) {
         Objects.requireNonNull(keyExtractor, "keyExtractor is null");
         final java.util.Set<U> seen = new java.util.HashSet<>();
         return filter(t -> seen.add(keyExtractor.apply(t)));
     }
 
     @Override
-    default List<T> drop(int n) {
+    public final List<T> drop(int n) {
         if (n <= 0) {
             return this;
         }
@@ -825,13 +826,13 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> dropUntil(Predicate<? super T> predicate) {
+    public final List<T> dropUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return dropWhile(predicate.negate());
     }
 
     @Override
-    default List<T> dropWhile(Predicate<? super T> predicate) {
+    public final List<T> dropWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         List<T> list = this;
         while (!list.isEmpty() && predicate.test(list.head())) {
@@ -841,7 +842,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> dropRight(int n) {
+    public final List<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         }
@@ -852,19 +853,19 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> dropRightUntil(Predicate<? super T> predicate) {
+    public final List<T> dropRightUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return reverse().dropUntil(predicate).reverse();
     }
 
     @Override
-    default List<T> dropRightWhile(Predicate<? super T> predicate) {
+    public final List<T> dropRightWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return dropRightUntil(predicate.negate());
     }
 
     @Override
-    default List<T> filter(Predicate<? super T> predicate) {
+    public final List<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (isEmpty()) {
             return this;
@@ -881,20 +882,20 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> filterNot(Predicate<? super T> predicate){
+    public final List<T> filterNot(Predicate<? super T> predicate){
         Objects.requireNonNull(predicate, "predicate is null");
         return Collections.filterNot(this, predicate);
     }
 
     @Deprecated
     @Override
-    default List<T> reject(Predicate<? super T> predicate){
+    public final List<T> reject(Predicate<? super T> predicate){
         Objects.requireNonNull(predicate, "predicate is null");
         return Collections.reject(this, predicate);
     }
 
     @Override
-    default <U> List<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    public final <U> List<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         List<U> list = empty();
         for (T t : this) {
@@ -906,7 +907,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default T get(int index) {
+    public final T get(int index) {
         if (isEmpty()) {
             throw new IndexOutOfBoundsException("get(" + index + ") on Nil");
         }
@@ -924,22 +925,22 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default <C> Map<C, List<T>> groupBy(Function<? super T, ? extends C> classifier) {
+    public final <C> Map<C, List<T>> groupBy(Function<? super T, ? extends C> classifier) {
         return Collections.groupBy(this, classifier, List::ofAll);
     }
 
     @Override
-    default Iterator<List<T>> grouped(int size) {
+    public final Iterator<List<T>> grouped(int size) {
         return sliding(size, size);
     }
 
     @Override
-    default boolean hasDefiniteSize() {
+    public final boolean hasDefiniteSize() {
         return true;
     }
 
     @Override
-    default int indexOf(T element, int from) {
+    public final int indexOf(T element, int from) {
         int index = 0;
         for (List<T> list = this; !list.isEmpty(); list = list.tail(), index++) {
             if (index >= from && Objects.equals(list.head(), element)) {
@@ -950,7 +951,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> init() {
+    public final List<T> init() {
         if (isEmpty()) {
             throw new UnsupportedOperationException("init of empty list");
         } else {
@@ -959,15 +960,15 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Option<List<T>> initOption() {
+    public final Option<List<T>> initOption() {
         return isEmpty() ? Option.none() : Option.some(init());
     }
 
     @Override
-    int length();
+    public abstract int length();
 
     @Override
-    default List<T> insert(int index, T element) {
+    public final List<T> insert(int index, T element) {
         if (index < 0) {
             throw new IndexOutOfBoundsException("insert(" + index + ", e)");
         }
@@ -987,7 +988,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> insertAll(int index, Iterable<? extends T> elements) {
+    public final List<T> insertAll(int index, Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         if (index < 0) {
             throw new IndexOutOfBoundsException("insertAll(" + index + ", elements)");
@@ -1008,22 +1009,22 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> intersperse(T element) {
+    public final List<T> intersperse(T element) {
         return ofAll(iterator().intersperse(element));
     }
 
     @Override
-    default boolean isTraversableAgain() {
+    public final boolean isTraversableAgain() {
         return true;
     }
 
     @Override
-    default T last() {
+    public final T last() {
         return Collections.last(this);
     }
 
     @Override
-    default int lastIndexOf(T element, int end) {
+    public final int lastIndexOf(T element, int end) {
         int result = -1, index = 0;
         for (List<T> list = this; index <= end && !list.isEmpty(); list = list.tail(), index++) {
             if (Objects.equals(list.head(), element)) {
@@ -1034,7 +1035,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default <U> List<U> map(Function<? super T, ? extends U> mapper) {
+    public final <U> List<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         List<U> list = empty();
         for (T t : this) {
@@ -1044,17 +1045,17 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> orElse(Iterable<? extends T> other) {
+    public final List<T> orElse(Iterable<? extends T> other) {
         return isEmpty() ? ofAll(other) : this;
     }
 
     @Override
-    default List<T> orElse(Supplier<? extends Iterable<? extends T>> supplier) {
+    public final List<T> orElse(Supplier<? extends Iterable<? extends T>> supplier) {
         return isEmpty() ? ofAll(supplier.get()) : this;
     }
 
     @Override
-    default List<T> padTo(int length, T element) {
+    public final List<T> padTo(int length, T element) {
         final int actualLength = length();
         if (length <= actualLength) {
             return this;
@@ -1064,7 +1065,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> leftPadTo(int length, T element) {
+    public final List<T> leftPadTo(int length, T element) {
         final int actualLength = length();
         if (length <= actualLength) {
             return this;
@@ -1074,7 +1075,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> patch(int from, Iterable<? extends T> that, int replaced) {
+    public final List<T> patch(int from, Iterable<? extends T> that, int replaced) {
         from = from < 0 ? 0 : from;
         replaced = replaced < 0 ? 0 : replaced;
         List<T> result = take(from).appendAll(that);
@@ -1084,7 +1085,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Tuple2<List<T>, List<T>> partition(Predicate<? super T> predicate) {
+    public final Tuple2<List<T>, List<T>> partition(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         List<T> left = empty(), right = empty();
         for (T t : this) {
@@ -1103,7 +1104,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return the first element
      * @throws java.util.NoSuchElementException if this List is empty
      */
-    default T peek() {
+    public final T peek() {
         if (isEmpty()) {
             throw new NoSuchElementException("peek of empty list");
         }
@@ -1115,7 +1116,7 @@ public interface List<T> extends LinearSeq<T> {
      *
      * @return {@code None} if this List is empty, otherwise a {@code Some} containing the head element
      */
-    default Option<T> peekOption() {
+    public final Option<T> peekOption() {
         return isEmpty() ? Option.none() : Option.some(head());
     }
 
@@ -1126,7 +1127,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return this {@code List}
      */
     @Override
-    default List<T> peek(Consumer<? super T> action) {
+    public final List<T> peek(Consumer<? super T> action) {
         Objects.requireNonNull(action, "action is null");
         if (!isEmpty()) {
             action.accept(head());
@@ -1135,7 +1136,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<List<T>> permutations() {
+    public final List<List<T>> permutations() {
         if (isEmpty()) {
             return Nil.instance();
         } else {
@@ -1158,7 +1159,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return the elements of this List without the head element
      * @throws java.util.NoSuchElementException if this List is empty
      */
-    default List<T> pop() {
+    public final List<T> pop() {
         if (isEmpty()) {
             throw new NoSuchElementException("pop of empty list");
         }
@@ -1170,7 +1171,7 @@ public interface List<T> extends LinearSeq<T> {
      *
      * @return {@code None} if this List is empty, otherwise a {@code Some} containing the elements of this List without the head element
      */
-    default Option<List<T>> popOption() {
+    public final Option<List<T>> popOption() {
         return isEmpty() ? Option.none() : Option.some(pop());
     }
 
@@ -1180,7 +1181,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return a tuple containing the head element and the remaining elements of this List
      * @throws java.util.NoSuchElementException if this List is empty
      */
-    default Tuple2<T, List<T>> pop2() {
+    public final Tuple2<T, List<T>> pop2() {
         if (isEmpty()) {
             throw new NoSuchElementException("pop2 of empty list");
         }
@@ -1192,17 +1193,17 @@ public interface List<T> extends LinearSeq<T> {
      *
      * @return {@code None} if this List is empty, otherwise {@code Some} {@code Tuple} containing the head element and the remaining elements of this List
      */
-    default Option<Tuple2<T, List<T>>> pop2Option() {
+    public final Option<Tuple2<T, List<T>>> pop2Option() {
         return isEmpty() ? Option.none() : Option.some(Tuple.of(head(), pop()));
     }
 
     @Override
-    default List<T> prepend(T element) {
+    public final List<T> prepend(T element) {
         return new Cons<>(element, this);
     }
 
     @Override
-    default List<T> prependAll(Iterable<? extends T> elements) {
+    public final List<T> prependAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         return isEmpty() ? ofAll(elements) : ofAll(elements).reverse().foldLeft(this, List::prepend);
     }
@@ -1213,7 +1214,7 @@ public interface List<T> extends LinearSeq<T> {
      * @param element The new element
      * @return a new {@code List} instance, containing the new element on top of this List
      */
-    default List<T> push(T element) {
+    public final List<T> push(T element) {
         return new Cons<>(element, this);
     }
 
@@ -1226,7 +1227,7 @@ public interface List<T> extends LinearSeq<T> {
      * @throws NullPointerException if elements is null
      */
     @SuppressWarnings("unchecked")
-    default List<T> push(T... elements) {
+    public final List<T> push(T... elements) {
         Objects.requireNonNull(elements, "elements is null");
         List<T> result = this;
         for (T element : elements) {
@@ -1243,7 +1244,7 @@ public interface List<T> extends LinearSeq<T> {
      * @return a new {@code List} instance, containing the new elements on top of this List
      * @throws NullPointerException if elements is null
      */
-    default List<T> pushAll(Iterable<T> elements) {
+    public final List<T> pushAll(Iterable<T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         List<T> result = this;
         for (T element : elements) {
@@ -1253,7 +1254,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> remove(T element) {
+    public final List<T> remove(T element) {
         final Deque<T> preceding = new ArrayDeque<>(size());
         List<T> result = this;
         boolean found = false;
@@ -1276,7 +1277,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> removeFirst(Predicate<T> predicate) {
+    public final List<T> removeFirst(Predicate<T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         List<T> init = empty();
         List<T> tail = this;
@@ -1292,14 +1293,14 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> removeLast(Predicate<T> predicate) {
+    public final List<T> removeLast(Predicate<T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         final List<T> removedAndReversed = reverse().removeFirst(predicate);
         return removedAndReversed.length() == length() ? this : removedAndReversed.reverse();
     }
 
     @Override
-    default List<T> removeAt(int index) {
+    public final List<T> removeAt(int index) {
         if (index < 0) {
             throw new IndexOutOfBoundsException("removeAt(" + index + ")");
         }
@@ -1320,24 +1321,24 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> removeAll(T element) {
+    public final List<T> removeAll(T element) {
         return Collections.removeAll(this, element);
     }
 
     @Override
-    default List<T> removeAll(Iterable<? extends T> elements) {
+    public final List<T> removeAll(Iterable<? extends T> elements) {
         return Collections.removeAll(this, elements);
     }
 
     @Override
     @Deprecated
-    default List<T> removeAll(Predicate<? super T> predicate) {
+    public final List<T> removeAll(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return reject(predicate);
     }
 
     @Override
-    default List<T> replace(T currentElement, T newElement) {
+    public final List<T> replace(T currentElement, T newElement) {
         List<T> preceding = Nil.instance();
         List<T> tail = this;
         while (!tail.isEmpty() && !Objects.equals(tail.head(), currentElement)) {
@@ -1356,7 +1357,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> replaceAll(T currentElement, T newElement) {
+    public final List<T> replaceAll(T currentElement, T newElement) {
         List<T> result = Nil.instance();
         boolean changed = false;
         for (List<T> list = this; !list.isEmpty(); list = list.tail()) {
@@ -1372,52 +1373,52 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> retainAll(Iterable<? extends T> elements) {
+    public final List<T> retainAll(Iterable<? extends T> elements) {
         return Collections.retainAll(this, elements);
     }
 
     @Override
-    default List<T> reverse() {
+    public final List<T> reverse() {
         return (length() <= 1) ? this : foldLeft(empty(), List::prepend);
     }
 
     @Override
-    default List<T> rotateLeft(int n) {
+    public final List<T> rotateLeft(int n) {
         return Collections.rotateLeft(this, n);
     }
 
     @Override
-    default List<T> rotateRight(int n) {
+    public final List<T> rotateRight(int n) {
         return Collections.rotateRight(this, n);
     }
 
     @Override
-    default List<T> scan(T zero, BiFunction<? super T, ? super T, ? extends T> operation) {
+    public final List<T> scan(T zero, BiFunction<? super T, ? super T, ? extends T> operation) {
         return scanLeft(zero, operation);
     }
 
     @Override
-    default <U> List<U> scanLeft(U zero, BiFunction<? super U, ? super T, ? extends U> operation) {
+    public final <U> List<U> scanLeft(U zero, BiFunction<? super U, ? super T, ? extends U> operation) {
         return Collections.scanLeft(this, zero, operation, Iterator::toList);
     }
 
     @Override
-    default <U> List<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation) {
+    public final <U> List<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation) {
         return Collections.scanRight(this, zero, operation, Iterator::toList);
     }
 
     @Override
-    default List<T> shuffle() {
+    public final List<T> shuffle() {
         return Collections.shuffle(this, List::ofAll);
     }
 
     @Override
-    default List<T> shuffle(Random random) {
+    public final List<T> shuffle(Random random) {
         return Collections.shuffle(this, random, List::ofAll);
     }
 
     @Override
-    default List<T> slice(int beginIndex, int endIndex) {
+    public final List<T> slice(int beginIndex, int endIndex) {
         if (beginIndex >= endIndex || beginIndex >= length() || isEmpty()) {
             return empty();
         } else {
@@ -1436,50 +1437,50 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Iterator<List<T>> slideBy(Function<? super T, ?> classifier) {
+    public final Iterator<List<T>> slideBy(Function<? super T, ?> classifier) {
         return iterator().slideBy(classifier).map(List::ofAll);
     }
 
     @Override
-    default Iterator<List<T>> sliding(int size) {
+    public final Iterator<List<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    default Iterator<List<T>> sliding(int size, int step) {
+    public final Iterator<List<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(List::ofAll);
     }
 
     @Override
-    default List<T> sorted() {
+    public final List<T> sorted() {
         return isEmpty() ? this : toJavaStream().sorted().collect(collector());
     }
 
     @Override
-    default List<T> sorted(Comparator<? super T> comparator) {
+    public final List<T> sorted(Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
         return isEmpty() ? this : toJavaStream().sorted(comparator).collect(collector());
     }
 
     @Override
-    default <U extends Comparable<? super U>> List<T> sortBy(Function<? super T, ? extends U> mapper) {
+    public final <U extends Comparable<? super U>> List<T> sortBy(Function<? super T, ? extends U> mapper) {
         return sortBy(U::compareTo, mapper);
     }
 
     @Override
-    default <U> List<T> sortBy(Comparator<? super U> comparator, Function<? super T, ? extends U> mapper) {
+    public final <U> List<T> sortBy(Comparator<? super U> comparator, Function<? super T, ? extends U> mapper) {
         return Collections.sortBy(this, comparator, mapper, collector());
     }
 
     @Override
-    default Tuple2<List<T>, List<T>> span(Predicate<? super T> predicate) {
+    public final Tuple2<List<T>, List<T>> span(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         final Tuple2<Iterator<T>, Iterator<T>> itt = iterator().span(predicate);
         return Tuple.of(ofAll(itt._1), ofAll(itt._2));
     }
 
     @Override
-    default Tuple2<List<T>, List<T>> splitAt(int n) {
+    public final Tuple2<List<T>, List<T>> splitAt(int n) {
         if (isEmpty()) {
             return Tuple.of(empty(), empty());
         } else {
@@ -1495,7 +1496,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Tuple2<List<T>, List<T>> splitAt(Predicate<? super T> predicate) {
+    public final Tuple2<List<T>, List<T>> splitAt(Predicate<? super T> predicate) {
         if (isEmpty()) {
             return Tuple.of(empty(), empty());
         } else {
@@ -1509,7 +1510,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Tuple2<List<T>, List<T>> splitAtInclusive(Predicate<? super T> predicate) {
+    public final Tuple2<List<T>, List<T>> splitAtInclusive(Predicate<? super T> predicate) {
         if (isEmpty()) {
             return Tuple.of(empty(), empty());
         } else {
@@ -1523,12 +1524,12 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default String stringPrefix() {
+    public final String stringPrefix() {
         return "List";
     }
 
     @Override
-    default List<T> subSequence(int beginIndex) {
+    public final List<T> subSequence(int beginIndex) {
         if (beginIndex < 0 || beginIndex > length()) {
             throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ")");
         } else {
@@ -1537,7 +1538,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> subSequence(int beginIndex, int endIndex) {
+    public final List<T> subSequence(int beginIndex, int endIndex) {
         Collections.subSequenceRangeCheck(beginIndex, endIndex, length());
         if (beginIndex == endIndex) {
             return empty();
@@ -1556,15 +1557,15 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    List<T> tail();
+    public abstract List<T> tail();
 
     @Override
-    default Option<List<T>> tailOption() {
+    public final Option<List<T>> tailOption() {
         return isEmpty() ? Option.none() : Option.some(tail());
     }
 
     @Override
-    default List<T> take(int n) {
+    public final List<T> take(int n) {
         if (n <= 0) {
             return empty();
         }
@@ -1580,13 +1581,13 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> takeUntil(Predicate<? super T> predicate) {
+    public final List<T> takeUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return takeWhile(predicate.negate());
     }
 
     @Override
-    default List<T> takeWhile(Predicate<? super T> predicate) {
+    public final List<T> takeWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         List<T> result = Nil.instance();
         for (List<T> list = this; !list.isEmpty() && predicate.test(list.head()); list = list.tail()) {
@@ -1596,7 +1597,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> takeRight(int n) {
+    public final List<T> takeRight(int n) {
         if (n <= 0) {
             return empty();
         }
@@ -1607,13 +1608,13 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> takeRightUntil(Predicate<? super T> predicate) {
+    public final List<T> takeRightUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return takeRightWhile(predicate.negate());
     }
 
     @Override
-    default List<T> takeRightWhile(Predicate<? super T> predicate) {
+    public final List<T> takeRightWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return reverse().takeWhile(predicate).reverse();
     }
@@ -1626,13 +1627,13 @@ public interface List<T> extends LinearSeq<T> {
      * @return An instance of type {@code U}
      * @throws NullPointerException if {@code f} is null
      */
-    default <U> U transform(Function<? super List<T>, ? extends U> f) {
+    public final <U> U transform(Function<? super List<T>, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         return f.apply(this);
     }
 
     @Override
-    default <T1, T2> Tuple2<List<T1>, List<T2>> unzip(
+    public final <T1, T2> Tuple2<List<T1>, List<T2>> unzip(
             Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         List<T1> xs = Nil.instance();
@@ -1646,7 +1647,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default <T1, T2, T3> Tuple3<List<T1>, List<T2>, List<T3>> unzip3(
+    public final <T1, T2, T3> Tuple3<List<T1>, List<T2>, List<T3>> unzip3(
             Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         List<T1> xs = Nil.instance();
@@ -1662,7 +1663,7 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> update(int index, T element) {
+    public final List<T> update(int index, T element) {
         if (isEmpty()) {
             throw new IndexOutOfBoundsException("update(" + index + ", e) on Nil");
         }
@@ -1689,36 +1690,36 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
-    default List<T> update(int index, Function<? super T, ? extends T> updater) {
+    public final List<T> update(int index, Function<? super T, ? extends T> updater) {
         Objects.requireNonNull(updater, "updater is null");
         return update(index, updater.apply(get(index)));
     }
 
     @Override
-    default <U> List<Tuple2<T, U>> zip(Iterable<? extends U> that) {
+    public final <U> List<Tuple2<T, U>> zip(Iterable<? extends U> that) {
         return zipWith(that, Tuple::of);
     }
 
     @Override
-    default <U, R> List<R> zipWith(Iterable<? extends U> that, BiFunction<? super T, ? super U, ? extends R> mapper) {
+    public final <U, R> List<R> zipWith(Iterable<? extends U> that, BiFunction<? super T, ? super U, ? extends R> mapper) {
         Objects.requireNonNull(that, "that is null");
         Objects.requireNonNull(mapper, "mapper is null");
         return ofAll(iterator().zipWith(that, mapper));
     }
 
     @Override
-    default <U> List<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem) {
+    public final <U> List<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem) {
         Objects.requireNonNull(that, "that is null");
         return ofAll(iterator().zipAll(that, thisElem, thatElem));
     }
 
     @Override
-    default List<Tuple2<T, Integer>> zipWithIndex() {
+    public final List<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    default <U> List<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
+    public final <U> List<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return ofAll(iterator().zipWithIndex(mapper));
     }
@@ -1727,8 +1728,10 @@ public interface List<T> extends LinearSeq<T> {
      * Representation of the singleton empty {@code List}.
      *
      * @param <T> Component type of the List.
+     * @deprecated will be removed from the public API
      */
-    final class Nil<T> implements List<T>, Serializable {
+    @Deprecated
+    public static final class Nil<T> extends List<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -1799,9 +1802,11 @@ public interface List<T> extends LinearSeq<T> {
      * Non-empty {@code List}, consisting of a {@code head} and a {@code tail}.
      *
      * @param <T> Component type of the List.
+     * @deprecated will be removed from the public API
      */
+    @Deprecated
     // DEV NOTE: class declared final because of serialization proxy pattern (see Effective Java, 2nd ed., p. 315)
-    final class Cons<T> implements List<T>, Serializable {
+    public static final class Cons<T> extends List<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -1961,11 +1966,8 @@ public interface List<T> extends LinearSeq<T> {
             }
         }
     }
-}
 
-interface ListModule {
-
-    interface Combinations {
+    private interface Combinations {
 
         static <T> List<List<T>> apply(List<T> elements, int k) {
             if (k == 0) {
@@ -1978,7 +1980,7 @@ interface ListModule {
         }
     }
 
-    interface SplitAt {
+    private interface SplitAt {
 
         static <T> Tuple2<List<T>, List<T>> splitByPredicateReversed(List<T> source, Predicate<? super T> predicate) {
             Objects.requireNonNull(predicate, "predicate is null");

--- a/src/main/java/io/vavr/collection/Stream.java
+++ b/src/main/java/io/vavr/collection/Stream.java
@@ -19,9 +19,6 @@
 package io.vavr.collection;
 
 import io.vavr.*;
-import io.vavr.collection.Stream.Cons;
-import io.vavr.collection.Stream.Empty;
-import io.vavr.collection.StreamModule.*;
 import io.vavr.control.Option;
 
 import java.io.*;
@@ -111,9 +108,13 @@ import static io.vavr.collection.JavaConverters.ChangePolicy.MUTABLE;
  *
  * @param <T> component type of this Stream
  */
-public interface Stream<T> extends LinearSeq<T> {
+public abstract class Stream<T> implements LinearSeq<T> {
 
-    long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
+
+    // sealed
+    private Stream() {
+    }
 
     /**
      * Returns a {@link java.util.stream.Collector} which may be used in conjunction with
@@ -122,7 +123,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param <T> Component type of the Stream.
      * @return A io.vavr.collection.Stream Collector.
      */
-    static <T> Collector<T, ArrayList<T>, Stream<T>> collector() {
+    public static <T> Collector<T, ArrayList<T>, Stream<T>> collector() {
         final Supplier<ArrayList<T>> supplier = ArrayList::new;
         final BiConsumer<ArrayList<T>, T> accumulator = ArrayList::add;
         final BinaryOperator<ArrayList<T>> combiner = (left, right) -> {
@@ -142,7 +143,7 @@ public interface Stream<T> extends LinearSeq<T> {
      */
     @SuppressWarnings("varargs")
     @SafeVarargs
-    static <T> Stream<T> concat(Iterable<? extends T>... iterables) {
+    public static <T> Stream<T> concat(Iterable<? extends T>... iterables) {
         return Iterator.concat(iterables).toStream();
     }
 
@@ -153,7 +154,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param <T>       Component type.
      * @return A new {@code Stream}
      */
-    static <T> Stream<T> concat(Iterable<? extends Iterable<? extends T>> iterables) {
+    public static <T> Stream<T> concat(Iterable<? extends Iterable<? extends T>> iterables) {
         return Iterator.<T> concat(iterables).toStream();
     }
 
@@ -165,7 +166,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param value a start int value
      * @return a new Stream of int values starting from {@code from}
      */
-    static Stream<Integer> from(int value) {
+    public static Stream<Integer> from(int value) {
         return Stream.ofAll(Iterator.from(value));
     }
 
@@ -178,7 +179,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param step  the step by which to advance on each next value
      * @return a new {@code Stream} of int values starting from {@code from}
      */
-    static Stream<Integer> from(int value, int step) {
+    public static Stream<Integer> from(int value, int step) {
         return Stream.ofAll(Iterator.from(value, step));
     }
 
@@ -190,7 +191,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param value a start long value
      * @return a new Stream of long values starting from {@code from}
      */
-    static Stream<Long> from(long value) {
+    public static Stream<Long> from(long value) {
         return Stream.ofAll(Iterator.from(value));
     }
 
@@ -203,7 +204,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param step  the step by which to advance on each next value
      * @return a new {@code Stream} of long values starting from {@code from}
      */
-    static Stream<Long> from(long value, long step) {
+    public static Stream<Long> from(long value, long step) {
         return Stream.ofAll(Iterator.from(value, step));
     }
 
@@ -214,7 +215,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param <T>      value type
      * @return A new Stream
      */
-    static <T> Stream<T> continually(Supplier<? extends T> supplier) {
+    public static <T> Stream<T> continually(Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return Stream.ofAll(Iterator.continually(supplier));
     }
@@ -228,7 +229,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param <T>  value type
      * @return A new Stream
      */
-    static <T> Stream<T> iterate(T seed, Function<? super T, ? extends T> f) {
+    public static <T> Stream<T> iterate(T seed, Function<? super T, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
         return Stream.ofAll(Iterator.iterate(seed, f));
     }
@@ -244,7 +245,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param <T> value type
      * @return A new Stream
      */
-    static <T> Stream<T> iterate(Supplier<? extends Option<? extends T>> supplier) {
+    public static <T> Stream<T> iterate(Supplier<? extends Option<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return Stream.ofAll(Iterator.iterate(supplier));
     }
@@ -258,7 +259,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A new Stream
      */
     @SuppressWarnings("unchecked")
-    static <T> Stream<T> cons(T head, Supplier<? extends Stream<? extends T>> tailSupplier) {
+    public static <T> Stream<T> cons(T head, Supplier<? extends Stream<? extends T>> tailSupplier) {
         Objects.requireNonNull(tailSupplier, "tailSupplier is null");
         return new ConsImpl<>(head, (Supplier<Stream<T>>) tailSupplier);
     }
@@ -272,7 +273,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param <T> Component type of Nil, determined by type inference in the particular context.
      * @return The empty list.
      */
-    static <T> Stream<T> empty() {
+    public static <T> Stream<T> empty() {
         return Empty.instance();
     }
 
@@ -286,7 +287,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return the given {@code stream} instance as narrowed type {@code Stream<T>}.
      */
     @SuppressWarnings("unchecked")
-    static <T> Stream<T> narrow(Stream<? extends T> stream) {
+    public static <T> Stream<T> narrow(Stream<? extends T> stream) {
         return (Stream<T>) stream;
     }
 
@@ -297,7 +298,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param <T>     The component type
      * @return A new Stream instance containing the given element
      */
-    static <T> Stream<T> of(T element) {
+    public static <T> Stream<T> of(T element) {
         return cons(element, Empty::instance);
     }
 
@@ -313,7 +314,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A list containing the given elements in the same order.
      */
     @SafeVarargs
-    static <T> Stream<T> of(T... elements) {
+    public static <T> Stream<T> of(T... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return Stream.ofAll(new Iterator<T>() {
             int i = 0;
@@ -340,7 +341,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A Stream consisting of elements {@code f(0),f(1), ..., f(n - 1)}
      * @throws NullPointerException if {@code f} is null
      */
-    static <T> Stream<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
+    public static <T> Stream<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
         return Stream.ofAll(io.vavr.collection.Collections.tabulate(n, f));
     }
@@ -354,7 +355,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A Stream of size {@code n}, where each element contains the result supplied by {@code s}.
      * @throws NullPointerException if {@code s} is null
      */
-    static <T> Stream<T> fill(int n, Supplier<? extends T> s) {
+    public static <T> Stream<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
         return Stream.ofAll(io.vavr.collection.Collections.fill(n, s));
     }
@@ -367,7 +368,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param element The element
      * @return A Stream of size {@code n}, where each element is the given {@code element}.
      */
-    static <T> Stream<T> fill(int n, T element) {
+    public static <T> Stream<T> fill(int n, T element) {
         return Stream.ofAll(io.vavr.collection.Collections.fillObject(n, element));
     }
 
@@ -379,7 +380,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A Stream containing the given elements in the same order.
      */
     @SuppressWarnings("unchecked")
-    static <T> Stream<T> ofAll(Iterable<? extends T> elements) {
+    public static <T> Stream<T> ofAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         if (elements instanceof Stream) {
             return (Stream<T>) elements;
@@ -395,7 +396,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param <T>        Component type of the Stream.
      * @return A Stream containing the given elements in the same order.
      */
-    static <T> Stream<T> ofAll(java.util.stream.Stream<? extends T> javaStream) {
+    public static <T> Stream<T> ofAll(java.util.stream.Stream<? extends T> javaStream) {
         Objects.requireNonNull(javaStream, "javaStream is null");
         return StreamFactory.create(javaStream.iterator());
     }
@@ -407,7 +408,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A new Stream of Boolean values
      * @throws NullPointerException if elements is null
      */
-    static Stream<Boolean> ofAll(boolean... elements) {
+    public static Stream<Boolean> ofAll(boolean... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return Stream.ofAll(Iterator.ofAll(elements));
     }
@@ -419,7 +420,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A new Stream of Byte values
      * @throws NullPointerException if elements is null
      */
-    static Stream<Byte> ofAll(byte... elements) {
+    public static Stream<Byte> ofAll(byte... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return Stream.ofAll(Iterator.ofAll(elements));
     }
@@ -431,7 +432,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A new Stream of Character values
      * @throws NullPointerException if elements is null
      */
-    static Stream<Character> ofAll(char... elements) {
+    public static Stream<Character> ofAll(char... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return Stream.ofAll(Iterator.ofAll(elements));
     }
@@ -443,7 +444,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A new Stream of Double values
      * @throws NullPointerException if elements is null
      */
-    static Stream<Double> ofAll(double... elements) {
+    public static Stream<Double> ofAll(double... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return Stream.ofAll(Iterator.ofAll(elements));
     }
@@ -455,7 +456,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A new Stream of Float values
      * @throws NullPointerException if elements is null
      */
-    static Stream<Float> ofAll(float... elements) {
+    public static Stream<Float> ofAll(float... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return Stream.ofAll(Iterator.ofAll(elements));
     }
@@ -467,7 +468,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A new Stream of Integer values
      * @throws NullPointerException if elements is null
      */
-    static Stream<Integer> ofAll(int... elements) {
+    public static Stream<Integer> ofAll(int... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return Stream.ofAll(Iterator.ofAll(elements));
     }
@@ -479,7 +480,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A new Stream of Long values
      * @throws NullPointerException if elements is null
      */
-    static Stream<Long> ofAll(long... elements) {
+    public static Stream<Long> ofAll(long... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return Stream.ofAll(Iterator.ofAll(elements));
     }
@@ -491,21 +492,21 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return A new Stream of Short values
      * @throws NullPointerException if elements is null
      */
-    static Stream<Short> ofAll(short... elements) {
+    public static Stream<Short> ofAll(short... elements) {
         Objects.requireNonNull(elements, "elements is null");
         return Stream.ofAll(Iterator.ofAll(elements));
     }
 
-    static Stream<Character> range(char from, char toExclusive) {
+    public static Stream<Character> range(char from, char toExclusive) {
         return Stream.ofAll(Iterator.range(from, toExclusive));
     }
 
-    static Stream<Character> rangeBy(char from, char toExclusive, int step) {
+    public static Stream<Character> rangeBy(char from, char toExclusive, int step) {
         return Stream.ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
     @GwtIncompatible
-    static Stream<Double> rangeBy(double from, double toExclusive, double step) {
+    public static Stream<Double> rangeBy(double from, double toExclusive, double step) {
         return Stream.ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
@@ -525,7 +526,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param toExclusive the last number + 1
      * @return a range of int values as specified or {@code Nil} if {@code from >= toExclusive}
      */
-    static Stream<Integer> range(int from, int toExclusive) {
+    public static Stream<Integer> range(int from, int toExclusive) {
         return Stream.ofAll(Iterator.range(from, toExclusive));
     }
 
@@ -551,7 +552,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * {@code from <= toInclusive} and {@code step < 0}
      * @throws IllegalArgumentException if {@code step} is zero
      */
-    static Stream<Integer> rangeBy(int from, int toExclusive, int step) {
+    public static Stream<Integer> rangeBy(int from, int toExclusive, int step) {
         return Stream.ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
@@ -571,7 +572,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param toExclusive the last number + 1
      * @return a range of long values as specified or {@code Nil} if {@code from >= toExclusive}
      */
-    static Stream<Long> range(long from, long toExclusive) {
+    public static Stream<Long> range(long from, long toExclusive) {
         return Stream.ofAll(Iterator.range(from, toExclusive));
     }
 
@@ -597,20 +598,20 @@ public interface Stream<T> extends LinearSeq<T> {
      * {@code from <= toInclusive} and {@code step < 0}
      * @throws IllegalArgumentException if {@code step} is zero
      */
-    static Stream<Long> rangeBy(long from, long toExclusive, long step) {
+    public static Stream<Long> rangeBy(long from, long toExclusive, long step) {
         return Stream.ofAll(Iterator.rangeBy(from, toExclusive, step));
     }
 
-    static Stream<Character> rangeClosed(char from, char toInclusive) {
+    public static Stream<Character> rangeClosed(char from, char toInclusive) {
         return Stream.ofAll(Iterator.rangeClosed(from, toInclusive));
     }
 
-    static Stream<Character> rangeClosedBy(char from, char toInclusive, int step) {
+    public static Stream<Character> rangeClosedBy(char from, char toInclusive, int step) {
         return Stream.ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
     @GwtIncompatible
-    static Stream<Double> rangeClosedBy(double from, double toInclusive, double step) {
+    public static Stream<Double> rangeClosedBy(double from, double toInclusive, double step) {
         return Stream.ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
@@ -630,7 +631,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param toInclusive the last number
      * @return a range of int values as specified or {@code Nil} if {@code from > toInclusive}
      */
-    static Stream<Integer> rangeClosed(int from, int toInclusive) {
+    public static Stream<Integer> rangeClosed(int from, int toInclusive) {
         return Stream.ofAll(Iterator.rangeClosed(from, toInclusive));
     }
 
@@ -656,7 +657,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * {@code from < toInclusive} and {@code step < 0}
      * @throws IllegalArgumentException if {@code step} is zero
      */
-    static Stream<Integer> rangeClosedBy(int from, int toInclusive, int step) {
+    public static Stream<Integer> rangeClosedBy(int from, int toInclusive, int step) {
         return Stream.ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
@@ -676,7 +677,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param toInclusive the last number
      * @return a range of long values as specified or {@code Nil} if {@code from > toInclusive}
      */
-    static Stream<Long> rangeClosed(long from, long toInclusive) {
+    public static Stream<Long> rangeClosed(long from, long toInclusive) {
         return Stream.ofAll(Iterator.rangeClosed(from, toInclusive));
     }
 
@@ -702,7 +703,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * {@code from < toInclusive} and {@code step < 0}
      * @throws IllegalArgumentException if {@code step} is zero
      */
-    static Stream<Long> rangeClosedBy(long from, long toInclusive, long step) {
+    public static Stream<Long> rangeClosedBy(long from, long toInclusive, long step) {
         return Stream.ofAll(Iterator.rangeClosedBy(from, toInclusive, step));
     }
 
@@ -718,7 +719,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * Stream.transpose(Stream(Stream(1,2,3), Stream(4,5,6))) → Stream(Stream(1,4), Stream(2,5), Stream(3,6))
      * }
      */
-    static <T> Stream<Stream<T>> transpose(Stream<Stream<T>> matrix) {
+    public static <T> Stream<Stream<T>> transpose(Stream<Stream<T>> matrix) {
         return io.vavr.collection.Collections.transpose(matrix, Stream::ofAll, Stream::of);
     }
 
@@ -747,7 +748,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return a Stream with the values built up by the iteration
      * @throws NullPointerException if {@code f} is null
      */
-    static <T, U> Stream<U> unfoldRight(T seed, Function<? super T, Option<Tuple2<? extends U, ? extends T>>> f) {
+    public static <T, U> Stream<U> unfoldRight(T seed, Function<? super T, Option<Tuple2<? extends U, ? extends T>>> f) {
         return Iterator.unfoldRight(seed, f).toStream();
     }
 
@@ -776,7 +777,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return a Stream with the values built up by the iteration
      * @throws NullPointerException if {@code f} is null
      */
-    static <T, U> Stream<U> unfoldLeft(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends U>>> f) {
+    public static <T, U> Stream<U> unfoldLeft(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends U>>> f) {
         return Iterator.unfoldLeft(seed, f).toStream();
     }
 
@@ -804,7 +805,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return a Stream with the values built up by the iteration
      * @throws NullPointerException if {@code f} is null
      */
-    static <T> Stream<T> unfold(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends T>>> f) {
+    public static <T> Stream<T> unfold(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends T>>> f) {
         return Iterator.unfold(seed, f).toStream();
     }
 
@@ -815,26 +816,15 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param <T> Element type
      * @return A new Stream containing infinite {@code t}'s.
      */
-    static <T> Stream<T> continually(T t) {
+    public static <T> Stream<T> continually(T t) {
         return Stream.ofAll(Iterator.continually(t));
     }
 
     @Override
-    default Stream<T> append(T element) {
-        return isEmpty() ? Stream.of(element) : new AppendElements<>(head(), io.vavr.collection.Queue.of(element), this::tail);
-    }
+    public abstract Stream<T> append(T element);
 
     @Override
-    default Stream<T> appendAll(Iterable<? extends T> elements) {
-        Objects.requireNonNull(elements, "elements is null");
-        if (Collections.isEmpty(elements)) {
-            return this;
-        } else if (isEmpty()) {
-            return Stream.ofAll(elements);
-        } else {
-            return Stream.ofAll(Iterator.concat(this, elements));
-        }
-    }
+    public abstract Stream<T> appendAll(Iterable<? extends T> elements);
 
     /**
      * Appends itself to the end of stream with {@code mapper} function.
@@ -857,52 +847,52 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param mapper an mapper
      * @return a new Stream
      */
-    default Stream<T> appendSelf(Function<? super Stream<T>, ? extends Stream<T>> mapper) {
+    public final Stream<T> appendSelf(Function<? super Stream<T>, ? extends Stream<T>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? this : new AppendSelf<>((Cons<T>) this, mapper).stream();
     }
 
     @GwtIncompatible
     @Override
-    default java.util.List<T> asJava() {
+    public final java.util.List<T> asJava() {
         return JavaConverters.asJava(this, IMMUTABLE);
     }
 
     @GwtIncompatible
     @Override
-    default Stream<T> asJava(Consumer<? super java.util.List<T>> action) {
+    public final Stream<T> asJava(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, IMMUTABLE);
     }
 
     @GwtIncompatible
     @Override
-    default java.util.List<T> asJavaMutable() {
+    public final java.util.List<T> asJavaMutable() {
         return JavaConverters.asJava(this, MUTABLE);
     }
 
     @GwtIncompatible
     @Override
-    default Stream<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
+    public final Stream<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, MUTABLE);
     }
 
     @Override
-    default <R> Stream<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
+    public final <R> Stream<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         return ofAll(iterator().<R> collect(partialFunction));
     }
     
     @Override
-    default Stream<Stream<T>> combinations() {
+    public final Stream<Stream<T>> combinations() {
         return Stream.rangeClosed(0, length()).map(this::combinations).flatMap(Function.identity());
     }
 
     @Override
-    default Stream<Stream<T>> combinations(int k) {
+    public final Stream<Stream<T>> combinations(int k) {
         return Combinations.apply(this, Math.max(k, 0));
     }
 
     @Override
-    default Iterator<Stream<T>> crossProduct(int power) {
+    public final Iterator<Stream<T>> crossProduct(int power) {
         return io.vavr.collection.Collections.crossProduct(Stream.empty(), this, power);
     }
 
@@ -919,7 +909,7 @@ public interface Stream<T> extends LinearSeq<T> {
      *
      * @return A new Stream containing this elements cycled.
      */
-    default Stream<T> cycle() {
+    public final Stream<T> cycle() {
         return isEmpty() ? this : appendSelf(Function.identity());
     }
 
@@ -943,7 +933,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param count the number of cycles to be performed
      * @return A new Stream containing this elements cycled {@code count} times.
      */
-    default Stream<T> cycle(int count) {
+    public final Stream<T> cycle(int count) {
         if (count <= 0 || isEmpty()) {
             return empty();
         } else {
@@ -972,25 +962,25 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> distinct() {
+    public final Stream<T> distinct() {
         return distinctBy(Function.identity());
     }
 
     @Override
-    default Stream<T> distinctBy(Comparator<? super T> comparator) {
+    public final Stream<T> distinctBy(Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
         final java.util.Set<T> seen = new java.util.TreeSet<>(comparator);
         return filter(seen::add);
     }
 
     @Override
-    default <U> Stream<T> distinctBy(Function<? super T, ? extends U> keyExtractor) {
+    public final <U> Stream<T> distinctBy(Function<? super T, ? extends U> keyExtractor) {
         final java.util.Set<U> seen = new java.util.HashSet<>();
         return filter(t -> seen.add(keyExtractor.apply(t)));
     }
 
     @Override
-    default Stream<T> drop(int n) {
+    public final Stream<T> drop(int n) {
         Stream<T> stream = this;
         while (n-- > 0 && !stream.isEmpty()) {
             stream = stream.tail();
@@ -999,13 +989,13 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> dropUntil(Predicate<? super T> predicate) {
+    public final Stream<T> dropUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return dropWhile(predicate.negate());
     }
 
     @Override
-    default Stream<T> dropWhile(Predicate<? super T> predicate) {
+    public final Stream<T> dropWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         Stream<T> stream = this;
         while (!stream.isEmpty() && predicate.test(stream.head())) {
@@ -1015,7 +1005,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> dropRight(int n) {
+    public final Stream<T> dropRight(int n) {
         if (n <= 0) {
             return this;
         } else {
@@ -1024,19 +1014,19 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> dropRightUntil(Predicate<? super T> predicate) {
+    public final Stream<T> dropRightUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return reverse().dropUntil(predicate).reverse();
     }
 
     @Override
-    default Stream<T> dropRightWhile(Predicate<? super T> predicate) {
+    public final Stream<T> dropRightWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return dropRightUntil(predicate.negate());
     }
 
     @Override
-    default Stream<T> filter(Predicate<? super T> predicate) {
+    public final Stream<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (isEmpty()) {
             return this;
@@ -1052,26 +1042,26 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> filterNot(Predicate<? super T> predicate) {
+    public final Stream<T> filterNot(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return Collections.filterNot(this, predicate);
     }
 
     @Deprecated
     @Override
-    default Stream<T> reject(Predicate<? super T> predicate) {
+    public final Stream<T> reject(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return Collections.reject(this, predicate);
     }
 
     @Override
-    default <U> Stream<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    public final <U> Stream<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? Empty.instance() : Stream.ofAll(new FlatMapIterator<>(this.iterator(), mapper));
     }
 
     @Override
-    default T get(int index) {
+    public final T get(int index) {
         if (isEmpty()) {
             throw new IndexOutOfBoundsException("get(" + index + ") on Nil");
         }
@@ -1089,22 +1079,22 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default <C> Map<C, Stream<T>> groupBy(Function<? super T, ? extends C> classifier) {
+    public final <C> Map<C, Stream<T>> groupBy(Function<? super T, ? extends C> classifier) {
         return io.vavr.collection.Collections.groupBy(this, classifier, Stream::ofAll);
     }
 
     @Override
-    default Iterator<Stream<T>> grouped(int size) {
+    public final Iterator<Stream<T>> grouped(int size) {
         return sliding(size, size);
     }
 
     @Override
-    default boolean hasDefiniteSize() {
+    public final boolean hasDefiniteSize() {
         return false;
     }
 
     @Override
-    default int indexOf(T element, int from) {
+    public final int indexOf(T element, int from) {
         int index = 0;
         for (Stream<T> stream = this; !stream.isEmpty(); stream = stream.tail(), index++) {
             if (index >= from && Objects.equals(stream.head(), element)) {
@@ -1115,7 +1105,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> init() {
+    public final Stream<T> init() {
         if (isEmpty()) {
             throw new UnsupportedOperationException("init of empty stream");
         } else {
@@ -1129,12 +1119,12 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Option<Stream<T>> initOption() {
+    public final Option<Stream<T>> initOption() {
         return isEmpty() ? Option.none() : Option.some(init());
     }
 
     @Override
-    default Stream<T> insert(int index, T element) {
+    public final Stream<T> insert(int index, T element) {
         if (index < 0) {
             throw new IndexOutOfBoundsException("insert(" + index + ", e)");
         } else if (index == 0) {
@@ -1147,7 +1137,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> insertAll(int index, Iterable<? extends T> elements) {
+    public final Stream<T> insertAll(int index, Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         if (index < 0) {
             throw new IndexOutOfBoundsException("insertAll(" + index + ", elements)");
@@ -1161,7 +1151,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> intersperse(T element) {
+    public final Stream<T> intersperse(T element) {
         if (isEmpty()) {
             return this;
         } else {
@@ -1178,7 +1168,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return false
      */
     @Override
-    default boolean isAsync() {
+    public final boolean isAsync() {
         return false;
     }
 
@@ -1188,22 +1178,22 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return true
      */
     @Override
-    default boolean isLazy() {
+    public final boolean isLazy() {
         return true;
     }
 
     @Override
-    default boolean isTraversableAgain() {
+    public final boolean isTraversableAgain() {
         return true;
     }
 
     @Override
-    default T last() {
+    public final T last() {
         return Collections.last(this);
     }
 
     @Override
-    default int lastIndexOf(T element, int end) {
+    public final int lastIndexOf(T element, int end) {
         int result = -1, index = 0;
         for (Stream<T> stream = this; index <= end && !stream.isEmpty(); stream = stream.tail(), index++) {
             if (Objects.equals(stream.head(), element)) {
@@ -1214,12 +1204,12 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default int length() {
+    public final int length() {
         return foldLeft(0, (n, ignored) -> n + 1);
     }
 
     @Override
-    default <U> Stream<U> map(Function<? super T, ? extends U> mapper) {
+    public final <U> Stream<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {
             return Empty.instance();
@@ -1229,7 +1219,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> padTo(int length, T element) {
+    public final Stream<T> padTo(int length, T element) {
         if (length <= 0) {
             return this;
         } else if (isEmpty()) {
@@ -1240,7 +1230,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> leftPadTo(int length, T element) {
+    public final Stream<T> leftPadTo(int length, T element) {
         final int actualLength = length();
         if (length <= actualLength) {
             return this;
@@ -1250,17 +1240,17 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> orElse(Iterable<? extends T> other) {
+    public final Stream<T> orElse(Iterable<? extends T> other) {
         return isEmpty() ? ofAll(other) : this;
     }
 
     @Override
-    default Stream<T> orElse(Supplier<? extends Iterable<? extends T>> supplier) {
+    public final Stream<T> orElse(Supplier<? extends Iterable<? extends T>> supplier) {
         return isEmpty() ? ofAll(supplier.get()) : this;
     }
 
     @Override
-    default Stream<T> patch(int from, Iterable<? extends T> that, int replaced) {
+    public final Stream<T> patch(int from, Iterable<? extends T> that, int replaced) {
         from = from < 0 ? 0 : from;
         replaced = replaced < 0 ? 0 : replaced;
         Stream<T> result = take(from).appendAll(that);
@@ -1270,13 +1260,13 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Tuple2<Stream<T>, Stream<T>> partition(Predicate<? super T> predicate) {
+    public final Tuple2<Stream<T>, Stream<T>> partition(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return Tuple.of(filter(predicate), filter(predicate.negate()));
     }
 
     @Override
-    default Stream<T> peek(Consumer<? super T> action) {
+    public final Stream<T> peek(Consumer<? super T> action) {
         Objects.requireNonNull(action, "action is null");
         if (isEmpty()) {
             return this;
@@ -1288,7 +1278,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<Stream<T>> permutations() {
+    public final Stream<Stream<T>> permutations() {
         if (isEmpty()) {
             return Empty.instance();
         } else {
@@ -1306,12 +1296,12 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> prepend(T element) {
+    public final Stream<T> prepend(T element) {
         return cons(element, () -> this);
     }
 
     @Override
-    default Stream<T> prependAll(Iterable<? extends T> elements) {
+    public final Stream<T> prependAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         if (isEmpty()) {
             if (elements instanceof Stream) {
@@ -1327,7 +1317,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> remove(T element) {
+    public final Stream<T> remove(T element) {
         if (isEmpty()) {
             return this;
         } else {
@@ -1337,7 +1327,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> removeFirst(Predicate<T> predicate) {
+    public final Stream<T> removeFirst(Predicate<T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (isEmpty()) {
             return this;
@@ -1348,12 +1338,12 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> removeLast(Predicate<T> predicate) {
+    public final Stream<T> removeLast(Predicate<T> predicate) {
         return isEmpty() ? this : reverse().removeFirst(predicate).reverse();
     }
 
     @Override
-    default Stream<T> removeAt(int index) {
+    public final Stream<T> removeAt(int index) {
         if (index < 0) {
             throw new IndexOutOfBoundsException("removeAt(" + index + ")");
         } else if (index == 0) {
@@ -1366,24 +1356,24 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> removeAll(T element) {
+    public final Stream<T> removeAll(T element) {
         return io.vavr.collection.Collections.removeAll(this, element);
     }
 
     @Override
-    default Stream<T> removeAll(Iterable<? extends T> elements) {
+    public final Stream<T> removeAll(Iterable<? extends T> elements) {
         return io.vavr.collection.Collections.removeAll(this, elements);
     }
 
     @Override
     @Deprecated
-    default Stream<T> removeAll(Predicate<? super T> predicate) {
+    public final Stream<T> removeAll(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return reject(predicate);
     }
 
     @Override
-    default Stream<T> replace(T currentElement, T newElement) {
+    public final Stream<T> replace(T currentElement, T newElement) {
         if (isEmpty()) {
             return this;
         } else {
@@ -1397,7 +1387,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> replaceAll(T currentElement, T newElement) {
+    public final Stream<T> replaceAll(T currentElement, T newElement) {
         if (isEmpty()) {
             return this;
         } else {
@@ -1408,54 +1398,54 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> retainAll(Iterable<? extends T> elements) {
+    public final Stream<T> retainAll(Iterable<? extends T> elements) {
         return io.vavr.collection.Collections.retainAll(this, elements);
     }
 
     @Override
-    default Stream<T> reverse() {
+    public final Stream<T> reverse() {
         return isEmpty() ? this : foldLeft(Stream.empty(), Stream::prepend);
     }
 
     @Override
-    default Stream<T> rotateLeft(int n) {
+    public final Stream<T> rotateLeft(int n) {
         return Collections.rotateLeft(this, n);
     }
 
     @Override
-    default Stream<T> rotateRight(int n) {
+    public final Stream<T> rotateRight(int n) {
         return Collections.rotateRight(this, n);
     }
 
     @Override
-    default Stream<T> scan(T zero, BiFunction<? super T, ? super T, ? extends T> operation) {
+    public final Stream<T> scan(T zero, BiFunction<? super T, ? super T, ? extends T> operation) {
         return scanLeft(zero, operation);
     }
 
     @Override
-    default <U> Stream<U> scanLeft(U zero, BiFunction<? super U, ? super T, ? extends U> operation) {
+    public final <U> Stream<U> scanLeft(U zero, BiFunction<? super U, ? super T, ? extends U> operation) {
         // lazily streams the elements of an iterator
         return io.vavr.collection.Collections.scanLeft(this, zero, operation, Iterator::toStream);
     }
 
     // not lazy!
     @Override
-    default <U> Stream<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation) {
+    public final <U> Stream<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation) {
         return io.vavr.collection.Collections.scanRight(this, zero, operation, Iterator::toStream);
     }
 
     @Override
-    default Stream<T> shuffle() {
+    public final Stream<T> shuffle() {
         return io.vavr.collection.Collections.shuffle(this, Stream::ofAll);
     }
 
     @Override
-    default Stream<T> shuffle(Random random) {
+    public final Stream<T> shuffle(Random random) {
         return io.vavr.collection.Collections.shuffle(this, random, Stream::ofAll);
     }
 
     @Override
-    default Stream<T> slice(int beginIndex, int endIndex) {
+    public final Stream<T> slice(int beginIndex, int endIndex) {
         if (beginIndex >= endIndex || isEmpty()) {
             return empty();
         } else {
@@ -1469,60 +1459,60 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Iterator<Stream<T>> slideBy(Function<? super T, ?> classifier) {
+    public final Iterator<Stream<T>> slideBy(Function<? super T, ?> classifier) {
         return iterator().slideBy(classifier).map(Stream::ofAll);
     }
 
     @Override
-    default Iterator<Stream<T>> sliding(int size) {
+    public final Iterator<Stream<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    default Iterator<Stream<T>> sliding(int size, int step) {
+    public final Iterator<Stream<T>> sliding(int size, int step) {
         return iterator().sliding(size, step).map(Stream::ofAll);
     }
 
     @Override
-    default Stream<T> sorted() {
+    public final Stream<T> sorted() {
         return isEmpty() ? this : toJavaStream().sorted().collect(Stream.collector());
     }
 
     @Override
-    default Stream<T> sorted(Comparator<? super T> comparator) {
+    public final Stream<T> sorted(Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
         return isEmpty() ? this : toJavaStream().sorted(comparator).collect(Stream.collector());
     }
 
     @Override
-    default <U extends Comparable<? super U>> Stream<T> sortBy(Function<? super T, ? extends U> mapper) {
+    public final <U extends Comparable<? super U>> Stream<T> sortBy(Function<? super T, ? extends U> mapper) {
         return sortBy(U::compareTo, mapper);
     }
 
     @Override
-    default <U> Stream<T> sortBy(Comparator<? super U> comparator, Function<? super T, ? extends U> mapper) {
+    public final <U> Stream<T> sortBy(Comparator<? super U> comparator, Function<? super T, ? extends U> mapper) {
         return Collections.sortBy(this, comparator, mapper, collector());
     }
 
     @Override
-    default Tuple2<Stream<T>, Stream<T>> span(Predicate<? super T> predicate) {
+    public final Tuple2<Stream<T>, Stream<T>> span(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return Tuple.of(takeWhile(predicate), dropWhile(predicate));
     }
 
     @Override
-    default Tuple2<Stream<T>, Stream<T>> splitAt(int n) {
+    public final Tuple2<Stream<T>, Stream<T>> splitAt(int n) {
         return Tuple.of(take(n), drop(n));
     }
 
     @Override
-    default Tuple2<Stream<T>, Stream<T>> splitAt(Predicate<? super T> predicate) {
+    public final Tuple2<Stream<T>, Stream<T>> splitAt(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return Tuple.of(takeWhile(predicate.negate()), dropWhile(predicate.negate()));
     }
 
     @Override
-    default Tuple2<Stream<T>, Stream<T>> splitAtInclusive(Predicate<? super T> predicate) {
+    public final Tuple2<Stream<T>, Stream<T>> splitAtInclusive(Predicate<? super T> predicate) {
         final Tuple2<Stream<T>, Stream<T>> split = splitAt(predicate);
         if (split._2.isEmpty()) {
             return split;
@@ -1532,12 +1522,12 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default String stringPrefix() {
+    public final String stringPrefix() {
         return "Stream";
     }
 
     @Override
-    default Stream<T> subSequence(int beginIndex) {
+    public final Stream<T> subSequence(int beginIndex) {
         if (beginIndex < 0) {
             throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ")");
         }
@@ -1551,7 +1541,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> subSequence(int beginIndex, int endIndex) {
+    public final Stream<T> subSequence(int beginIndex, int endIndex) {
         if (beginIndex < 0) {
             throw new IndexOutOfBoundsException("subSequence(" + beginIndex + ", " + endIndex + ")");
         }
@@ -1570,15 +1560,15 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    Stream<T> tail();
+    public abstract Stream<T> tail();
 
     @Override
-    default Option<Stream<T>> tailOption() {
+    public final Option<Stream<T>> tailOption() {
         return isEmpty() ? Option.none() : Option.some(tail());
     }
 
     @Override
-    default Stream<T> take(int n) {
+    public final Stream<T> take(int n) {
         if (n < 1 || isEmpty()) {
             return empty();
         } else if (n == 1) {
@@ -1589,13 +1579,13 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> takeUntil(Predicate<? super T> predicate) {
+    public final Stream<T> takeUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return takeWhile(predicate.negate());
     }
 
     @Override
-    default Stream<T> takeWhile(Predicate<? super T> predicate) {
+    public final Stream<T> takeWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (isEmpty()) {
             return Empty.instance();
@@ -1610,7 +1600,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> takeRight(int n) {
+    public final Stream<T> takeRight(int n) {
         Stream<T> right = this;
         Stream<T> remaining = drop(n);
         while (!remaining.isEmpty()) {
@@ -1621,13 +1611,13 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> takeRightUntil(Predicate<? super T> predicate) {
+    public final Stream<T> takeRightUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return reverse().takeUntil(predicate).reverse();
     }
 
     @Override
-    default Stream<T> takeRightWhile(Predicate<? super T> predicate) {
+    public final Stream<T> takeRightWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return takeRightUntil(predicate.negate());
     }
@@ -1640,13 +1630,13 @@ public interface Stream<T> extends LinearSeq<T> {
      * @return An instance of type {@code U}
      * @throws NullPointerException if {@code f} is null
      */
-    default <U> U transform(Function<? super Stream<T>, ? extends U> f) {
+    public final <U> U transform(Function<? super Stream<T>, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         return f.apply(this);
     }
 
     @Override
-    default <T1, T2> Tuple2<Stream<T1>, Stream<T2>> unzip(
+    public final <T1, T2> Tuple2<Stream<T1>, Stream<T2>> unzip(
             Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         final Stream<Tuple2<? extends T1, ? extends T2>> stream = map(unzipper);
@@ -1656,7 +1646,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default <T1, T2, T3> Tuple3<Stream<T1>, Stream<T2>, Stream<T3>> unzip3(
+    public final <T1, T2, T3> Tuple3<Stream<T1>, Stream<T2>, Stream<T3>> unzip3(
             Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         final Stream<Tuple3<? extends T1, ? extends T2, ? extends T3>> stream = map(unzipper);
@@ -1667,7 +1657,7 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> update(int index, T element) {
+    public final Stream<T> update(int index, T element) {
         if (isEmpty()) {
             throw new IndexOutOfBoundsException("update(" + index + ", e) on Nil");
         }
@@ -1690,36 +1680,36 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
-    default Stream<T> update(int index, Function<? super T, ? extends T> updater) {
+    public final Stream<T> update(int index, Function<? super T, ? extends T> updater) {
         Objects.requireNonNull(updater, "updater is null");
         return update(index, updater.apply(get(index)));
     }
 
     @Override
-    default <U> Stream<Tuple2<T, U>> zip(Iterable<? extends U> that) {
+    public final <U> Stream<Tuple2<T, U>> zip(Iterable<? extends U> that) {
         return zipWith(that, Tuple::of);
     }
 
     @Override
-    default <U, R> Stream<R> zipWith(Iterable<? extends U> that, BiFunction<? super T, ? super U, ? extends R> mapper) {
+    public final <U, R> Stream<R> zipWith(Iterable<? extends U> that, BiFunction<? super T, ? super U, ? extends R> mapper) {
         Objects.requireNonNull(that, "that is null");
         Objects.requireNonNull(mapper, "mapper is null");
         return Stream.ofAll(iterator().zipWith(that, mapper));
     }
 
     @Override
-    default <U> Stream<Tuple2<T, U>> zipAll(Iterable<? extends U> iterable, T thisElem, U thatElem) {
+    public final <U> Stream<Tuple2<T, U>> zipAll(Iterable<? extends U> iterable, T thisElem, U thatElem) {
         Objects.requireNonNull(iterable, "iterable is null");
         return Stream.ofAll(iterator().zipAll(iterable, thisElem, thatElem));
     }
 
     @Override
-    default Stream<Tuple2<T, Integer>> zipWithIndex() {
+    public final Stream<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    default <U> Stream<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
+    public final <U> Stream<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return Stream.ofAll(iterator().zipWithIndex(mapper));
     }
@@ -1730,7 +1720,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param next value with which the stream should be extended
      * @return new {@code Stream} composed from this stream extended with a Stream of provided value
      */
-    default Stream<T> extend(T next) {
+    public final Stream<T> extend(T next) {
         return Stream.ofAll(this.appendAll(Stream.continually(next)));
     }
 
@@ -1740,7 +1730,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param nextSupplier a supplier which will provide values for extending a stream
      * @return new {@code Stream} composed from this stream extended with values provided by the supplier
      */
-    default Stream<T> extend(Supplier<? extends T> nextSupplier) {
+    public final Stream<T> extend(Supplier<? extends T> nextSupplier) {
         Objects.requireNonNull(nextSupplier, "nextSupplier is null");
         return Stream.ofAll(appendAll(Stream.continually(nextSupplier)));
     }
@@ -1752,7 +1742,7 @@ public interface Stream<T> extends LinearSeq<T> {
      * @param nextFunction a function which calculates the next value basing on the previous value
      * @return new {@code Stream} composed from this stream extended with values calculated by the provided function
      */
-    default Stream<T> extend(Function<? super T, ? extends T> nextFunction) {
+    public final Stream<T> extend(Function<? super T, ? extends T> nextFunction) {
         Objects.requireNonNull(nextFunction, "nextFunction is null");
         if (isEmpty()) {
             return this;
@@ -1790,8 +1780,10 @@ public interface Stream<T> extends LinearSeq<T> {
      * This is a singleton, i.e. not Cloneable.
      *
      * @param <T> Component type of the Stream.
+     * @deprecated will be removed from the public API
      */
-    final class Empty<T> implements Stream<T>, Serializable {
+    @Deprecated
+    public static final class Empty<T> extends Stream<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -1799,6 +1791,21 @@ public interface Stream<T> extends LinearSeq<T> {
 
         // hidden
         private Empty() {
+        }
+
+        @Override
+        public Stream<T> append(T element) {
+            return Stream.of(element);
+        }
+
+        @Override
+        public Stream<T> appendAll(Iterable<? extends T> elements) {
+            Objects.requireNonNull(elements, "elements is null");
+            if (Collections.isEmpty(elements)) {
+                return this;
+            } else {
+                return Stream.ofAll(elements);
+            }
         }
 
         /**
@@ -1862,8 +1869,10 @@ public interface Stream<T> extends LinearSeq<T> {
      * Non-empty {@code Stream}, consisting of a {@code head}, and {@code tail}.
      *
      * @param <T> Component type of the Stream.
+     * @deprecated will be removed from the public API
      */
-    abstract class Cons<T> implements Stream<T> {
+    @Deprecated
+    public static abstract class Cons<T> extends Stream<T> {
 
         private static final long serialVersionUID = 1L;
 
@@ -1921,16 +1930,28 @@ public interface Stream<T> extends LinearSeq<T> {
             return builder.append(")").toString();
         }
     }
-}
 
-interface StreamModule {
-
-    final class ConsImpl<T> extends Cons<T> implements Serializable {
+    private static final class ConsImpl<T> extends Cons<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
         ConsImpl(T head, Supplier<Stream<T>> tail) {
             super(head, tail);
+        }
+
+        @Override
+        public Stream<T> append(T element) {
+            return new AppendElements<>(head(), io.vavr.collection.Queue.of(element), this::tail);
+        }
+
+        @Override
+        public Stream<T> appendAll(Iterable<? extends T> elements) {
+            Objects.requireNonNull(elements, "elements is null");
+            if (Collections.isEmpty(elements)) {
+                return this;
+            } else {
+                return Stream.ofAll(Iterator.concat(this, elements));
+            }
         }
 
         @Override
@@ -1949,7 +1970,7 @@ interface StreamModule {
         }
     }
 
-    final class AppendElements<T> extends Cons<T> implements Serializable {
+    private static final class AppendElements<T> extends Cons<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -1968,7 +1989,7 @@ interface StreamModule {
         @Override
         public Stream<T> appendAll(Iterable<? extends T> elements) {
             Objects.requireNonNull(elements, "elements is null");
-            return isEmpty() ? Stream.ofAll(queue) : new AppendElements<>(head, queue.appendAll(elements), tail);
+            return new AppendElements<>(head, queue.appendAll(elements), tail);
         }
 
         @Override
@@ -2007,7 +2028,7 @@ interface StreamModule {
     // DEV NOTE: The serialization proxy pattern is not compatible with non-final, i.e. extendable,
     // classes. Also, it may not be compatible with circular object graphs.
     @GwtIncompatible("The Java serialization protocol is explicitly not supported")
-    final class SerializationProxy<T> implements Serializable {
+    private static final class SerializationProxy<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -2078,7 +2099,7 @@ interface StreamModule {
         }
     }
 
-    final class AppendSelf<T> {
+    private static final class AppendSelf<T> {
 
         private final Cons<T> self;
 
@@ -2098,7 +2119,7 @@ interface StreamModule {
         }
     }
 
-    interface Combinations {
+    private interface Combinations {
 
         static <T> Stream<Stream<T>> apply(Stream<T> elements, int k) {
             if (k == 0) {
@@ -2111,7 +2132,7 @@ interface StreamModule {
         }
     }
 
-    interface DropRight {
+    private interface DropRight {
 
         // works with infinite streams by buffering elements
         static <T> Stream<T> apply(io.vavr.collection.List<T> front, io.vavr.collection.List<T> rear, Stream<T> remaining) {
@@ -2126,14 +2147,14 @@ interface StreamModule {
         }
     }
 
-    interface StreamFactory {
+    private interface StreamFactory {
 
         static <T> Stream<T> create(java.util.Iterator<? extends T> iterator) {
             return iterator.hasNext() ? Stream.cons(iterator.next(), () -> create(iterator)) : Empty.instance();
         }
     }
 
-    final class StreamIterator<T> implements Iterator<T> {
+    private static final class StreamIterator<T> implements Iterator<T> {
 
         private Supplier<Stream<T>> current;
 
@@ -2158,7 +2179,7 @@ interface StreamModule {
         }
     }
 
-    final class FlatMapIterator<T, U> implements Iterator<U> {
+    private static final class FlatMapIterator<T, U> implements Iterator<U> {
 
         final Function<? super T, ? extends Iterable<? extends U>> mapper;
         final Iterator<? extends T> inputs;

--- a/src/main/java/io/vavr/collection/Tree.java
+++ b/src/main/java/io/vavr/collection/Tree.java
@@ -19,9 +19,6 @@
 package io.vavr.collection;
 
 import io.vavr.*;
-import io.vavr.collection.List.Nil;
-import io.vavr.collection.Tree.Empty;
-import io.vavr.collection.Tree.Node;
 import io.vavr.control.Option;
 
 import java.io.*;
@@ -31,19 +28,19 @@ import java.util.function.*;
 import java.util.stream.Collector;
 
 import static io.vavr.collection.Tree.Order.PRE_ORDER;
-import static io.vavr.collection.Tree.empty;
-import static io.vavr.collection.Tree.of;
-import static io.vavr.collection.Tree.ofAll;
-import static io.vavr.collection.Tree.recurse;
 
 /**
  * A general Tree interface.
  *
  * @param <T> component type of this Tree
  */
-public interface Tree<T> extends Traversable<T>, Serializable {
+public abstract class Tree<T> implements Traversable<T>, Serializable {
 
-    long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
+
+    // sealed
+    private Tree() {
+    }
 
     /**
      * Returns a {@link java.util.stream.Collector} which may be used in conjunction with
@@ -52,7 +49,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @param <T> Component type of the Tree.
      * @return A io.vavr.collection.Tree Collector.
      */
-    static <T> Collector<T, ArrayList<T>, Tree<T>> collector() {
+    public static <T> Collector<T, ArrayList<T>, Tree<T>> collector() {
         final Supplier<ArrayList<T>> supplier = ArrayList::new;
         final BiConsumer<ArrayList<T>, T> accumulator = ArrayList::add;
         final BinaryOperator<ArrayList<T>> combiner = (left, right) -> {
@@ -69,7 +66,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @param <T> Type of tree values.
      * @return The empty tree.
      */
-    static <T> Empty<T> empty() {
+    public static <T> Empty<T> empty() {
         return Empty.instance();
     }
 
@@ -83,7 +80,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return the given {@code tree} instance as narrowed type {@code Tree<T>}.
      */
     @SuppressWarnings("unchecked")
-    static <T> Tree<T> narrow(Tree<? extends T> tree) {
+    public static <T> Tree<T> narrow(Tree<? extends T> tree) {
         return (Tree<T>) tree;
     }
 
@@ -94,7 +91,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @param <T>   Value type
      * @return A new Node instance.
      */
-    static <T> Node<T> of(T value) {
+    public static <T> Node<T> of(T value) {
         return new Node<>(value, io.vavr.collection.List.empty());
     }
 
@@ -108,7 +105,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      */
     @SuppressWarnings("varargs")
     @SafeVarargs
-    static <T> Node<T> of(T value, Node<T>... children) {
+    public static <T> Node<T> of(T value, Node<T>... children) {
         Objects.requireNonNull(children, "children is null");
         return new Node<>(value, io.vavr.collection.List.of(children));
     }
@@ -121,7 +118,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @param <T>      Value type
      * @return A new Node instance.
      */
-    static <T> Node<T> of(T value, Iterable<Node<T>> children) {
+    public static <T> Node<T> of(T value, Iterable<Node<T>> children) {
         Objects.requireNonNull(children, "children is null");
         return new Node<>(value, io.vavr.collection.List.ofAll(children));
     }
@@ -136,7 +133,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      */
     @SuppressWarnings("varargs")
     @SafeVarargs
-    static <T> Tree<T> of(T... values) {
+    public static <T> Tree<T> of(T... values) {
         Objects.requireNonNull(values, "values is null");
         final io.vavr.collection.List<T> list = io.vavr.collection.List.of(values);
         return list.isEmpty() ? Empty.instance() : new Node<>(list.head(), list.tail().map(Tree::of));
@@ -154,7 +151,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @throws NullPointerException if {@code elements} is null
      */
     @SuppressWarnings("unchecked")
-    static <T> Tree<T> ofAll(Iterable<? extends T> iterable) {
+    public static <T> Tree<T> ofAll(Iterable<? extends T> iterable) {
         Objects.requireNonNull(iterable, "iterable is null");
         if (iterable instanceof Tree) {
             return (Tree<T>) iterable;
@@ -171,7 +168,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @param <T>        Component type of the Stream.
      * @return A Tree containing the given elements in the same order.
      */
-    static <T> Tree<T> ofAll(java.util.stream.Stream<? extends T> javaStream) {
+    public static <T> Tree<T> ofAll(java.util.stream.Stream<? extends T> javaStream) {
         Objects.requireNonNull(javaStream, "javaStream is null");
         return ofAll(io.vavr.collection.Iterator.ofAll(javaStream.iterator()));
     }
@@ -186,7 +183,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return A Tree consisting of elements {@code f(0),f(1), ..., f(n - 1)}
      * @throws NullPointerException if {@code f} is null
      */
-    static <T> Tree<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
+    public static <T> Tree<T> tabulate(int n, Function<? super Integer, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
         return io.vavr.collection.Collections.tabulate(n, f, empty(), Tree::of);
     }
@@ -200,7 +197,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return A Tree of size {@code n}, where each element contains the result supplied by {@code s}.
      * @throws NullPointerException if {@code s} is null
      */
-    static <T> Tree<T> fill(int n, Supplier<? extends T> s) {
+    public static <T> Tree<T> fill(int n, Supplier<? extends T> s) {
         Objects.requireNonNull(s, "s is null");
         return io.vavr.collection.Collections.fill(n, s, empty(), Tree::of);
     }
@@ -213,7 +210,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @param element The element
      * @return A Tree of size {@code n}, where each element is the given {@code element}.
      */
-    static <T> Tree<T> fill(int n, T element) {
+    public static <T> Tree<T> fill(int n, T element) {
         return io.vavr.collection.Collections.fillObject(n, element, empty(), Tree::of);
     }
 
@@ -242,7 +239,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return a new, non-empty {@code Tree} instance
      * @throws NullPointerException if {@code descend} is null
      */
-    static <T> Node<T> recurse(T seed, Function<? super T, ? extends Iterable<? extends T>> descend) {
+    public static <T> Node<T> recurse(T seed, Function<? super T, ? extends Iterable<? extends T>> descend) {
         Objects.requireNonNull(descend, "descend is null");
         return Tree.of(seed, Stream.of(seed).flatMap(descend).map(children -> recurse(children, descend)));
     }
@@ -272,7 +269,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return a new, maybe empty {@code List} instance with non-empty {@code Tree} instances
      * @throws NullPointerException if {@code source}, {@code idMapper} or {@code parentMapper} is null
      */
-    static <T, ID> List<Node<T>> build(Iterable<? extends T> source, Function<? super T, ? extends ID> idMapper, Function<? super T, ? extends ID> parentMapper) {
+    public static <T, ID> List<Node<T>> build(Iterable<? extends T> source, Function<? super T, ? extends ID> idMapper, Function<? super T, ? extends ID> parentMapper) {
         Objects.requireNonNull(source, "source is null");
         Objects.requireNonNull(source, "idMapper is null");
         Objects.requireNonNull(source, "parentMapper is null");
@@ -286,8 +283,8 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default <R> Tree<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
-        return ofAll(iterator().<R> collect(partialFunction));
+    public final <R> Tree<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
+        return ofAll(iterator().<R>collect(partialFunction));
     }
 
     /**
@@ -296,14 +293,14 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return The value of this tree.
      * @throws java.lang.UnsupportedOperationException if this tree is empty
      */
-    T getValue();
+    public abstract T getValue();
 
     /**
      * Returns the children of this tree.
      *
      * @return the tree's children
      */
-    io.vavr.collection.List<Node<T>> getChildren();
+    public abstract io.vavr.collection.List<Node<T>> getChildren();
 
     /**
      * Checks if this Tree is a leaf. A tree is a leaf if it is a Node with no children.
@@ -311,7 +308,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      *
      * @return true if this tree is a leaf, false otherwise.
      */
-    boolean isLeaf();
+    public abstract boolean isLeaf();
 
     /**
      * Checks if this Tree is a branch. A Tree is a branch if it is a Node which has children.
@@ -319,7 +316,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      *
      * @return true if this tree is a branch, false otherwise.
      */
-    default boolean isBranch() {
+    public final boolean isBranch() {
         return !(isEmpty() || isLeaf());
     }
 
@@ -329,12 +326,12 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return false
      */
     @Override
-    default boolean isAsync() {
+    public final boolean isAsync() {
         return false;
     }
 
     @Override
-    default boolean isDistinct() {
+    public final boolean isDistinct() {
         return false;
     }
 
@@ -344,12 +341,12 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return false
      */
     @Override
-    default boolean isLazy() {
+    public final boolean isLazy() {
         return false;
     }
 
     @Override
-    default boolean isSequential() {
+    public final boolean isSequential() {
         return true;
     }
 
@@ -359,7 +356,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @param order A traversal order
      * @return A new Iterator
      */
-    default io.vavr.collection.Iterator<T> iterator(Order order) {
+    public final io.vavr.collection.Iterator<T> iterator(Order order) {
         return values(order).iterator();
     }
 
@@ -368,7 +365,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      *
      * @return This {@code Tree} as Lisp-string, i.e. represented as list of lists.
      */
-    String toLispString();
+    public abstract String toLispString();
 
     /**
      * Transforms this {@code Tree}.
@@ -378,7 +375,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return An instance of type {@code U}
      * @throws NullPointerException if {@code f} is null
      */
-    default <U> U transform(Function<? super Tree<T>, ? extends U> f) {
+    public final <U> U transform(Function<? super Tree<T>, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         return f.apply(this);
     }
@@ -388,7 +385,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      *
      * @return A sequence of nodes.
      */
-    default Seq<Node<T>> traverse() {
+    public final Seq<Node<T>> traverse() {
         return traverse(PRE_ORDER);
     }
 
@@ -399,7 +396,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return A sequence of nodes.
      * @throws java.lang.NullPointerException if order is null
      */
-    default Seq<Node<T>> traverse(Order order) {
+    public final Seq<Node<T>> traverse(Order order) {
         Objects.requireNonNull(order, "order is null");
         if (isEmpty()) {
             return Stream.empty();
@@ -407,13 +404,13 @@ public interface Tree<T> extends Traversable<T>, Serializable {
             final Node<T> node = (Node<T>) this;
             switch (order) {
                 case PRE_ORDER:
-                    return TreeModule.traversePreOrder(node);
+                    return Tree.traversePreOrder(node);
                 case IN_ORDER:
-                    return TreeModule.traverseInOrder(node);
+                    return Tree.traverseInOrder(node);
                 case POST_ORDER:
-                    return TreeModule.traversePostOrder(node);
+                    return Tree.traversePostOrder(node);
                 case LEVEL_ORDER:
-                    return TreeModule.traverseLevelOrder(node);
+                    return Tree.traverseLevelOrder(node);
                 default:
                     throw new IllegalStateException("Unknown order: " + order.name());
             }
@@ -426,7 +423,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      *
      * @return A sequence of the tree values.
      */
-    default Seq<T> values() {
+    public final Seq<T> values() {
         return traverse(PRE_ORDER).map(Node::getValue);
     }
 
@@ -438,7 +435,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * @return A sequence of the tree values.
      * @throws java.lang.NullPointerException if order is null
      */
-    default Seq<T> values(Order order) {
+    public final Seq<T> values(Order order) {
         return traverse(order).map(Node::getValue);
     }
 
@@ -447,7 +444,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      *
      * @return The number of branches of this tree.
      */
-    default int branchCount() {
+    public final int branchCount() {
         if (isEmpty() || isLeaf()) {
             return 0;
         } else {
@@ -460,7 +457,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      *
      * @return The number of leaves of this tree.
      */
-    default int leafCount() {
+    public final int leafCount() {
         if (isEmpty()) {
             return 0;
         } else if (isLeaf()) {
@@ -475,19 +472,19 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      *
      * @return The number of nodes of this tree.
      */
-    default int nodeCount() {
+    public final int nodeCount() {
         return length();
     }
 
     // -- Methods inherited from Traversable
 
     @Override
-    default Seq<T> distinct() {
+    public final Seq<T> distinct() {
         return values().distinct();
     }
 
     @Override
-    default Seq<T> distinctBy(Comparator<? super T> comparator) {
+    public final Seq<T> distinctBy(Comparator<? super T> comparator) {
         Objects.requireNonNull(comparator, "comparator is null");
         if (isEmpty()) {
             return Stream.empty();
@@ -497,7 +494,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default <U> Seq<T> distinctBy(Function<? super T, ? extends U> keyExtractor) {
+    public final <U> Seq<T> distinctBy(Function<? super T, ? extends U> keyExtractor) {
         Objects.requireNonNull(keyExtractor, "keyExtractor is null");
         if (isEmpty()) {
             return Stream.empty();
@@ -507,7 +504,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Seq<T> drop(int n) {
+    public final Seq<T> drop(int n) {
         if (n >= length()) {
             return Stream.empty();
         } else {
@@ -516,7 +513,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Seq<T> dropRight(int n) {
+    public final Seq<T> dropRight(int n) {
         if (n >= length()) {
             return Stream.empty();
         } else {
@@ -525,13 +522,13 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Seq<T> dropUntil(Predicate<? super T> predicate) {
+    public final Seq<T> dropUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return dropWhile(predicate.negate());
     }
 
     @Override
-    default Seq<T> dropWhile(Predicate<? super T> predicate) {
+    public final Seq<T> dropWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (isEmpty()) {
             return Stream.empty();
@@ -541,7 +538,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Seq<T> filter(Predicate<? super T> predicate) {
+    public final Seq<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (isEmpty()) {
             return Stream.empty();
@@ -551,7 +548,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Seq<T> filterNot(Predicate<? super T> predicate) {
+    public final Seq<T> filterNot(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (isEmpty()) {
             return Stream.empty();
@@ -562,7 +559,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
 
     @Deprecated
     @Override
-    default Seq<T> reject(Predicate<? super T> predicate) {
+    public final Seq<T> reject(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (isEmpty()) {
             return Stream.empty();
@@ -572,13 +569,13 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default <U> Tree<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    public final <U> Tree<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return isEmpty() ? Empty.instance() : TreeModule.flatMap((Node<T>) this, mapper);
+        return isEmpty() ? Empty.instance() : Tree.flatMap((Node<T>) this, mapper);
     }
 
     @Override
-    default <U> U foldRight(U zero, BiFunction<? super T, ? super U, ? extends U> f) {
+    public final <U> U foldRight(U zero, BiFunction<? super T, ? super U, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         if (isEmpty()) {
             return zero;
@@ -589,22 +586,22 @@ public interface Tree<T> extends Traversable<T>, Serializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    default <C> Map<C, Seq<T>> groupBy(Function<? super T, ? extends C> classifier) {
+    public final <C> Map<C, Seq<T>> groupBy(Function<? super T, ? extends C> classifier) {
         return io.vavr.collection.Collections.groupBy(values(), classifier, Stream::ofAll);
     }
 
     @Override
-    default io.vavr.collection.Iterator<Seq<T>> grouped(int size) {
+    public final io.vavr.collection.Iterator<Seq<T>> grouped(int size) {
         return sliding(size, size);
     }
 
     @Override
-    default boolean hasDefiniteSize() {
+    public final boolean hasDefiniteSize() {
         return true;
     }
 
     @Override
-    default T head() {
+    public final T head() {
         if (isEmpty()) {
             throw new NoSuchElementException("head of empty tree");
         } else {
@@ -613,7 +610,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Seq<T> init() {
+    public final Seq<T> init() {
         if (isEmpty()) {
             throw new UnsupportedOperationException("init of empty tree");
         } else {
@@ -622,39 +619,39 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Option<Seq<T>> initOption() {
+    public final Option<Seq<T>> initOption() {
         return isEmpty() ? Option.none() : Option.some(init());
     }
 
     @Override
-    default boolean isTraversableAgain() {
+    public final boolean isTraversableAgain() {
         return true;
     }
 
     @Override
-    default io.vavr.collection.Iterator<T> iterator() {
+    public final io.vavr.collection.Iterator<T> iterator() {
         return values().iterator();
     }
 
     @Override
-    default <U> Tree<U> map(Function<? super T, ? extends U> mapper) {
+    public final <U> Tree<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return isEmpty() ? Empty.instance() : TreeModule.map((Node<T>) this, mapper);
+        return isEmpty() ? Empty.instance() : Tree.map((Node<T>) this, mapper);
     }
 
     @Override
-    default Tree<T> orElse(Iterable<? extends T> other) {
+    public final Tree<T> orElse(Iterable<? extends T> other) {
         return isEmpty() ? ofAll(other) : this;
     }
 
     @Override
-    default Tree<T> orElse(Supplier<? extends Iterable<? extends T>> supplier) {
+    public final Tree<T> orElse(Supplier<? extends Iterable<? extends T>> supplier) {
         return isEmpty() ? ofAll(supplier.get()) : this;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    default Tuple2<Seq<T>, Seq<T>> partition(Predicate<? super T> predicate) {
+    public final Tuple2<Seq<T>, Seq<T>> partition(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (isEmpty()) {
             return Tuple.of(Stream.empty(), Stream.empty());
@@ -664,7 +661,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Tree<T> peek(Consumer<? super T> action) {
+    public final Tree<T> peek(Consumer<? super T> action) {
         Objects.requireNonNull(action, "action is null");
         if (!isEmpty()) {
             action.accept(head());
@@ -673,58 +670,58 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Tree<T> replace(T currentElement, T newElement) {
+    public final Tree<T> replace(T currentElement, T newElement) {
         if (isEmpty()) {
             return Empty.instance();
         } else {
-            return TreeModule.replace((Node<T>) this, currentElement, newElement);
+            return Tree.replace((Node<T>) this, currentElement, newElement);
         }
     }
 
     @Override
-    default Tree<T> replaceAll(T currentElement, T newElement) {
+    public final Tree<T> replaceAll(T currentElement, T newElement) {
         return map(t -> Objects.equals(t, currentElement) ? newElement : t);
     }
 
     @Override
-    default Seq<T> retainAll(Iterable<? extends T> elements) {
+    public final Seq<T> retainAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
         return values().retainAll(elements);
     }
 
     @Override
-    default Seq<T> scan(T zero, BiFunction<? super T, ? super T, ? extends T> operation) {
+    public final Seq<T> scan(T zero, BiFunction<? super T, ? super T, ? extends T> operation) {
         return scanLeft(zero, operation);
     }
 
     @Override
-    default <U> Seq<U> scanLeft(U zero, BiFunction<? super U, ? super T, ? extends U> operation) {
+    public final <U> Seq<U> scanLeft(U zero, BiFunction<? super U, ? super T, ? extends U> operation) {
         return io.vavr.collection.Collections.scanLeft(this, zero, operation, io.vavr.collection.Iterator::toStream);
     }
 
     @Override
-    default <U> Seq<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation) {
+    public final <U> Seq<U> scanRight(U zero, BiFunction<? super T, ? super U, ? extends U> operation) {
         return io.vavr.collection.Collections.scanRight(this, zero, operation, io.vavr.collection.Iterator::toStream);
     }
 
     @Override
-    default io.vavr.collection.Iterator<Seq<T>> slideBy(Function<? super T, ?> classifier) {
+    public final io.vavr.collection.Iterator<Seq<T>> slideBy(Function<? super T, ?> classifier) {
         return iterator().slideBy(classifier);
     }
 
     @Override
-    default io.vavr.collection.Iterator<Seq<T>> sliding(int size) {
+    public final io.vavr.collection.Iterator<Seq<T>> sliding(int size) {
         return sliding(size, 1);
     }
 
     @Override
-    default io.vavr.collection.Iterator<Seq<T>> sliding(int size, int step) {
+    public final io.vavr.collection.Iterator<Seq<T>> sliding(int size, int step) {
         return iterator().sliding(size, step);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    default Tuple2<Seq<T>, Seq<T>> span(Predicate<? super T> predicate) {
+    public final Tuple2<Seq<T>, Seq<T>> span(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         if (isEmpty()) {
             return Tuple.of(Stream.empty(), Stream.empty());
@@ -734,12 +731,12 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default String stringPrefix() {
+    public final String stringPrefix() {
         return "Tree";
     }
 
     @Override
-    default Seq<T> tail() {
+    public final Seq<T> tail() {
         if (isEmpty()) {
             throw new UnsupportedOperationException("tail of empty tree");
         } else {
@@ -748,12 +745,12 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Option<Seq<T>> tailOption() {
+    public final Option<Seq<T>> tailOption() {
         return isEmpty() ? Option.none() : Option.some(tail());
     }
 
     @Override
-    default Seq<T> take(int n) {
+    public final Seq<T> take(int n) {
         if (isEmpty()) {
             return Stream.empty();
         } else {
@@ -762,7 +759,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Seq<T> takeRight(int n) {
+    public final Seq<T> takeRight(int n) {
         if (isEmpty()) {
             return Stream.empty();
         } else {
@@ -771,65 +768,65 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Seq<T> takeUntil(Predicate<? super T> predicate) {
+    public final Seq<T> takeUntil(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return values().takeUntil(predicate);
     }
 
     @Override
-    default Seq<T> takeWhile(Predicate<? super T> predicate) {
+    public final Seq<T> takeWhile(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return values().takeWhile(predicate);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    default <T1, T2> Tuple2<Tree<T1>, Tree<T2>> unzip(
+    public final <T1, T2> Tuple2<Tree<T1>, Tree<T2>> unzip(
             Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         if (isEmpty()) {
             return Tuple.of(Empty.instance(), Empty.instance());
         } else {
-            return (Tuple2<Tree<T1>, Tree<T2>>) (Object) TreeModule.unzip((Node<T>) this, unzipper);
+            return (Tuple2<Tree<T1>, Tree<T2>>) (Object) Tree.unzip((Node<T>) this, unzipper);
         }
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    default <T1, T2, T3> Tuple3<Tree<T1>, Tree<T2>, Tree<T3>> unzip3(
+    public final <T1, T2, T3> Tuple3<Tree<T1>, Tree<T2>, Tree<T3>> unzip3(
             Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         if (isEmpty()) {
             return Tuple.of(Empty.instance(), Empty.instance(), Empty.instance());
         } else {
-            return (Tuple3<Tree<T1>, Tree<T2>, Tree<T3>>) (Object) TreeModule.unzip3((Node<T>) this, unzipper);
+            return (Tuple3<Tree<T1>, Tree<T2>, Tree<T3>>) (Object) Tree.unzip3((Node<T>) this, unzipper);
         }
     }
 
     @Override
-    default <U> Tree<Tuple2<T, U>> zip(Iterable<? extends U> that) {
+    public final <U> Tree<Tuple2<T, U>> zip(Iterable<? extends U> that) {
         return zipWith(that, Tuple::of);
     }
 
     @Override
-    default <U, R> Tree<R> zipWith(Iterable<? extends U> that, BiFunction<? super T, ? super U, ? extends R> mapper) {
+    public final <U, R> Tree<R> zipWith(Iterable<? extends U> that, BiFunction<? super T, ? super U, ? extends R> mapper) {
         Objects.requireNonNull(that, "that is null");
         Objects.requireNonNull(mapper, "mapper is null");
         if (isEmpty()) {
             return Empty.instance();
         } else {
-            return TreeModule.zip((Node<T>) this, that.iterator(), mapper);
+            return Tree.zip((Node<T>) this, that.iterator(), mapper);
         }
     }
 
     @Override
-    default <U> Tree<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem) {
+    public final <U> Tree<Tuple2<T, U>> zipAll(Iterable<? extends U> that, T thisElem, U thatElem) {
         Objects.requireNonNull(that, "that is null");
         if (isEmpty()) {
-            return io.vavr.collection.Iterator.<U> ofAll(that).map(elem -> Tuple.of(thisElem, elem)).toTree();
+            return io.vavr.collection.Iterator.<U>ofAll(that).map(elem -> Tuple.of(thisElem, elem)).toTree();
         } else {
             final java.util.Iterator<? extends U> thatIter = that.iterator();
-            final Tree<Tuple2<T, U>> tree = TreeModule.zipAll((Node<T>) this, thatIter, thatElem);
+            final Tree<Tuple2<T, U>> tree = Tree.zipAll((Node<T>) this, thatIter, thatElem);
             if (thatIter.hasNext()) {
                 final Iterable<Node<Tuple2<T, U>>> remainder = io.vavr.collection.Iterator
                         .ofAll(thatIter)
@@ -842,38 +839,31 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
-    default Tree<Tuple2<T, Integer>> zipWithIndex() {
+    public final Tree<Tuple2<T, Integer>> zipWithIndex() {
         return zipWithIndex(Tuple::of);
     }
 
     @Override
-    default <U> Tree<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
+    public final <U> Tree<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return zipWith(io.vavr.collection.Iterator.from(0), mapper);
     }
-
-    @Override
-    boolean equals(Object o);
-
-    @Override
-    int hashCode();
-
-    @Override
-    String toString();
 
     /**
      * Creates a neat 2-dimensional drawing of a tree. Unicode characters are used to draw node junctions.
      *
      * @return A nice string representation of the tree.
      */
-    String draw();
+    public abstract String draw();
 
     /**
      * Represents a tree node.
      *
      * @param <T> value type
+     * @deprecated will be removed from the public API
      */
-    final class Node<T> implements Tree<T>, Serializable {
+    @Deprecated
+    public static final class Node<T> extends Tree<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -1085,8 +1075,10 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * The empty tree. Use Tree.empty() to create an instance.
      *
      * @param <T> type of the tree's values
+     * @deprecated will be removed from the public API
      */
-    final class Empty<T> implements Tree<T>, Serializable {
+    @Deprecated
+    public static final class Empty<T> extends Tree<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -1103,7 +1095,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
 
         @Override
         public io.vavr.collection.List<Node<T>> getChildren() {
-            return Nil.instance();
+            return List.empty();
         }
 
         @Override
@@ -1152,7 +1144,9 @@ public interface Tree<T> extends Traversable<T>, Serializable {
         }
 
         @Override
-        public String draw() { return "▣"; }
+        public String draw() {
+            return "▣";
+        }
 
         // -- Serializable implementation
 
@@ -1192,7 +1186,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      * </ul>
      */
     // see http://programmers.stackexchange.com/questions/138766/in-order-traversal-of-m-way-trees
-    enum Order {
+    public enum Order {
 
         /**
          * 1 2 4 7 5 3 6 8 9 (= depth-first)
@@ -1214,17 +1208,9 @@ public interface Tree<T> extends Traversable<T>, Serializable {
          */
         LEVEL_ORDER
     }
-}
-
-/**
- * Because the empty tree {@code Empty} cannot be a child of an existing tree, method implementations distinguish between the
- * empty and non-empty case. Because the structure of trees is recursive, often we have commands in the form of module
- * classes with one static method.
- */
-interface TreeModule {
 
     @SuppressWarnings("unchecked")
-    static <T, U> Tree<U> flatMap(Node<T> node, Function<? super T, ? extends Iterable<? extends U>> mapper) {
+    private static <T, U> Tree<U> flatMap(Node<T> node, Function<? super T, ? extends Iterable<? extends U>> mapper) {
         final Tree<U> mapped = ofAll(mapper.apply(node.getValue()));
         if (mapped.isEmpty()) {
             return empty();
@@ -1237,7 +1223,7 @@ interface TreeModule {
         }
     }
 
-    static <T, U> Node<U> map(Node<T> node, Function<? super T, ? extends U> mapper) {
+    private static <T, U> Node<U> map(Node<T> node, Function<? super T, ? extends U> mapper) {
         final U value = mapper.apply(node.getValue());
         final io.vavr.collection.List<Node<U>> children = node.getChildren().map(child -> map(child, mapper));
         return new Node<>(value, children);
@@ -1246,7 +1232,7 @@ interface TreeModule {
     // Idea:
     // Traverse (depth-first) until a match is found, then stop and rebuild relevant parts of the tree.
     // If not found, return the same tree instance.
-    static <T> Node<T> replace(Node<T> node, T currentElement, T newElement) {
+    private static <T> Node<T> replace(Node<T> node, T currentElement, T newElement) {
         if (Objects.equals(node.getValue(), currentElement)) {
             return new Node<>(newElement, node.getChildren());
         } else {
@@ -1262,32 +1248,32 @@ interface TreeModule {
         }
     }
 
-    static <T> Stream<Node<T>> traversePreOrder(Node<T> node) {
+    private static <T> Stream<Node<T>> traversePreOrder(Node<T> node) {
         return node.getChildren().foldLeft(Stream.of(node),
                 (acc, child) -> acc.appendAll(traversePreOrder(child)));
     }
 
-    static <T> Stream<Node<T>> traverseInOrder(Node<T> node) {
+    private static <T> Stream<Node<T>> traverseInOrder(Node<T> node) {
         if (node.isLeaf()) {
             return Stream.of(node);
         } else {
             final io.vavr.collection.List<Node<T>> children = node.getChildren();
             return children
                     .tail()
-                    .foldLeft(Stream.<Node<T>> empty(), (acc, child) -> acc.appendAll(traverseInOrder(child)))
+                    .foldLeft(Stream.<Node<T>>empty(), (acc, child) -> acc.appendAll(traverseInOrder(child)))
                     .prepend(node)
                     .prependAll(traverseInOrder(children.head()));
         }
     }
 
-    static <T> Stream<Node<T>> traversePostOrder(Node<T> node) {
+    private static <T> Stream<Node<T>> traversePostOrder(Node<T> node) {
         return node
                 .getChildren()
-                .foldLeft(Stream.<Node<T>> empty(), (acc, child) -> acc.appendAll(traversePostOrder(child)))
+                .foldLeft(Stream.<Node<T>>empty(), (acc, child) -> acc.appendAll(traversePostOrder(child)))
                 .append(node);
     }
 
-    static <T> Stream<Node<T>> traverseLevelOrder(Node<T> node) {
+    private static <T> Stream<Node<T>> traverseLevelOrder(Node<T> node) {
         Stream<Node<T>> result = Stream.empty();
         final java.util.Queue<Node<T>> queue = new java.util.LinkedList<>();
         queue.add(node);
@@ -1299,8 +1285,8 @@ interface TreeModule {
         return result.reverse();
     }
 
-    static <T, T1, T2> Tuple2<Node<T1>, Node<T2>> unzip(Node<T> node,
-            Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
+    private static <T, T1, T2> Tuple2<Node<T1>, Node<T2>> unzip(Node<T> node,
+                                                                Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         final Tuple2<? extends T1, ? extends T2> value = unzipper.apply(node.getValue());
         final io.vavr.collection.List<Tuple2<Node<T1>, Node<T2>>> children = node
                 .getChildren()
@@ -1310,8 +1296,8 @@ interface TreeModule {
         return Tuple.of(node1, node2);
     }
 
-    static <T, T1, T2, T3> Tuple3<Node<T1>, Node<T2>, Node<T3>> unzip3(Node<T> node,
-            Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
+    private static <T, T1, T2, T3> Tuple3<Node<T1>, Node<T2>, Node<T3>> unzip3(Node<T> node,
+                                                                               Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         final Tuple3<? extends T1, ? extends T2, ? extends T3> value = unzipper.apply(node.getValue());
         final io.vavr.collection.List<Tuple3<Node<T1>, Node<T2>, Node<T3>>> children = node.getChildren()
                 .map(child -> unzip3(child, unzipper));
@@ -1322,7 +1308,7 @@ interface TreeModule {
     }
 
     @SuppressWarnings("unchecked")
-    static <T, U, R> Tree<R> zip(Node<T> node, java.util.Iterator<? extends U> that, BiFunction<? super T, ? super U, ? extends R> mapper) {
+    private static <T, U, R> Tree<R> zip(Node<T> node, java.util.Iterator<? extends U> that, BiFunction<? super T, ? super U, ? extends R> mapper) {
         if (!that.hasNext()) {
             return Empty.instance();
         } else {
@@ -1336,7 +1322,7 @@ interface TreeModule {
     }
 
     @SuppressWarnings("unchecked")
-    static <T, U> Tree<Tuple2<T, U>> zipAll(Node<T> node, java.util.Iterator<? extends U> that, U thatElem) {
+    private static <T, U> Tree<Tuple2<T, U>> zipAll(Node<T> node, java.util.Iterator<? extends U> that, U thatElem) {
         if (!that.hasNext()) {
             return node.map(value -> Tuple.of(value, thatElem));
         } else {

--- a/src/main/java/io/vavr/control/Either.java
+++ b/src/main/java/io/vavr/control/Either.java
@@ -56,9 +56,13 @@ import java.util.function.Supplier;
  * @param <R> The type of the Right value of an Either.
  */
 @SuppressWarnings("deprecation")
-public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Serializable {
+public abstract class Either<L, R> implements io.vavr.Iterable<R>, io.vavr.Value<R>, Serializable {
 
-    long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
+
+    // sealed
+    private Either() {
+    }
 
     /**
      * Constructs a {@link Right}
@@ -68,7 +72,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @param <R>   Type of right value.
      * @return A new {@code Right} instance.
      */
-    static <L, R> Either<L, R> right(R right) {
+    public static <L, R> Either<L, R> right(R right) {
         return new Right<>(right);
     }
 
@@ -80,7 +84,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @param <R>  Type of right value.
      * @return A new {@code Left} instance.
      */
-    static <L, R> Either<L, R> left(L left) {
+    public static <L, R> Either<L, R> left(L left) {
         return new Left<>(left);
     }
 
@@ -95,7 +99,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return the given {@code either} instance as narrowed type {@code Either<L, R>}.
      */
     @SuppressWarnings("unchecked")
-    static <L, R> Either<L, R> narrow(Either<? extends L, ? extends R> either) {
+    public static <L, R> Either<L, R> narrow(Either<? extends L, ? extends R> either) {
         return (Either<L, R>) either;
     }
 
@@ -105,21 +109,21 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return The left value.
      * @throws NoSuchElementException if this is a {@code Right}.
      */
-    L getLeft();
+    public abstract L getLeft();
 
     /**
      * Returns whether this Either is a Left.
      *
      * @return true, if this is a Left, false otherwise
      */
-    boolean isLeft();
+    public abstract boolean isLeft();
 
     /**
      * Returns whether this Either is a Right.
      *
      * @return true, if this is a Right, false otherwise
      */
-    boolean isRight();
+    public abstract boolean isRight();
 
     /**
      * Returns a LeftProjection of this Either.
@@ -128,7 +132,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @deprecated Either is right-biased. Use {@link #swap()} instead of projections.
      */
     @Deprecated
-    default LeftProjection<L, R> left() {
+    public final LeftProjection<L, R> left() {
         return new LeftProjection<>(this);
     }
 
@@ -139,7 +143,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @deprecated Either is right-biased. Use {@link #swap()} instead of projections.
      */
     @Deprecated
-    default RightProjection<L, R> right() {
+    public final RightProjection<L, R> right() {
         return new RightProjection<>(this);
     }
 
@@ -152,7 +156,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @param <Y>         The new right type of the resulting Either
      * @return A new Either instance
      */
-    default <X, Y> Either<X, Y> bimap(Function<? super L, ? extends X> leftMapper, Function<? super R, ? extends Y> rightMapper) {
+    public final <X, Y> Either<X, Y> bimap(Function<? super L, ? extends X> leftMapper, Function<? super R, ? extends Y> rightMapper) {
         Objects.requireNonNull(leftMapper, "leftMapper is null");
         Objects.requireNonNull(rightMapper, "rightMapper is null");
         if (isRight()) {
@@ -170,7 +174,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @param <U>         type of the folded value
      * @return A value of type U
      */
-    default <U> U fold(Function<? super L, ? extends U> leftMapper, Function<? super R, ? extends U> rightMapper) {
+    public final <U> U fold(Function<? super L, ? extends U> leftMapper, Function<? super R, ? extends U> rightMapper) {
         Objects.requireNonNull(leftMapper, "leftMapper is null");
         Objects.requireNonNull(rightMapper, "rightMapper is null");
         if (isRight()) {
@@ -208,7 +212,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @throws NullPointerException if {@code eithers} is null
      */
     @SuppressWarnings("unchecked")
-    static <L,R> Either<Seq<L>, Seq<R>> sequence(Iterable<? extends Either<? extends L, ? extends R>> eithers) {
+    public static <L,R> Either<Seq<L>, Seq<R>> sequence(Iterable<? extends Either<? extends L, ? extends R>> eithers) {
         Objects.requireNonNull(eithers, "eithers is null");
         return Iterator.ofAll((Iterable<Either<L, R>>) eithers)
                 .partition(Either::isLeft)
@@ -231,7 +235,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return A {@code Either} of a {@link Seq} of results.
      * @throws NullPointerException if values or f is null.
      */
-    static <L, R, T> Either<Seq<L>, Seq<R>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Either<? extends L, ? extends R>> mapper) {
+    public static <L, R, T> Either<Seq<L>, Seq<R>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Either<? extends L, ? extends R>> mapper) {
         Objects.requireNonNull(values, "values is null");
         Objects.requireNonNull(mapper, "mapper is null");
         return sequence(Iterator.ofAll(values).map(mapper));
@@ -264,7 +268,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return An {@code Either} of either a {@link Seq} of right values or the first left value, if present.
      * @throws NullPointerException if {@code eithers} is null
      */
-    static <L,R> Either<L, Seq<R>> sequenceRight(Iterable<? extends Either<? extends L, ? extends R>> eithers) {
+    public static <L,R> Either<L, Seq<R>> sequenceRight(Iterable<? extends Either<? extends L, ? extends R>> eithers) {
         Objects.requireNonNull(eithers, "eithers is null");
         Vector<R> rightValues = Vector.empty();
         for (Either<? extends L, ? extends R> either : eithers) {
@@ -290,7 +294,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return A {@code Either} of a {@link Seq} of results.
      * @throws NullPointerException if values or f is null.
      */
-    static <L, R, T> Either<L, Seq<R>> traverseRight(Iterable<? extends T> values, Function<? super T, ? extends Either<? extends L, ? extends R>> mapper) {
+    public static <L, R, T> Either<L, Seq<R>> traverseRight(Iterable<? extends T> values, Function<? super T, ? extends Either<? extends L, ? extends R>> mapper) {
         Objects.requireNonNull(values, "values is null");
         Objects.requireNonNull(mapper, "mapper is null");
         return sequenceRight(Iterator.ofAll(values).map(mapper));
@@ -303,7 +307,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return the right value, if the underlying Either is a Right or else the alternative Right value provided by
      * {@code other} by applying the Left value.
      */
-    default R getOrElseGet(Function<? super L, ? extends R> other) {
+    public final R getOrElseGet(Function<? super L, ? extends R> other) {
         Objects.requireNonNull(other, "other is null");
         if (isRight()) {
             return get();
@@ -317,7 +321,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      *
      * @param action an action which consumes a Left value
      */
-    default void orElseRun(Consumer<? super L> action) {
+    public final void orElseRun(Consumer<? super L> action) {
         Objects.requireNonNull(action, "action is null");
         if (isLeft()) {
             action.accept(getLeft());
@@ -333,7 +337,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * {@code exceptionFunction} by applying the Left value.
      * @throws X if the projected Either is a Left
      */
-    default <X extends Throwable> R getOrElseThrow(Function<? super L, X> exceptionFunction) throws X {
+    public final <X extends Throwable> R getOrElseThrow(Function<? super L, X> exceptionFunction) throws X {
         Objects.requireNonNull(exceptionFunction, "exceptionFunction is null");
         if (isRight()) {
             return get();
@@ -347,7 +351,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      *
      * @return a new {@code Either}
      */
-    default Either<R, L> swap() {
+    public final Either<R, L> swap() {
         if (isRight()) {
             return new Left<>(get());
         } else {
@@ -366,7 +370,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @throws NullPointerException if {@code mapper} is null
      */
     @SuppressWarnings("unchecked")
-    default <U> Either<L, U> flatMap(Function<? super R, ? extends Either<L, ? extends U>> mapper) {
+    public final <U> Either<L, U> flatMap(Function<? super R, ? extends Either<L, ? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isRight()) {
             return (Either<L, U>) mapper.apply(get());
@@ -395,7 +399,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      */
     @SuppressWarnings("unchecked")
     @Override
-    default <U> Either<L, U> map(Function<? super R, ? extends U> mapper) {
+    public final <U> Either<L, U> map(Function<? super R, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isRight()) {
             return Either.right(mapper.apply(get()));
@@ -423,7 +427,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @throws NullPointerException if {@code mapper} is null
      */
     @SuppressWarnings("unchecked")
-    default <U> Either<U, R> mapLeft(Function<? super L, ? extends U> leftMapper) {
+    public final <U> Either<U, R> mapLeft(Function<? super L, ? extends U> leftMapper) {
         Objects.requireNonNull(leftMapper, "leftMapper is null");
         if (isLeft()) {
             return Either.left(leftMapper.apply(getLeft()));
@@ -442,7 +446,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return a new {@code Option} instance
      * @throws NullPointerException if {@code predicate} is null
      */
-    default Option<Either<L, R>> filter(Predicate<? super R> predicate) {
+    public final Option<Either<L, R>> filter(Predicate<? super R> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return isLeft() || predicate.test(get()) ? Option.some(this) : Option.none();
     }
@@ -455,7 +459,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @throws NullPointerException if {@code predicate} is null
      *
      */
-    default Option<Either<L, R>> filterNot(Predicate<? super R> predicate) {
+    public final Option<Either<L, R>> filterNot(Predicate<? super R> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filter(predicate.negate());
     }
@@ -481,7 +485,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return an {@code Either} instance
      * @throws NullPointerException if {@code predicate} is null
      */
-    default Either<L,R> filterOrElse(Predicate<? super R> predicate, Function<? super R, ? extends L> zero) {
+    public final Either<L,R> filterOrElse(Predicate<? super R> predicate, Function<? super R, ? extends L> zero) {
         Objects.requireNonNull(predicate, "predicate is null");
         Objects.requireNonNull(zero, "zero is null");
         if (isLeft() || predicate.test(get())) {
@@ -498,21 +502,21 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @throws NoSuchElementException if this is a {@code Left}.
      */
     @Override
-    R get();
+    public abstract R get();
 
     @Override
-    default boolean isEmpty() {
+    public final boolean isEmpty() {
         return isLeft();
     }
 
     @SuppressWarnings("unchecked")
-    default Either<L, R> orElse(Either<? extends L, ? extends R> other) {
+    public final Either<L, R> orElse(Either<? extends L, ? extends R> other) {
         Objects.requireNonNull(other, "other is null");
         return isRight() ? this : (Either<L, R>) other;
     }
 
     @SuppressWarnings("unchecked")
-    default Either<L, R> orElse(Supplier<? extends Either<? extends L, ? extends R>> supplier) {
+    public final Either<L, R> orElse(Supplier<? extends Either<? extends L, ? extends R>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return isRight() ? this : (Either<L, R>) supplier.get();
     }
@@ -523,7 +527,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return false
      */
     @Override
-    default boolean isAsync() {
+    public final boolean isAsync() {
         return false;
     }
 
@@ -533,7 +537,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return false
      */
     @Override
-    default boolean isLazy() {
+    public final boolean isLazy() {
         return false;
     }
 
@@ -543,12 +547,12 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @return {@code true}
      */
     @Override
-    default boolean isSingleValued() {
+    public final boolean isSingleValued() {
         return true;
     }
 
     @Override
-    default Iterator<R> iterator() {
+    public final Iterator<R> iterator() {
         if (isRight()) {
             return Iterator.of(get());
         } else {
@@ -557,7 +561,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
     }
 
     @Override
-    default Either<L, R> peek(Consumer<? super R> action) {
+    public final Either<L, R> peek(Consumer<? super R> action) {
         Objects.requireNonNull(action, "action is null");
         if (isRight()) {
             action.accept(get());
@@ -565,7 +569,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
         return this;
     }
 
-    default Either<L, R> peekLeft(Consumer<? super L> action) {
+    public final Either<L, R> peekLeft(Consumer<? super L> action) {
         Objects.requireNonNull(action, "action is null");
         if (isLeft()) {
             action.accept(getLeft());
@@ -578,20 +582,9 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      *
      * @return {@code Validation.valid(get())} if this is right, otherwise {@code Validation.invalid(getLeft())}.
      */
-    default Validation<L, R> toValidation() {
+    public final Validation<L, R> toValidation() {
         return isRight() ? Validation.valid(get()) : Validation.invalid(getLeft());
     }
-
-    // -- Object.*
-
-    @Override
-    boolean equals(Object o);
-
-    @Override
-    int hashCode();
-
-    @Override
-    String toString();
 
     // -- Left/Right projections
 
@@ -603,7 +596,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @deprecated Either is right-biased. Use {@link #swap()} instead of projections.
      */
     @Deprecated
-    final class LeftProjection<L, R> implements io.vavr.Value<L> {
+    public static final class LeftProjection<L, R> implements io.vavr.Value<L> {
 
         private final Either<L, R> either;
 
@@ -858,7 +851,7 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      * @deprecated Either is right-biased. Use {@link #swap()} instead of projections.
      */
     @Deprecated
-    final class RightProjection<L, R> implements io.vavr.Value<R> {
+    public static final class RightProjection<L, R> implements io.vavr.Value<R> {
 
         private final Either<L, R> either;
 
@@ -1096,8 +1089,10 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      *
      * @param <L> left component type
      * @param <R> right component type
+     * @deprecated will be removed from the public API
      */
-    final class Left<L, R> implements Either<L, R>, Serializable {
+    @Deprecated
+    public static final class Left<L, R> extends Either<L, R> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -1158,8 +1153,10 @@ public interface Either<L, R> extends io.vavr.Iterable<R>, io.vavr.Value<R>, Ser
      *
      * @param <L> left component type
      * @param <R> right component type
+     * @deprecated will be removed from the public API
      */
-    final class Right<L, R> implements Either<L, R>, Serializable {
+    @Deprecated
+    public static final class Right<L, R> extends Either<L, R> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 

--- a/src/main/java/io/vavr/control/Option.java
+++ b/src/main/java/io/vavr/control/Option.java
@@ -47,9 +47,12 @@ import java.util.function.Supplier;
  * @param <T> The type of the optional value.
  */
 @SuppressWarnings("deprecation")
-public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializable {
+public abstract class Option<T> implements io.vavr.Iterable<T>, io.vavr.Value<T>, Serializable {
 
-    long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
+
+    // sealed
+    private Option() {}
 
     /**
      * Creates a new {@code Option} of a given value.
@@ -58,7 +61,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @param <T>   type of the value
      * @return {@code Some(value)} if value is not {@code null}, {@code None} otherwise
      */
-    static <T> Option<T> of(T value) {
+    public static <T> Option<T> of(T value) {
         return (value == null) ? none() : some(value);
     }
 
@@ -72,7 +75,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return An {@code Option} of a {@link Seq} of results
      * @throws NullPointerException if {@code values} is null
      */
-    static <T> Option<Seq<T>> sequence(Iterable<? extends Option<? extends T>> values) {
+    public static <T> Option<Seq<T>> sequence(Iterable<? extends Option<? extends T>> values) {
         Objects.requireNonNull(values, "values is null");
         Vector<T> vector = Vector.empty();
         for (Option<? extends T> value : values) {
@@ -96,7 +99,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return A {@code Option} of a {@link Seq} of results.
      * @throws NullPointerException if values or f is null.
      */
-    static <T, U> Option<Seq<U>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Option<? extends U>> mapper) {
+    public static <T, U> Option<Seq<U>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Option<? extends U>> mapper) {
         Objects.requireNonNull(values, "values is null");
         Objects.requireNonNull(mapper, "mapper is null");
         return sequence(Iterator.ofAll(values).map(mapper));
@@ -117,7 +120,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @param <T>   type of the value
      * @return {@code Some(value)}
      */
-    static <T> Option<T> some(T value) {
+    public static <T> Option<T> some(T value) {
         return new Some<>(value);
     }
 
@@ -127,7 +130,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @param <T> component type
      * @return the single instance of {@code None}
      */
-    static <T> Option<T> none() {
+    public static <T> Option<T> none() {
         @SuppressWarnings("unchecked")
         final None<T> none = (None<T>) None.INSTANCE;
         return none;
@@ -143,7 +146,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return the given {@code option} instance as narrowed type {@code Option<T>}.
      */
     @SuppressWarnings("unchecked")
-    static <T> Option<T> narrow(Option<? extends T> option) {
+    public static <T> Option<T> narrow(Option<? extends T> option) {
         return (Option<T>) option;
     }
 
@@ -156,7 +159,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return return {@code Some} of supplier's value if condition is true, or {@code None} in other case
      * @throws NullPointerException if the given {@code supplier} is null
      */
-    static <T> Option<T> when(boolean condition, Supplier<? extends T> supplier) {
+    public static <T> Option<T> when(boolean condition, Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return condition ? some(supplier.get()) : none();
     }
@@ -169,7 +172,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @param value     An optional value, may be {@code null}
      * @return return {@code Some} of value if condition is true, or {@code None} in other case
      */
-    static <T> Option<T> when(boolean condition, T value) {
+    public static <T> Option<T> when(boolean condition, T value) {
         return condition ? some(value) : none();
     }
 
@@ -181,7 +184,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return {@code Some(optional.get())} if value is Java {@code Optional} is present, {@code None} otherwise
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    static <T> Option<T> ofOptional(Optional<? extends T> optional) {
+    public static <T> Option<T> ofOptional(Optional<? extends T> optional) {
         Objects.requireNonNull(optional, "optional is null");
         return optional.<Option<T>>map(Option::of).orElseGet(Option::none);
     }
@@ -205,7 +208,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return A new {@code Option} instance containing value of type {@code R}
      * @throws NullPointerException if {@code partialFunction} is null
      */
-    default <R> Option<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
+    public final <R> Option<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         Objects.requireNonNull(partialFunction, "partialFunction is null");
         return flatMap(partialFunction.lift()::apply);
     }
@@ -216,7 +219,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return true, if this {@code Option} is empty, false otherwise
      */
     @Override
-    boolean isEmpty();
+    public abstract boolean isEmpty();
 
     /**
      * Runs a Java Runnable passed as parameter if this {@code Option} is empty.
@@ -224,7 +227,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @param action a given Runnable to be run
      * @return this {@code Option}
      */
-    default Option<T> onEmpty(Runnable action) {
+    public final Option<T> onEmpty(Runnable action) {
         Objects.requireNonNull(action, "action is null");
         if (isEmpty()) {
             action.run();
@@ -238,7 +241,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return false
      */
     @Override
-    default boolean isAsync() {
+    public final boolean isAsync() {
         return false;
     }
 
@@ -249,7 +252,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      *
      * @return true, if this {@code Option} has a defined value, false otherwise
      */
-    default boolean isDefined() {
+    public final boolean isDefined() {
         return !isEmpty();
     }
 
@@ -259,7 +262,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return false
      */
     @Override
-    default boolean isLazy() {
+    public final boolean isLazy() {
         return false;
     }
 
@@ -269,7 +272,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return {@code true}
      */
     @Override
-    default boolean isSingleValued() {
+    public final boolean isSingleValued() {
         return true;
     }
 
@@ -280,7 +283,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @throws NoSuchElementException if this is a {@code None}.
      */
     @Override
-    T get();
+    public abstract T get();
 
     /**
      * Returns the value if this is a {@code Some} or the {@code other} value if this is a {@code None}.
@@ -291,7 +294,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return This value, if this Option is defined or the {@code other} value, if this Option is empty.
      */
     @Override
-    default T getOrElse(T other) {
+    public final T getOrElse(T other) {
         return isEmpty() ? other : get();
     }
 
@@ -302,7 +305,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return this {@code Option} if it is nonempty, otherwise return the alternative.
      */
     @SuppressWarnings("unchecked")
-    default Option<T> orElse(Option<? extends T> other) {
+    public final Option<T> orElse(Option<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return isEmpty() ? (Option<T>) other : this;
     }
@@ -314,7 +317,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return this {@code Option} if it is nonempty, otherwise return the result of evaluating supplier.
      */
     @SuppressWarnings("unchecked")
-    default Option<T> orElse(Supplier<? extends Option<? extends T>> supplier) {
+    public final Option<T> orElse(Supplier<? extends Option<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return isEmpty() ? (Option<T>) supplier.get() : this;
     }
@@ -329,7 +332,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return This value, if this Option is defined or the {@code other} value, if this Option is empty.
      */
     @Override
-    default T getOrElse(Supplier<? extends T> supplier) {
+    public final T getOrElse(Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return isEmpty() ? supplier.get() : get();
     }
@@ -343,7 +346,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @throws X a throwable
      */
     @Override
-    default <X extends Throwable> T getOrElseThrow(Supplier<X> exceptionSupplier) throws X {
+    public final <X extends Throwable> T getOrElseThrow(Supplier<X> exceptionSupplier) throws X {
         Objects.requireNonNull(exceptionSupplier, "exceptionSupplier is null");
         if (isEmpty()) {
             throw exceptionSupplier.get();
@@ -359,7 +362,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @param predicate A predicate which is used to test an optional value
      * @return {@code Some(value)} or {@code None} as specified
      */
-    default Option<T> filter(Predicate<? super T> predicate) {
+    public final Option<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return isEmpty() || predicate.test(get()) ? this : none();
     }
@@ -371,7 +374,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @param predicate A predicate which is used to test an optional value
      * @return {@code Some(value)} or {@code None} as specified
      */
-    default Option<T> filterNot(Predicate<? super T> predicate) {
+    public final Option<T> filterNot(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filter(predicate.negate());
     }
@@ -384,7 +387,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return a new {@code Option}
      */
     @SuppressWarnings("unchecked")
-    default <U> Option<U> flatMap(Function<? super T, ? extends Option<? extends U>> mapper) {
+    public final <U> Option<U> flatMap(Function<? super T, ? extends Option<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? none() : (Option<U>) mapper.apply(get());
     }
@@ -397,7 +400,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return a new {@code Some} containing the mapped value if this Option is defined, otherwise {@code None}, if this is empty.
      */
     @Override
-    default <U> Option<U> map(Function<? super T, ? extends U> mapper) {
+    public final <U> Option<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? none() : some(mapper.apply(get()));
     }
@@ -410,7 +413,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @param <U>         type of the folded value
      * @return A value of type U
      */
-    default <U> U fold(Supplier<? extends U> ifNone, Function<? super T, ? extends U> f) {
+    public final <U> U fold(Supplier<? extends U> ifNone, Function<? super T, ? extends U> f) {
         return this.<U>map(f).getOrElse(ifNone);
     }
 
@@ -421,7 +424,7 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return this {@code Option}
      */
     @Override
-    default Option<T> peek(Consumer<? super T> action) {
+    public final Option<T> peek(Consumer<? super T> action) {
         Objects.requireNonNull(action, "action is null");
         if (isDefined()) {
             action.accept(get());
@@ -437,24 +440,15 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * @return An instance of type {@code U}
      * @throws NullPointerException if {@code f} is null
      */
-    default <U> U transform(Function<? super Option<T>, ? extends U> f) {
+    public final <U> U transform(Function<? super Option<T>, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         return f.apply(this);
     }
 
     @Override
-    default Iterator<T> iterator() {
+    public final Iterator<T> iterator() {
         return isEmpty() ? Iterator.empty() : Iterator.of(get());
     }
-
-    @Override
-    boolean equals(Object o);
-
-    @Override
-    int hashCode();
-
-    @Override
-    String toString();
 
     /**
      * Some represents a defined {@link Option}. It contains a value which may be null. However, to
@@ -462,8 +456,10 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * {@link Option#of(Object)} is sufficient.
      *
      * @param <T> The type of the optional value.
+     * @deprecated will be removed from the public API
      */
-    final class Some<T> implements Option<T>, Serializable {
+    @Deprecated
+    public static final class Some<T> extends Option<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -513,8 +509,10 @@ public interface Option<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serial
      * None is a singleton representation of the undefined {@link Option}.
      *
      * @param <T> The type of the optional value.
+     * @deprecated will be removed from the public API
      */
-    final class None<T> implements Option<T>, Serializable {
+    @Deprecated
+    public static final class None<T> extends Option<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 

--- a/src/main/java/io/vavr/control/Try.java
+++ b/src/main/java/io/vavr/control/Try.java
@@ -54,9 +54,13 @@ import static io.vavr.control.TryModule.sneakyThrow;
  * @param <T> Value type in the case of success.
  */
 @SuppressWarnings("deprecation")
-public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializable {
+public abstract class Try<T> implements io.vavr.Iterable<T>, io.vavr.Value<T>, Serializable {
 
-    long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
+
+    // sealed
+    private Try() {
+    }
 
     /**
      * Creates a Try of a CheckedFunction0.
@@ -66,7 +70,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return {@code Success(supplier.apply())} if no exception occurs, otherwise {@code Failure(throwable)} if an
      * exception occurs calling {@code supplier.apply()}.
      */
-    static <T> Try<T> of(CheckedFunction0<? extends T> supplier) {
+    public static <T> Try<T> of(CheckedFunction0<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         try {
             return new Success<>(supplier.apply());
@@ -84,7 +88,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return {@code Success(supplier.get())} if no exception occurs, otherwise {@code Failure(throwable)} if an
      * exception occurs calling {@code supplier.get()}.
      */
-    static <T> Try<T> ofSupplier(Supplier<? extends T> supplier) {
+    public static <T> Try<T> ofSupplier(Supplier<? extends T> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return of(supplier::get);
     }
@@ -97,7 +101,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return {@code Success(callable.call())} if no exception occurs, otherwise {@code Failure(throwable)} if an
      * exception occurs calling {@code callable.call()}.
      */
-    static <T> Try<T> ofCallable(Callable<? extends T> callable) {
+    public static <T> Try<T> ofCallable(Callable<? extends T> callable) {
         Objects.requireNonNull(callable, "callable is null");
         return of(callable::call);
     }
@@ -109,7 +113,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return {@code Success(null)} if no exception occurs, otherwise {@code Failure(throwable)} if an exception occurs
      * calling {@code runnable.run()}.
      */
-    static Try<Void> run(CheckedRunnable runnable) {
+    public static Try<Void> run(CheckedRunnable runnable) {
         Objects.requireNonNull(runnable, "runnable is null");
         try {
             runnable.run();
@@ -126,7 +130,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return {@code Success(null)} if no exception occurs, otherwise {@code Failure(throwable)} if an exception occurs
      * calling {@code runnable.run()}.
      */
-    static Try<Void> runRunnable(Runnable runnable) {
+    public static Try<Void> runRunnable(Runnable runnable) {
         Objects.requireNonNull(runnable, "runnable is null");
         return run(runnable::run);
     }
@@ -141,7 +145,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return A {@code Try} of a {@link Seq} of results
      * @throws NullPointerException if {@code values} is null
      */
-    static <T> Try<Seq<T>> sequence(Iterable<? extends Try<? extends T>> values) {
+    public static <T> Try<Seq<T>> sequence(Iterable<? extends Try<? extends T>> values) {
         Objects.requireNonNull(values, "values is null");
         Vector<T> vector = Vector.empty();
         for (Try<? extends T> value : values) {
@@ -165,7 +169,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return A {@code Try} of a {@link Seq} of results.
      * @throws NullPointerException if values or f is null.
      */
-    static <T, U> Try<Seq<U>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Try<? extends U>> mapper) {
+    public static <T, U> Try<Seq<U>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Try<? extends U>> mapper) {
         Objects.requireNonNull(values, "values is null");
         Objects.requireNonNull(mapper, "mapper is null");
         return sequence(Iterator.ofAll(values).map(mapper));
@@ -178,7 +182,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T>   Type of the given {@code value}.
      * @return A new {@code Success}.
      */
-    static <T> Try<T> success(T value) {
+    public static <T> Try<T> success(T value) {
         return new Success<>(value);
     }
 
@@ -189,7 +193,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T>       Component type of the {@code Try}.
      * @return A new {@code Failure}.
      */
-    static <T> Try<T> failure(Throwable exception) {
+    public static <T> Try<T> failure(Throwable exception) {
         return new Failure<>(exception);
     }
 
@@ -203,7 +207,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return the given {@code t} instance as narrowed type {@code Try<T>}.
      */
     @SuppressWarnings("unchecked")
-    static <T> Try<T> narrow(Try<? extends T> t) {
+    public static <T> Try<T> narrow(Try<? extends T> t) {
         return (Try<T>) t;
     }
 
@@ -215,7 +219,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * {@code Failure} of the consumption.
      * @throws NullPointerException if {@code consumer} is null
      */
-    default Try<T> andThen(Consumer<? super T> consumer) {
+    public final Try<T> andThen(Consumer<? super T> consumer) {
         Objects.requireNonNull(consumer, "consumer is null");
         return andThenTry(consumer::accept);
     }
@@ -238,7 +242,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * {@code Failure} of the consumption.
      * @throws NullPointerException if {@code consumer} is null
      */
-    default Try<T> andThenTry(CheckedConsumer<? super T> consumer) {
+    public final Try<T> andThenTry(CheckedConsumer<? super T> consumer) {
         Objects.requireNonNull(consumer, "consumer is null");
         if (isFailure()) {
             return this;
@@ -260,7 +264,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * {@code Failure} of the run.
      * @throws NullPointerException if {@code runnable} is null
      */
-    default Try<T> andThen(Runnable runnable) {
+    public final Try<T> andThen(Runnable runnable) {
         Objects.requireNonNull(runnable, "runnable is null");
         return andThenTry(runnable::run);
     }
@@ -297,7 +301,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * {@code Failure} of the run.
      * @throws NullPointerException if {@code runnable} is null
      */
-    default Try<T> andThenTry(CheckedRunnable runnable) {
+    public final Try<T> andThenTry(CheckedRunnable runnable) {
         Objects.requireNonNull(runnable, "runnable is null");
         if (isFailure()) {
             return this;
@@ -331,7 +335,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @throws NullPointerException if {@code partialFunction} is null
      */
     @SuppressWarnings("unchecked")
-    default <R> Try<R> collect(PartialFunction<? super T, ? extends R> partialFunction){
+    public final <R> Try<R> collect(PartialFunction<? super T, ? extends R> partialFunction){
         Objects.requireNonNull(partialFunction, "partialFunction is null");
         return filter(partialFunction::isDefinedAt).map(partialFunction::apply);
     }
@@ -342,7 +346,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      *
      * @return a new Try
      */
-    default Try<Throwable> failed() {
+    public final Try<Throwable> failed() {
         if (isFailure()) {
             return new Success<>(getCause());
         } else {
@@ -359,7 +363,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try} instance
      * @throws NullPointerException if {@code predicate} or {@code throwableSupplier} is null
      */
-    default Try<T> filter(Predicate<? super T> predicate, Supplier<? extends Throwable> throwableSupplier) {
+    public final Try<T> filter(Predicate<? super T> predicate, Supplier<? extends Throwable> throwableSupplier) {
         Objects.requireNonNull(predicate, "predicate is null");
         Objects.requireNonNull(throwableSupplier, "throwableSupplier is null");
         return filterTry(predicate::test, throwableSupplier);
@@ -374,7 +378,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try} instance
      * @throws NullPointerException if {@code predicate} or {@code errorProvider} is null
      */
-    default Try<T> filter(Predicate<? super T> predicate, Function<? super T, ? extends Throwable> errorProvider) {
+    public final Try<T> filter(Predicate<? super T> predicate, Function<? super T, ? extends Throwable> errorProvider) {
         Objects.requireNonNull(predicate, "predicate is null");
         Objects.requireNonNull(errorProvider, "errorProvider is null");
         return filterTry(predicate::test, errorProvider::apply);
@@ -387,7 +391,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try} instance
      * @throws NullPointerException if {@code predicate} is null
      */
-    default Try<T> filter(Predicate<? super T> predicate) {
+    public final Try<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filterTry(predicate::test);
     }
@@ -400,7 +404,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try} instance
      * @throws NullPointerException if {@code predicate} or {@code throwableSupplier} is null
      */
-    default Try<T> filterNot(Predicate<? super T> predicate, Supplier<? extends Throwable> throwableSupplier) {
+    public final Try<T> filterNot(Predicate<? super T> predicate, Supplier<? extends Throwable> throwableSupplier) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filter(predicate.negate(), throwableSupplier);
     }
@@ -414,7 +418,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try} instance
      * @throws NullPointerException if {@code predicate} or {@code errorProvider} is null
      */
-    default Try<T> filterNot(Predicate<? super T> predicate, Function<? super T, ? extends Throwable> errorProvider) {
+    public final Try<T> filterNot(Predicate<? super T> predicate, Function<? super T, ? extends Throwable> errorProvider) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filter(predicate.negate(), errorProvider);
     }
@@ -427,7 +431,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try} instance
      * @throws NullPointerException if {@code predicate} is null
      */
-    default Try<T> filterNot(Predicate<? super T> predicate) {
+    public final Try<T> filterNot(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filter(predicate.negate());
     }
@@ -444,7 +448,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try} instance
      * @throws NullPointerException if {@code predicate} or {@code throwableSupplier} is null
      */
-    default Try<T> filterTry(CheckedPredicate<? super T> predicate, Supplier<? extends Throwable> throwableSupplier) {
+    public final Try<T> filterTry(CheckedPredicate<? super T> predicate, Supplier<? extends Throwable> throwableSupplier) {
         Objects.requireNonNull(predicate, "predicate is null");
         Objects.requireNonNull(throwableSupplier, "throwableSupplier is null");
 
@@ -475,7 +479,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try} instance
      * @throws NullPointerException if {@code predicate} or {@code errorProvider} is null
      */
-    default Try<T> filterTry(CheckedPredicate<? super T> predicate, CheckedFunction1<? super T, ? extends Throwable> errorProvider) {
+    public final Try<T> filterTry(CheckedPredicate<? super T> predicate, CheckedFunction1<? super T, ? extends Throwable> errorProvider) {
         Objects.requireNonNull(predicate, "predicate is null");
         Objects.requireNonNull(errorProvider, "errorProvider is null");
         return flatMapTry(t -> predicate.test(t) ? this : failure(errorProvider.apply(t)));
@@ -491,7 +495,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try} instance
      * @throws NullPointerException if {@code predicate} is null
      */
-    default Try<T> filterTry(CheckedPredicate<? super T> predicate) {
+    public final Try<T> filterTry(CheckedPredicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return filterTry(predicate, () -> new NoSuchElementException("Predicate does not hold for " + get()));
     }
@@ -504,7 +508,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try}
      * @throws NullPointerException if {@code mapper} is null
      */
-    default <U> Try<U> flatMap(Function<? super T, ? extends Try<? extends U>> mapper) {
+    public final <U> Try<U> flatMap(Function<? super T, ? extends Try<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return flatMapTry((CheckedFunction1<T, Try<? extends U>>) mapper::apply);
     }
@@ -518,7 +522,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @throws NullPointerException if {@code mapper} is null
      */
     @SuppressWarnings("unchecked")
-    default <U> Try<U> flatMapTry(CheckedFunction1<? super T, ? extends Try<? extends U>> mapper) {
+    public final <U> Try<U> flatMapTry(CheckedFunction1<? super T, ? extends Try<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isFailure()) {
             return (Failure<U>) this;
@@ -541,7 +545,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return The result of this {@code Try}.
      */
     @Override
-    T get();
+    public abstract T get();
 
     /**
      * Gets the cause if this is a Failure or throws if this is a Success.
@@ -549,7 +553,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return The cause if this is a Failure
      * @throws UnsupportedOperationException if this is a Success
      */
-    Throwable getCause();
+    public abstract Throwable getCause();
 
     /**
      * A {@code Try}'s value is computed synchronously.
@@ -557,7 +561,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return false
      */
     @Override
-    default boolean isAsync() {
+    public final boolean isAsync() {
         return false;
     }
 
@@ -567,14 +571,14 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return true if this is a Failure, returns false if this is a Success.
      */
     @Override
-    boolean isEmpty();
+    public abstract boolean isEmpty();
 
     /**
      * Checks if this is a Failure.
      *
      * @return true, if this is a Failure, otherwise false, if this is a Success
      */
-    boolean isFailure();
+    public abstract boolean isFailure();
 
     /**
      * A {@code Try}'s value is computed eagerly.
@@ -582,7 +586,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return false
      */
     @Override
-    default boolean isLazy() {
+    public final boolean isLazy() {
         return false;
     }
 
@@ -592,7 +596,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return {@code true}
      */
     @Override
-    default boolean isSingleValued() {
+    public final boolean isSingleValued() {
         return true;
     }
 
@@ -601,10 +605,10 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      *
      * @return true, if this is a Success, otherwise false, if this is a Failure
      */
-    boolean isSuccess();
+    public abstract boolean isSuccess();
 
     @Override
-    default Iterator<T> iterator() {
+    public final Iterator<T> iterator() {
         return isSuccess() ? Iterator.of(get()) : Iterator.empty();
     }
 
@@ -617,7 +621,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @throws NullPointerException if {@code mapper} is null
      */
     @Override
-    default <U> Try<U> map(Function<? super T, ? extends U> mapper) {
+    public final <U> Try<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return mapTry(mapper::apply);
     }
@@ -632,7 +636,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      */
     @GwtIncompatible
     @SuppressWarnings({ "unchecked", "varargs" })
-    default Try<T> mapFailure(Match.Case<? extends Throwable, ? extends Throwable>... cases) {
+    public final Try<T> mapFailure(Match.Case<? extends Throwable, ? extends Throwable>... cases) {
         if (isSuccess()) {
             return this;
         } else {
@@ -662,7 +666,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @throws NullPointerException if {@code mapper} is null
      */
     @SuppressWarnings("unchecked")
-    default <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
+    public final <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         if (isFailure()) {
             return (Failure<U>) this;
@@ -690,7 +694,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return this
      * @throws NullPointerException if {@code action} is null
      */
-    default Try<T> onFailure(Consumer<? super Throwable> action) {
+    public final Try<T> onFailure(Consumer<? super Throwable> action) {
         Objects.requireNonNull(action, "action is null");
         if (isFailure()) {
             action.accept(getCause());
@@ -719,7 +723,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      */
     @GwtIncompatible
     @SuppressWarnings("unchecked")
-    default <X extends Throwable> Try<T> onFailure(Class<X> exceptionType, Consumer<? super X> action) {
+    public final <X extends Throwable> Try<T> onFailure(Class<X> exceptionType, Consumer<? super X> action) {
         Objects.requireNonNull(exceptionType, "exceptionType is null");
         Objects.requireNonNull(action, "action is null");
         if (isFailure() && exceptionType.isAssignableFrom(getCause().getClass())) {
@@ -743,7 +747,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return this
      * @throws NullPointerException if {@code action} is null
      */
-    default Try<T> onSuccess(Consumer<? super T> action) {
+    public final Try<T> onSuccess(Consumer<? super T> action) {
         Objects.requireNonNull(action, "action is null");
         if (isSuccess()) {
             action.accept(get());
@@ -752,18 +756,18 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
     }
 
     @SuppressWarnings("unchecked")
-    default Try<T> orElse(Try<? extends T> other) {
+    public final Try<T> orElse(Try<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return isSuccess() ? this : (Try<T>) other;
     }
 
     @SuppressWarnings("unchecked")
-    default Try<T> orElse(Supplier<? extends Try<? extends T>> supplier) {
+    public final Try<T> orElse(Supplier<? extends Try<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return isSuccess() ? this : (Try<T>) supplier.get();
     }
 
-    default T getOrElseGet(Function<? super Throwable, ? extends T> other) {
+    public final T getOrElseGet(Function<? super Throwable, ? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         if (isFailure()) {
             return other.apply(getCause());
@@ -772,14 +776,14 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
         }
     }
 
-    default void orElseRun(Consumer<? super Throwable> action) {
+    public final void orElseRun(Consumer<? super Throwable> action) {
         Objects.requireNonNull(action, "action is null");
         if (isFailure()) {
             action.accept(getCause());
         }
     }
 
-    default <X extends Throwable> T getOrElseThrow(Function<? super Throwable, X> exceptionProvider) throws X {
+    public final <X extends Throwable> T getOrElseThrow(Function<? super Throwable, X> exceptionProvider) throws X {
         Objects.requireNonNull(exceptionProvider, "exceptionProvider is null");
         if (isFailure()) {
             throw exceptionProvider.apply(getCause());
@@ -796,7 +800,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <X>         type of the folded value
      * @return A value of type X
      */
-    default <X> X fold(Function<? super Throwable, ? extends X> ifFail, Function<? super T, ? extends X> f) {
+    public final <X> X fold(Function<? super Throwable, ? extends X> ifFail, Function<? super T, ? extends X> f) {
         if (isFailure()) {
             return ifFail.apply(getCause());
         } else {
@@ -812,7 +816,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @throws NullPointerException if {@code action} is null
      */
     @Override
-    default Try<T> peek(Consumer<? super T> action) {
+    public final Try<T> peek(Consumer<? super T> action) {
         Objects.requireNonNull(action, "action is null");
         if (isSuccess()) {
             action.accept(get());
@@ -846,7 +850,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      */
     @GwtIncompatible
     @SuppressWarnings("unchecked")
-    default <X extends Throwable> Try<T> recover(Class<X> exceptionType, Function<? super X, ? extends T> f) {
+    public final <X extends Throwable> Try<T> recover(Class<X> exceptionType, Function<? super X, ? extends T> f) {
         Objects.requireNonNull(exceptionType, "exceptionType is null");
         Objects.requireNonNull(f, "f is null");
         if (isFailure()) {
@@ -885,7 +889,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      */
     @GwtIncompatible
     @SuppressWarnings("unchecked")
-    default <X extends Throwable> Try<T> recoverWith(Class<X> exceptionType, Function<? super X, Try<? extends T>> f){
+    public final <X extends Throwable> Try<T> recoverWith(Class<X> exceptionType, Function<? super X, Try<? extends T>> f){
         Objects.requireNonNull(exceptionType, "exceptionType is null");
         Objects.requireNonNull(f, "f is null");
         if(isFailure()){
@@ -925,7 +929,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @throws NullPointerException if {@code exceptionType} or {@code recovered} is null
      */
     @GwtIncompatible
-    default <X extends Throwable> Try<T> recoverWith(Class<X> exceptionType,  Try<? extends T> recovered){
+    public final <X extends Throwable> Try<T> recoverWith(Class<X> exceptionType,  Try<? extends T> recovered){
         Objects.requireNonNull(exceptionType, "exeptionType is null");
         Objects.requireNonNull(recovered, "recovered is null");
         return (isFailure() && exceptionType.isAssignableFrom(getCause().getClass()))
@@ -957,7 +961,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @throws NullPointerException if {@code exception} is null
      */
     @GwtIncompatible
-    default <X extends Throwable> Try<T> recover(Class<X> exceptionType, T value) {
+    public final <X extends Throwable> Try<T> recover(Class<X> exceptionType, T value) {
         Objects.requireNonNull(exceptionType, "exceptionType is null");
         return (isFailure() && exceptionType.isAssignableFrom(getCause().getClass()))
                ? Try.success(value)
@@ -980,7 +984,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return a {@code Try}
      * @throws NullPointerException if {@code f} is null
      */
-    default Try<T> recover(Function<? super Throwable, ? extends T> f) {
+    public final Try<T> recover(Function<? super Throwable, ? extends T> f) {
         Objects.requireNonNull(f, "f is null");
         if (isFailure()) {
             return Try.of(() -> f.apply(getCause()));
@@ -1007,7 +1011,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @throws NullPointerException if {@code f} is null
      */
     @SuppressWarnings("unchecked")
-    default Try<T> recoverWith(Function<? super Throwable, ? extends Try<? extends T>> f) {
+    public final Try<T> recoverWith(Function<? super Throwable, ? extends Try<? extends T>> f) {
         Objects.requireNonNull(f, "f is null");
         if (isFailure()) {
             try {
@@ -1025,7 +1029,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      *
      * @return A new {@code Either}
      */
-    default Either<Throwable, T> toEither() {
+    public final Either<Throwable, T> toEither() {
         if (isFailure()) {
             return Either.left(getCause());
         } else {
@@ -1038,7 +1042,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      *
      * @return A new {@code Validation}
      */
-    default Validation<Throwable, T> toValidation() {
+    public final Validation<Throwable, T> toValidation() {
         return toValidation(Function.identity());
     }
 
@@ -1055,7 +1059,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return A new {@code Validation}
      * @throws NullPointerException if the given {@code throwableMapper} is null.
      */
-    default <U> Validation<U, T> toValidation(Function<? super Throwable, ? extends U> throwableMapper) {
+    public final <U> Validation<U, T> toValidation(Function<? super Throwable, ? extends U> throwableMapper) {
         Objects.requireNonNull(throwableMapper, "throwableMapper is null");
         if (isFailure()) {
             return Validation.invalid(throwableMapper.apply(getCause()));
@@ -1072,7 +1076,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return An instance of type {@code U}
      * @throws NullPointerException if {@code f} is null
      */
-    default <U> U transform(Function<? super Try<T>, ? extends U> f) {
+    public final <U> U transform(Function<? super Try<T>, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         return f.apply(this);
     }
@@ -1084,7 +1088,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return this {@code Try}.
      * @throws NullPointerException if {@code runnable} is null
      */
-    default Try<T> andFinally(Runnable runnable) {
+    public final Try<T> andFinally(Runnable runnable) {
         Objects.requireNonNull(runnable, "runnable is null");
         return andFinallyTry(runnable::run);
     }
@@ -1096,7 +1100,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @return this {@code Try}.
      * @throws NullPointerException if {@code runnable} is null
      */
-    default Try<T> andFinallyTry(CheckedRunnable runnable) {
+    public final Try<T> andFinallyTry(CheckedRunnable runnable) {
         Objects.requireNonNull(runnable, "runnable is null");
         try {
             runnable.run();
@@ -1106,21 +1110,14 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
         }
     }
 
-    @Override
-    boolean equals(Object o);
-
-    @Override
-    int hashCode();
-
-    @Override
-    String toString();
-
     /**
      * A succeeded Try.
      *
      * @param <T> component type of this Success
+     * @deprecated will be removed from the public API
      */
-    final class Success<T> implements Try<T>, Serializable {
+    @Deprecated
+    public static final class Success<T> extends Try<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -1185,8 +1182,10 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * A failed Try.
      *
      * @param <T> component type of this Failure
+     * @deprecated will be removed from the public API
      */
-    final class Failure<T> implements Try<T>, Serializable {
+    @Deprecated
+    public static final class Failure<T> extends Try<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -1263,7 +1262,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T1> Type of the 1st resource.
      * @return a new {@link WithResources1} instance.
      */
-    static <T1 extends AutoCloseable> WithResources1<T1> withResources(CheckedFunction0<? extends T1> t1Supplier) {
+    public static <T1 extends AutoCloseable> WithResources1<T1> withResources(CheckedFunction0<? extends T1> t1Supplier) {
         return new WithResources1<>(t1Supplier);
     }
 
@@ -1276,7 +1275,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T2> Type of the 2nd resource.
      * @return a new {@link WithResources2} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable> WithResources2<T1, T2> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier) {
+    public static <T1 extends AutoCloseable, T2 extends AutoCloseable> WithResources2<T1, T2> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier) {
         return new WithResources2<>(t1Supplier, t2Supplier);
     }
 
@@ -1291,7 +1290,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T3> Type of the 3rd resource.
      * @return a new {@link WithResources3} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable> WithResources3<T1, T2, T3> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier) {
+    public static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable> WithResources3<T1, T2, T3> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier) {
         return new WithResources3<>(t1Supplier, t2Supplier, t3Supplier);
     }
 
@@ -1308,7 +1307,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T4> Type of the 4th resource.
      * @return a new {@link WithResources4} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable> WithResources4<T1, T2, T3, T4> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier) {
+    public static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable> WithResources4<T1, T2, T3, T4> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier) {
         return new WithResources4<>(t1Supplier, t2Supplier, t3Supplier, t4Supplier);
     }
 
@@ -1327,7 +1326,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T5> Type of the 5th resource.
      * @return a new {@link WithResources5} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable> WithResources5<T1, T2, T3, T4, T5> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier) {
+    public static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable> WithResources5<T1, T2, T3, T4, T5> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier) {
         return new WithResources5<>(t1Supplier, t2Supplier, t3Supplier, t4Supplier, t5Supplier);
     }
 
@@ -1348,7 +1347,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T6> Type of the 6th resource.
      * @return a new {@link WithResources6} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable> WithResources6<T1, T2, T3, T4, T5, T6> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier) {
+    public static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable> WithResources6<T1, T2, T3, T4, T5, T6> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier) {
         return new WithResources6<>(t1Supplier, t2Supplier, t3Supplier, t4Supplier, t5Supplier, t6Supplier);
     }
 
@@ -1371,7 +1370,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T7> Type of the 7th resource.
      * @return a new {@link WithResources7} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable> WithResources7<T1, T2, T3, T4, T5, T6, T7> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier, CheckedFunction0<? extends T7> t7Supplier) {
+    public static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable> WithResources7<T1, T2, T3, T4, T5, T6, T7> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier, CheckedFunction0<? extends T7> t7Supplier) {
         return new WithResources7<>(t1Supplier, t2Supplier, t3Supplier, t4Supplier, t5Supplier, t6Supplier, t7Supplier);
     }
 
@@ -1396,7 +1395,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T8> Type of the 8th resource.
      * @return a new {@link WithResources8} instance.
      */
-    static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable, T8 extends AutoCloseable> WithResources8<T1, T2, T3, T4, T5, T6, T7, T8> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier, CheckedFunction0<? extends T7> t7Supplier, CheckedFunction0<? extends T8> t8Supplier) {
+    public static <T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable, T8 extends AutoCloseable> WithResources8<T1, T2, T3, T4, T5, T6, T7, T8> withResources(CheckedFunction0<? extends T1> t1Supplier, CheckedFunction0<? extends T2> t2Supplier, CheckedFunction0<? extends T3> t3Supplier, CheckedFunction0<? extends T4> t4Supplier, CheckedFunction0<? extends T5> t5Supplier, CheckedFunction0<? extends T6> t6Supplier, CheckedFunction0<? extends T7> t7Supplier, CheckedFunction0<? extends T8> t8Supplier) {
         return new WithResources8<>(t1Supplier, t2Supplier, t3Supplier, t4Supplier, t5Supplier, t6Supplier, t7Supplier, t8Supplier);
     }
 
@@ -1405,7 +1404,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      *
      * @param <T1> Type of the 1st resource.
      */
-    final class WithResources1<T1 extends AutoCloseable> {
+    public static final class WithResources1<T1 extends AutoCloseable> {
 
         private final CheckedFunction0<? extends T1> t1Supplier;
 
@@ -1436,7 +1435,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T1> Type of the 1st resource.
      * @param <T2> Type of the 2nd resource.
      */
-    final class WithResources2<T1 extends AutoCloseable, T2 extends AutoCloseable> {
+    public static final class WithResources2<T1 extends AutoCloseable, T2 extends AutoCloseable> {
 
         private final CheckedFunction0<? extends T1> t1Supplier;
         private final CheckedFunction0<? extends T2> t2Supplier;
@@ -1470,7 +1469,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T2> Type of the 2nd resource.
      * @param <T3> Type of the 3rd resource.
      */
-    final class WithResources3<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable> {
+    public static final class WithResources3<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable> {
 
         private final CheckedFunction0<? extends T1> t1Supplier;
         private final CheckedFunction0<? extends T2> t2Supplier;
@@ -1507,7 +1506,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T3> Type of the 3rd resource.
      * @param <T4> Type of the 4th resource.
      */
-    final class WithResources4<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable> {
+    public static final class WithResources4<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable> {
 
         private final CheckedFunction0<? extends T1> t1Supplier;
         private final CheckedFunction0<? extends T2> t2Supplier;
@@ -1547,7 +1546,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T4> Type of the 4th resource.
      * @param <T5> Type of the 5th resource.
      */
-    final class WithResources5<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable> {
+    public static final class WithResources5<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable> {
 
         private final CheckedFunction0<? extends T1> t1Supplier;
         private final CheckedFunction0<? extends T2> t2Supplier;
@@ -1590,7 +1589,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T5> Type of the 5th resource.
      * @param <T6> Type of the 6th resource.
      */
-    final class WithResources6<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable> {
+    public static final class WithResources6<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable> {
 
         private final CheckedFunction0<? extends T1> t1Supplier;
         private final CheckedFunction0<? extends T2> t2Supplier;
@@ -1636,7 +1635,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T6> Type of the 6th resource.
      * @param <T7> Type of the 7th resource.
      */
-    final class WithResources7<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable> {
+    public static final class WithResources7<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable> {
 
         private final CheckedFunction0<? extends T1> t1Supplier;
         private final CheckedFunction0<? extends T2> t2Supplier;
@@ -1685,7 +1684,7 @@ public interface Try<T> extends io.vavr.Iterable<T>, io.vavr.Value<T>, Serializa
      * @param <T7> Type of the 7th resource.
      * @param <T8> Type of the 8th resource.
      */
-    final class WithResources8<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable, T8 extends AutoCloseable> {
+    public static final class WithResources8<T1 extends AutoCloseable, T2 extends AutoCloseable, T3 extends AutoCloseable, T4 extends AutoCloseable, T5 extends AutoCloseable, T6 extends AutoCloseable, T7 extends AutoCloseable, T8 extends AutoCloseable> {
 
         private final CheckedFunction0<? extends T1> t1Supplier;
         private final CheckedFunction0<? extends T2> t2Supplier;

--- a/src/main/java/io/vavr/control/Validation.java
+++ b/src/main/java/io/vavr/control/Validation.java
@@ -74,9 +74,13 @@ import java.util.function.Supplier;
  * @see <a href="https://github.com/scalaz/scalaz/blob/series/7.3.x/core/src/main/scala/scalaz/Validation.scala">Validation</a>
  */
 @SuppressWarnings("deprecation")
-public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Serializable {
+public abstract class Validation<E, T> implements io.vavr.Iterable<T>, Value<T>, Serializable {
 
-    long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
+
+    // sealed
+    private Validation() {
+    }
 
     /**
      * Creates a {@link Valid} that contains the given {@code value}.
@@ -86,7 +90,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @param value A value
      * @return {@code Valid(value)}
      */
-    static <E, T> Validation<E, T> valid(T value) {
+    public static <E, T> Validation<E, T> valid(T value) {
         return new Valid<>(value);
     }
 
@@ -99,7 +103,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return {@code Invalid(error)}
      * @throws NullPointerException if error is null
      */
-    static <E, T> Validation<E, T> invalid(E error) {
+    public static <E, T> Validation<E, T> invalid(E error) {
         Objects.requireNonNull(error, "error is null");
         return new Invalid<>(error);
     }
@@ -113,7 +117,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return A {@code Valid(either.get())} if either is a Right, otherwise {@code Invalid(either.getLeft())}.
      * @throws NullPointerException if either is null
      */
-    static <E, T> Validation<E, T> fromEither(Either<E, T> either) {
+    public static <E, T> Validation<E, T> fromEither(Either<E, T> either) {
         Objects.requireNonNull(either, "either is null");
         return either.isRight() ? valid(either.get()) : invalid(either.getLeft());
     }
@@ -126,7 +130,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return A {@code Valid(t.get())} if t is a Success, otherwise {@code Invalid(t.getCause())}.
      * @throws NullPointerException if {@code t} is null
      */
-    static <T> Validation<Throwable, T> fromTry(Try<? extends T> t) {
+    public static <T> Validation<Throwable, T> fromTry(Try<? extends T> t) {
         Objects.requireNonNull(t, "t is null");
         return t.isSuccess() ? valid(t.get()) : invalid(t.getCause());
     }
@@ -143,7 +147,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * or an invalid Validation containing an accumulated List of errors.
      * @throws NullPointerException if values is null
      */
-    static <E, T> Validation<Seq<E>, Seq<T>> sequence(Iterable<? extends Validation<? extends Seq<? extends E>, ? extends T>> values) {
+    public static <E, T> Validation<Seq<E>, Seq<T>> sequence(Iterable<? extends Validation<? extends Seq<? extends E>, ? extends T>> values) {
         Objects.requireNonNull(values, "values is null");
         List<E> errors = List.empty();
         List<T> list = List.empty();
@@ -170,7 +174,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return A {@code Validation} of a {@link Seq} of results.
      * @throws NullPointerException if values or f is null.
      */
-    static <E, T, U> Validation<Seq<E>, Seq<U>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Validation<? extends Seq<? extends E>, ? extends U>> mapper) {
+    public static <E, T, U> Validation<Seq<E>, Seq<U>> traverse(Iterable<? extends T> values, Function<? super T, ? extends Validation<? extends Seq<? extends E>, ? extends U>> mapper) {
         Objects.requireNonNull(values, "values is null");
         Objects.requireNonNull(mapper, "mapper is null");
         return sequence(Iterator.ofAll(values).map(mapper));
@@ -187,7 +191,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return the given {@code validation} instance as narrowed type {@code Validation<E, T>}.
      */
     @SuppressWarnings("unchecked")
-    static <E, T> Validation<E, T> narrow(Validation<? extends E, ? extends T> validation) {
+    public static <E, T> Validation<E, T> narrow(Validation<? extends E, ? extends T> validation) {
         return (Validation<E, T>) validation;
     }
 
@@ -202,7 +206,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return an instance of Builder&lt;E,T1,T2&gt;
      * @throws NullPointerException if validation1 or validation2 is null
      */
-    static <E, T1, T2> Builder<E, T1, T2> combine(Validation<E, T1> validation1, Validation<E, T2> validation2) {
+    public static <E, T1, T2> Builder<E, T1, T2> combine(Validation<E, T1> validation1, Validation<E, T2> validation2) {
         Objects.requireNonNull(validation1, "validation1 is null");
         Objects.requireNonNull(validation2, "validation2 is null");
         return new Builder<>(validation1, validation2);
@@ -221,7 +225,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return an instance of Builder3&lt;E,T1,T2,T3&gt;
      * @throws NullPointerException if validation1, validation2 or validation3 is null
      */
-    static <E, T1, T2, T3> Builder3<E, T1, T2, T3> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3) {
+    public static <E, T1, T2, T3> Builder3<E, T1, T2, T3> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3) {
         Objects.requireNonNull(validation1, "validation1 is null");
         Objects.requireNonNull(validation2, "validation2 is null");
         Objects.requireNonNull(validation3, "validation3 is null");
@@ -243,7 +247,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return an instance of Builder3&lt;E,T1,T2,T3,T4&gt;
      * @throws NullPointerException if validation1, validation2, validation3 or validation4 is null
      */
-    static <E, T1, T2, T3, T4> Builder4<E, T1, T2, T3, T4> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4) {
+    public static <E, T1, T2, T3, T4> Builder4<E, T1, T2, T3, T4> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4) {
         Objects.requireNonNull(validation1, "validation1 is null");
         Objects.requireNonNull(validation2, "validation2 is null");
         Objects.requireNonNull(validation3, "validation3 is null");
@@ -268,7 +272,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return an instance of Builder3&lt;E,T1,T2,T3,T4,T5&gt;
      * @throws NullPointerException if validation1, validation2, validation3, validation4 or validation5 is null
      */
-    static <E, T1, T2, T3, T4, T5> Builder5<E, T1, T2, T3, T4, T5> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4, Validation<E, T5> validation5) {
+    public static <E, T1, T2, T3, T4, T5> Builder5<E, T1, T2, T3, T4, T5> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4, Validation<E, T5> validation5) {
         Objects.requireNonNull(validation1, "validation1 is null");
         Objects.requireNonNull(validation2, "validation2 is null");
         Objects.requireNonNull(validation3, "validation3 is null");
@@ -296,7 +300,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return an instance of Builder3&lt;E,T1,T2,T3,T4,T5,T6&gt;
      * @throws NullPointerException if validation1, validation2, validation3, validation4, validation5 or validation6 is null
      */
-    static <E, T1, T2, T3, T4, T5, T6> Builder6<E, T1, T2, T3, T4, T5, T6> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4, Validation<E, T5> validation5, Validation<E, T6> validation6) {
+    public static <E, T1, T2, T3, T4, T5, T6> Builder6<E, T1, T2, T3, T4, T5, T6> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4, Validation<E, T5> validation5, Validation<E, T6> validation6) {
         Objects.requireNonNull(validation1, "validation1 is null");
         Objects.requireNonNull(validation2, "validation2 is null");
         Objects.requireNonNull(validation3, "validation3 is null");
@@ -327,7 +331,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return an instance of Builder3&lt;E,T1,T2,T3,T4,T5,T6,T7&gt;
      * @throws NullPointerException if validation1, validation2, validation3, validation4, validation5, validation6 or validation7 is null
      */
-    static <E, T1, T2, T3, T4, T5, T6, T7> Builder7<E, T1, T2, T3, T4, T5, T6, T7> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4, Validation<E, T5> validation5, Validation<E, T6> validation6, Validation<E, T7> validation7) {
+    public static <E, T1, T2, T3, T4, T5, T6, T7> Builder7<E, T1, T2, T3, T4, T5, T6, T7> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4, Validation<E, T5> validation5, Validation<E, T6> validation6, Validation<E, T7> validation7) {
         Objects.requireNonNull(validation1, "validation1 is null");
         Objects.requireNonNull(validation2, "validation2 is null");
         Objects.requireNonNull(validation3, "validation3 is null");
@@ -361,7 +365,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return an instance of Builder3&lt;E,T1,T2,T3,T4,T5,T6,T7,T8&gt;
      * @throws NullPointerException if validation1, validation2, validation3, validation4, validation5, validation6, validation7 or validation8 is null
      */
-    static <E, T1, T2, T3, T4, T5, T6, T7, T8> Builder8<E, T1, T2, T3, T4, T5, T6, T7, T8> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4, Validation<E, T5> validation5, Validation<E, T6> validation6, Validation<E, T7> validation7, Validation<E, T8> validation8) {
+    public static <E, T1, T2, T3, T4, T5, T6, T7, T8> Builder8<E, T1, T2, T3, T4, T5, T6, T7, T8> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4, Validation<E, T5> validation5, Validation<E, T6> validation6, Validation<E, T7> validation7, Validation<E, T8> validation8) {
         Objects.requireNonNull(validation1, "validation1 is null");
         Objects.requireNonNull(validation2, "validation2 is null");
         Objects.requireNonNull(validation3, "validation3 is null");
@@ -378,14 +382,14 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      *
      * @return true if is a Valid, false if is an Invalid
      */
-    boolean isValid();
+    public abstract boolean isValid();
 
     /**
      * Check whether this is of type {@code Invalid}
      *
      * @return true if is an Invalid, false if is a Valid
      */
-    boolean isInvalid();
+    public abstract boolean isInvalid();
 
     /**
      * Returns this {@code Validation} if it is valid, otherwise return the alternative.
@@ -394,7 +398,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return this {@code Validation} if it is valid, otherwise return the alternative.
      */
     @SuppressWarnings("unchecked")
-    default Validation<E, T> orElse(Validation<? extends E, ? extends T> other) {
+    public final Validation<E, T> orElse(Validation<? extends E, ? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         return isValid() ? this : (Validation<E, T>) other;
     }
@@ -406,13 +410,13 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return this {@code Validation} if it is valid, otherwise return the result of evaluating supplier.
      */
     @SuppressWarnings("unchecked")
-    default Validation<E, T> orElse(Supplier<Validation<? extends E, ? extends T>> supplier) {
+    public final Validation<E, T> orElse(Supplier<Validation<? extends E, ? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return isValid() ? this : (Validation<E, T>) supplier.get();
     }
 
     @Override
-    default boolean isEmpty() {
+    public final boolean isEmpty() {
         return isInvalid();
     }
 
@@ -423,7 +427,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @throws NoSuchElementException if this is an {@code Invalid}
      */
     @Override
-    T get();
+    public abstract T get();
 
     /**
      * Gets the value if it is a Valid or an value calculated from the error.
@@ -432,7 +436,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return the value, if the underlying Validation is a Valid, or else the alternative value
      * provided by {@code other} by applying the error.
      */
-    default T getOrElseGet(Function<? super E, ? extends T> other) {
+    public final T getOrElseGet(Function<? super E, ? extends T> other) {
         Objects.requireNonNull(other, "other is null");
         if (isValid()) {
             return get();
@@ -447,25 +451,16 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return The error, if present
      * @throws RuntimeException if this is a {@code Valid}
      */
-    E getError();
+    public abstract E getError();
 
     /**
      * Converts this Validation to an {@link Either}.
      *
      * @return {@code Either.right(get())} if this is valid, otherwise {@code Either.left(getError())}.
      */
-    default Either<E, T> toEither() {
+    public final Either<E, T> toEither() {
         return isValid() ? Either.right(get()) : Either.left(getError());
     }
-
-    @Override
-    boolean equals(Object o);
-
-    @Override
-    int hashCode();
-
-    @Override
-    String toString();
 
     /**
      * Performs the given action for the value contained in {@code Valid}, or does nothing
@@ -475,7 +470,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @throws NullPointerException if action is null
      */
     @Override
-    default void forEach(Consumer<? super T> action) {
+    public final void forEach(Consumer<? super T> action) {
         Objects.requireNonNull(action, "action is null");
         if (isValid()) {
             action.accept(get());
@@ -497,7 +492,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return {@code ifValid.apply(get())} if this is valid, otherwise {@code ifInvalid.apply(getError())}.
      * @throws NullPointerException if one of the given mappers {@code ifInvalid} or {@code ifValid} is null
      */
-    default <U> U fold(Function<? super E, ? extends U> ifInvalid, Function<? super T, ? extends U> ifValid) {
+    public final <U> U fold(Function<? super E, ? extends U> ifInvalid, Function<? super T, ? extends U> ifValid) {
         Objects.requireNonNull(ifInvalid, "ifInvalid is null");
         Objects.requireNonNull(ifValid, "ifValid is null");
         return isValid() ? ifValid.apply(get()) : ifInvalid.apply(getError());
@@ -509,7 +504,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      *
      * @return a flipped instance of Validation
      */
-    default Validation<T, E> swap() {
+    public final Validation<T, E> swap() {
         if (isInvalid()) {
             final E error = this.getError();
             return Validation.valid(error);
@@ -520,7 +515,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
     }
 
     @Override
-    default <U> Validation<E, U> map(Function<? super T, ? extends U> f) {
+    public final <U> Validation<E, U> map(Function<? super T, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         if (isInvalid()) {
             return Validation.invalid(this.getError());
@@ -544,7 +539,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return an instance of Validation&lt;U,R&gt;
      * @throws NullPointerException if invalidMapper or validMapper is null
      */
-    default <E2, T2> Validation<E2, T2> bimap(Function<? super E, ? extends E2> errorMapper, Function<? super T, ? extends T2> valueMapper) {
+    public final <E2, T2> Validation<E2, T2> bimap(Function<? super E, ? extends E2> errorMapper, Function<? super T, ? extends T2> valueMapper) {
         Objects.requireNonNull(errorMapper, "errorMapper is null");
         Objects.requireNonNull(valueMapper, "valueMapper is null");
         if (isInvalid()) {
@@ -565,7 +560,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return an instance of Validation&lt;U,T&gt;
      * @throws NullPointerException if mapping operation f is null
      */
-    default <U> Validation<U, T> mapError(Function<? super E, ? extends U> f) {
+    public final <U> Validation<U, T> mapError(Function<? super E, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
         if (isInvalid()) {
             final E error = this.getError();
@@ -575,7 +570,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
         }
     }
 
-    default <U> Validation<Seq<E>, U> ap(Validation<Seq<E>, ? extends Function<? super T, ? extends U>> validation) {
+    public final <U> Validation<Seq<E>, U> ap(Validation<Seq<E>, ? extends Function<? super T, ? extends U>> validation) {
         Objects.requireNonNull(validation, "validation is null");
         if (isValid()) {
             if (validation.isValid()) {
@@ -606,25 +601,25 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @param validation the validation object to combine this with
      * @return an instance of Builder
      */
-    default <U> Builder<E, T, U> combine(Validation<E, U> validation) {
+    public final <U> Builder<E, T, U> combine(Validation<E, U> validation) {
         return new Builder<>(this, validation);
     }
 
     // -- Implementation of Value
 
-    default Option<Validation<E, T>> filter(Predicate<? super T> predicate) {
+    public final Option<Validation<E, T>> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         return isInvalid() || predicate.test(get()) ? Option.some(this) : Option.none();
     }
 
     @SuppressWarnings("unchecked")
-    default <U> Validation<E, U> flatMap(Function<? super T, ? extends Validation<E, ? extends U>> mapper) {
+    public final <U> Validation<E, U> flatMap(Function<? super T, ? extends Validation<E, ? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isInvalid() ? (Validation<E, U>) this : (Validation<E, U>) mapper.apply(get());
     }
 
     @Override
-    default Validation<E, T> peek(Consumer<? super T> action) {
+    public final Validation<E, T> peek(Consumer<? super T> action) {
         if (isValid()) {
             action.accept(get());
         }
@@ -637,7 +632,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return false
      */
     @Override
-    default boolean isAsync() {
+    public final boolean isAsync() {
         return false;
     }
 
@@ -647,17 +642,17 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      * @return false
      */
     @Override
-    default boolean isLazy() {
+    public final boolean isLazy() {
         return false;
     }
 
     @Override
-    default boolean isSingleValued() {
+    public final boolean isSingleValued() {
         return true;
     }
 
     @Override
-    default Iterator<T> iterator() {
+    public final Iterator<T> iterator() {
         return isValid() ? Iterator.of(get()) : Iterator.empty();
     }
 
@@ -666,8 +661,10 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      *
      * @param <E> type of the error of this Validation
      * @param <T> type of the value of this Validation
+     * @deprecated will be removed from the public API
      */
-    final class Valid<E, T> implements Validation<E, T>, Serializable {
+    @Deprecated
+    public static final class Valid<E, T> extends Validation<E, T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -729,8 +726,10 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
      *
      * @param <E> type of the error of this Validation
      * @param <T> type of the value of this Validation
+     * @deprecated will be removed from the public API
      */
-    final class Invalid<E, T> implements Validation<E, T>, Serializable {
+    @Deprecated
+    public static final class Invalid<E, T> extends Validation<E, T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
@@ -787,7 +786,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
 
     }
 
-    final class Builder<E, T1, T2> {
+    public static final class Builder<E, T1, T2> {
 
         private Validation<E, T1> v1;
         private Validation<E, T2> v2;
@@ -807,7 +806,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
 
     }
 
-    final class Builder3<E, T1, T2, T3> {
+    public static final class Builder3<E, T1, T2, T3> {
 
         private Validation<E, T1> v1;
         private Validation<E, T2> v2;
@@ -829,7 +828,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
 
     }
 
-    final class Builder4<E, T1, T2, T3, T4> {
+    public static final class Builder4<E, T1, T2, T3, T4> {
 
         private Validation<E, T1> v1;
         private Validation<E, T2> v2;
@@ -853,7 +852,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
 
     }
 
-    final class Builder5<E, T1, T2, T3, T4, T5> {
+    public static final class Builder5<E, T1, T2, T3, T4, T5> {
 
         private Validation<E, T1> v1;
         private Validation<E, T2> v2;
@@ -879,7 +878,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
 
     }
 
-    final class Builder6<E, T1, T2, T3, T4, T5, T6> {
+    public static final class Builder6<E, T1, T2, T3, T4, T5, T6> {
 
         private Validation<E, T1> v1;
         private Validation<E, T2> v2;
@@ -907,7 +906,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
 
     }
 
-    final class Builder7<E, T1, T2, T3, T4, T5, T6, T7> {
+    public static final class Builder7<E, T1, T2, T3, T4, T5, T6, T7> {
 
         private Validation<E, T1> v1;
         private Validation<E, T2> v2;
@@ -937,7 +936,7 @@ public interface Validation<E, T> extends io.vavr.Iterable<T>, Value<T>, Seriali
 
     }
 
-    final class Builder8<E, T1, T2, T3, T4, T5, T6, T7, T8> {
+    public static final class Builder8<E, T1, T2, T3, T4, T5, T6, T7, T8> {
 
         private Validation<E, T1> v1;
         private Validation<E, T2> v2;

--- a/src/test/java/io/vavr/MatchTest.java
+++ b/src/test/java/io/vavr/MatchTest.java
@@ -160,10 +160,10 @@ public class MatchTest {
         final List<Integer> list = List(1, 2, 3);
         final Predicate<Number> p = n -> n.intValue() > 0;
         final boolean actual = Match(list).of(
-                Case($(anyOf(p)), true),
+                Case($(l -> l.exists(anyOf(p))), true),
                 Case($(), false)
         );
-        assertThat(actual).isEqualTo(false);
+        assertThat(actual).isTrue();
     }
 
     // -- multiple cases


### PR DESCRIPTION
Fixes #1825

(The regression #2419 needs to be fixed)

This one is marked as backward incompatible because

* Interfaces were changed to abstract classes with private constructor
* Some API methods return the base types instead of subclasses (Option instead of Some or None)