### PR TITLE
Remove references to deprecated code

### DIFF
--- a/src/main/java/io/vavr/collection/List.java
+++ b/src/main/java/io/vavr/collection/List.java
@@ -63,8 +63,8 @@ import static io.vavr.collection.JavaConverters.ChangePolicy.MUTABLE;
  * <pre>
  * <code>
  * // factory methods
- * List.empty()                        // = List.of() = Nil.instance()
- * List.of(x)                          // = new Cons&lt;&gt;(x, Nil.instance())
+ * List.empty()                        // = List.of()
+ * List.of(x)                          // e.g. List.of(1)
  * List.of(Object...)                  // e.g. List.of(1, 2, 3)
  * List.ofAll(Iterable)                // e.g. List.ofAll(Stream.of(1, 2, 3)) = 1, 2, 3
  * List.ofAll(&lt;primitive array&gt;) // e.g. List.of(new int[] {1, 2, 3}) = 1, 2, 3
@@ -145,10 +145,9 @@ public abstract class List<T> implements LinearSeq<T> {
     }
 
     /**
-     * Returns the single instance of Nil. Convenience method for {@code Nil.instance()} .
+     * Returns the single instance of Nil.
      * <p>
      * Note: this method intentionally returns type {@code List} and not {@code Nil}. This comes handy when folding.
-     * If you explicitly need type {@code Nil} use {@linkplain Nil#instance()}.
      *
      * @param <T> Component type of Nil, determined by type inference in the particular context.
      * @return The empty list.
@@ -207,12 +206,9 @@ public abstract class List<T> implements LinearSeq<T> {
 
     /**
      * Creates a List of the given elements.
-     * <pre>
-     * <code>
-     *   List.of(1, 2, 3, 4)
-     * = Nil.instance().prepend(4).prepend(3).prepend(2).prepend(1)
-     * = new Cons(1, new Cons(2, new Cons(3, new Cons(4, Nil.instance()))))
-     * </code>
+     * <pre>{@code
+     * List.of(1, 2, 3, 4)
+     * }
      * </pre>
      *
      * @param <T>      Component type of the List.

--- a/src/main/java/io/vavr/control/Try.java
+++ b/src/main/java/io/vavr/control/Try.java
@@ -176,7 +176,7 @@ public abstract class Try<T> implements io.vavr.Iterable<T>, io.vavr.Value<T>, S
     }
 
     /**
-     * Creates a {@link Success} that contains the given {@code value}. Shortcut for {@code new Success<>(value)}.
+     * Creates a {@link Success} that contains the given {@code value}.
      *
      * @param value A value.
      * @param <T>   Type of the given {@code value}.
@@ -187,7 +187,7 @@ public abstract class Try<T> implements io.vavr.Iterable<T>, io.vavr.Value<T>, S
     }
 
     /**
-     * Creates a {@link Failure} that contains the given {@code exception}. Shortcut for {@code new Failure<>(exception)}.
+     * Creates a {@link Failure} that contains the given {@code exception}.
      *
      * @param exception An exception.
      * @param <T>       Component type of the {@code Try}.
@@ -678,7 +678,7 @@ public abstract class Try<T> implements io.vavr.Iterable<T>, io.vavr.Value<T>, S
             }
         }
     }
-    
+
     /**
      * Consumes the cause if this is a {@link Try.Failure}.
      *
@@ -714,7 +714,7 @@ public abstract class Try<T> implements io.vavr.Iterable<T>, io.vavr.Value<T>, S
      *    .onFailure(RuntimeException.class, x -> System.out.println("Runtime exception"))
      *    .onFailure(Error.class, x -> System.out.println("Error"));
      * }</pre>
-     * 
+     *
      * @param exceptionType the exception type that is handled
      * @param action an excpetion consumer
      * @param <X> the exception type that should be handled
@@ -879,7 +879,7 @@ public abstract class Try<T> implements io.vavr.Iterable<T>, io.vavr.Value<T>, S
      * // = Failure(java.lang.ArithmeticException: / by zero)
      * Try.of(() -> 1/0).recoverWith(Error.class, x -> Try.success(Integer.MAX_VALUE));
      * }</pre>
-     * 
+     *
      * @param <X>           Exception type
      * @param exceptionType The specific exception type that should be handled
      * @param f             A recovery function taking an exception of type {@code X} and returning Try as a result of recovery.


### PR DESCRIPTION
The following classes are now deprecated and will be removed from the public API, it's better not to mention them in Javadoc (#2458):

- `io.vavr.collection.List.Nil`
- `io.vavr.collection.List.Cons`
- `io.vavr.control.Try.Success`
- `io.vavr.control.Try.Failure`