### PR TITLE
Ensure license file is recognized by GitHub

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+


### PR DESCRIPTION
Currently, [Vavr](https://github.com/vavr-io/vavr)'s license is not recognized by GitHub properly:

![Screenshot 2019-07-31 at 09 52 11](https://user-images.githubusercontent.com/10179217/62193986-39952080-b379-11e9-8a3d-0b956c6cbfae.png)

While in [Scala](https://github.com/scala/scala), the license is recognized by GitHub:

![Screenshot 2019-07-31 at 09 52 31](https://user-images.githubusercontent.com/10179217/62194042-54679500-b379-11e9-81ba-f5d57f1ca002.png)

This PR fixes the problem by dumping the Apache 2.0 license from [GitHub License API](https://developer.github.com/v3/licenses/#get-an-individual-license) again:

```sh
curl -s https://api.github.com/licenses/apache-2.0 | jq -r ".body" > LICENSE
```