### PR TITLE
Filtering unnecessary snapshot uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ script:
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)
-- if [[ -n $DEPLOY ]]; then ./gradlew uploadArchives -PossrhUsername=${ossrhUsername} -PossrhPassword=${ossrhPassword}; fi
+- if [[ -n $DEPLOY ]] && [ "$TRAVIS_REPO_SLUG" == "vavr-io/vavr" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then ./gradlew uploadArchives -PossrhUsername="$ossrhUsername" -PossrhPassword="$ossrhPassword"; fi


### PR DESCRIPTION
Follow-up of #2482 (#2477)

This change ensures, that snapshots of PRs / pushes are only uploaded if the PR was **merged to master** and successfully built.

Especially, PR builds are not uploaded.