### PR TITLE
Replace classes Right, Left by factory methods in Javadoc examples

### DIFF
--- a/src/main/java/io/vavr/control/Either.java
+++ b/src/main/java/io/vavr/control/Either.java
@@ -461,15 +461,13 @@ public abstract class Either<L, R> implements io.vavr.Iterable<R>, io.vavr.Value
     /**
      * Maps the value of this Either if it is a Right, performs no operation if this is a Left.
      *
-     * <pre><code>
-     * import static io.vavr.API.*;
-     *
+     * <pre>{@code
      * // = Right("A")
-     * Right("a").map(String::toUpperCase);
+     * Either.right("a").map(String::toUpperCase);
      *
      * // = Left(1)
-     * Left(1).map(String::toUpperCase);
-     * </code></pre>
+     * Either.left(1).map(String::toUpperCase);
+     * }</pre>
      *
      * @param mapper A mapper
      * @param <U>    Component type of the mapped right value
@@ -491,13 +489,11 @@ public abstract class Either<L, R> implements io.vavr.Iterable<R>, io.vavr.Value
      * Maps the value of this Either if it is a Left, performs no operation if this is a Right.
      *
      * <pre>{@code
-     * import static io.vavr.API.*;
-     *
      * // = Left(2)
-     * Left(1).mapLeft(i -> i + 1);
+     * Either.left(1).mapLeft(i -> i + 1);
      *
      * // = Right("a")
-     * Right("a").mapLeft(i -> i + 1);
+     * Either.right("a").mapLeft(i -> i + 1);
      * }</pre>
      *
      * @param leftMapper A mapper
@@ -550,13 +546,11 @@ public abstract class Either<L, R> implements io.vavr.Iterable<R>, io.vavr.Value
      * the filterVal function to the {@code Either} value.
      *
      * <pre>{@code
-     * import static io.vavr.API.*;
-     *
      * // = Left("bad: a")
-     * Right("a").filterOrElse(i -> false, val -> "bad: " + val);
+     * Either.right("a").filterOrElse(i -> false, val -> "bad: " + val);
      *
      * // = Right("a")
-     * Right("a").filterOrElse(i -> true, val -> "bad: " + val);
+     * Either.right("a").filterOrElse(i -> true, val -> "bad: " + val);
      * }</pre>
      *
      * @param predicate A predicate


### PR DESCRIPTION
The following classes are deprecated since cce4332047ff8059d359ca92174a0f025642b96c, and will be removed from the public API:

  1. `io.vavr.control.Either.Right`
  2. `io.vavr.control.Either.Left`

The PR updates the Javadoc accordingly (see issue #2458).

However, this PR does not fix compilation failure on existing examples. I need more guidance to provide better alternatives. Here're those which do not compile:

```java
// `Either.left(1)` returns `Either<Integer, Object>`, not `Either<Integer, String>`
// ---
// incompatible types: cannot infer type-variable(s) U
Either.left(1).map(String::toUpperCase);

// `Either.right("a")` returns `Either<Object, String>`, not `Either<Integer, String>`
// ---
// bad operand types for binary operator '+'
Either.right("a").mapLeft(i -> i + 1);
```