### PR TITLE
Improve shuffle test

### DIFF
--- a/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -1584,9 +1584,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldShuffleHaveSameElements() {
         final Seq<Integer> shuffled = of(1, 2, 3).shuffle();
-        assertThat(shuffled.indexOf(1)).isNotEqualTo(-1);
-        assertThat(shuffled.indexOf(2)).isNotEqualTo(-1);
-        assertThat(shuffled.indexOf(3)).isNotEqualTo(-1);
+        assertThat(shuffled).containsOnlyOnce(1, 2, 3);
         assertThat(shuffled.indexOf(4)).isEqualTo(-1);
     }
 
@@ -1603,9 +1601,7 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     @Test
     public void shouldShuffleHaveSameElementsDeterministic() {
         final Seq<Integer> shuffled = of(1, 2, 3).shuffle(new Random(514662720L));
-        assertThat(shuffled.indexOf(1)).isNotEqualTo(-1);
-        assertThat(shuffled.indexOf(2)).isNotEqualTo(-1);
-        assertThat(shuffled.indexOf(3)).isNotEqualTo(-1);
+        assertThat(shuffled).containsExactly(2, 3, 1);
         assertThat(shuffled.indexOf(4)).isEqualTo(-1);
     }
 

--- a/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -1524,7 +1524,7 @@ public class CharSeqTest {
     public void shouldShuffleHaveSameElements() {
         final CharSeq actual = CharSeq.of('1', '2', '3');
         final CharSeq shuffled = actual.shuffle();
-        assertThat(shuffled.containsAll(actual)).isTrue();
+        assertThat(shuffled).containsOnlyOnce('1', '2', '3');
         assertThat(shuffled.indexOf(4)).isEqualTo(-1);
     }
 
@@ -1543,7 +1543,7 @@ public class CharSeqTest {
     public void shouldShuffleHaveSameElementsDeterministic() {
         final CharSeq actual = CharSeq.of('1', '2', '3');
         final CharSeq shuffled = actual.shuffle(new Random(514662720L));
-        assertThat(shuffled.containsAll(actual)).isTrue();
+        assertThat(shuffled).containsExactly('2', '3', '1');
         assertThat(shuffled.indexOf(4)).isEqualTo(-1);
     }
 


### PR DESCRIPTION
This PR aims to improve the shuffle test, as described in issue https://github.com/vavr-io/vavr/issues/2453. Compared to existing test case, it has some improvements on the following fields:

1. Ensure the size of the shuffled collection is the same as the original collection
2. Ensure the elements stayed the same
3. Ensure the shuffled collection does not equal to the original collection. If this is the case, repeat up to 10 times (test will fail after that).

Actually, about the 1st point, it's not exactly true. The size has been asserted in another test just above, called `shouldShuffleHaveSameLengthDeterministic()`. Not sure it should be deleted or not.
