### PR TITLE
Fix integer overflow in range

### DIFF
--- a/src/main/java/io/vavr/collection/Iterator.java
+++ b/src/main/java/io/vavr/collection/Iterator.java
@@ -2494,7 +2494,7 @@ final class RangeIntBackwardIterator implements Iterator<Integer> {
 
     private int next;
 
-    private boolean overflow;
+    private boolean underflow;
 
     RangeIntBackwardIterator(int start, int end, int step, boolean inclusive) {
         this.start = start;
@@ -2510,9 +2510,9 @@ final class RangeIntBackwardIterator implements Iterator<Integer> {
             return false;
         }
         if (inclusive) {
-            return !overflow && next >= end;
+            return !underflow && next >= end;
         } else {
-            return !overflow && next > end;
+            return !underflow && next > end;
         }
     }
 
@@ -2523,7 +2523,7 @@ final class RangeIntBackwardIterator implements Iterator<Integer> {
         }
         int curr = next;
         int r = curr + step;
-        overflow = ((curr ^ r) & (step ^ r)) < 0;
+        underflow = ((curr ^ r) & (step ^ r)) < 0;
         next = r;
         return curr;
     }
@@ -2588,7 +2588,7 @@ final class RangeLongBackwardIterator implements Iterator<Long> {
 
     private long next;
 
-    private boolean overflow;
+    private boolean underflow;
 
     RangeLongBackwardIterator(long start, long end, long step, boolean inclusive) {
         this.start = start;
@@ -2604,9 +2604,9 @@ final class RangeLongBackwardIterator implements Iterator<Long> {
             return false;
         }
         if (inclusive) {
-            return !overflow && next >= end;
+            return !underflow && next >= end;
         } else {
-            return !overflow && next > end;
+            return !underflow && next > end;
         }
     }
 
@@ -2617,7 +2617,7 @@ final class RangeLongBackwardIterator implements Iterator<Long> {
         }
         long curr = next;
         long r = curr + step;
-        overflow = ((curr ^ r) & (step ^ r)) < 0;
+        underflow = ((curr ^ r) & (step ^ r)) < 0;
         next = r;
         return curr;
     }

--- a/src/test/java/io/vavr/collection/AbstractTraversableRangeTest.java
+++ b/src/test/java/io/vavr/collection/AbstractTraversableRangeTest.java
@@ -208,17 +208,23 @@ public abstract class AbstractTraversableRangeTest extends AbstractTraversableTe
         assertThat(rangeClosedBy(1, 3, 1)).isEqualTo(of(1, 2, 3));
         assertThat(rangeClosedBy(1, 5, 2)).isEqualTo(of(1, 3, 5));
         assertThat(rangeClosedBy(1, 6, 2)).isEqualTo(of(1, 3, 5));
-        assertThat(rangeClosedBy(Integer.MAX_VALUE - 2, Integer.MAX_VALUE, 3)).isEqualTo(of(Integer.MAX_VALUE - 2));
-        assertThat(rangeClosedBy(Integer.MAX_VALUE - 3, Integer.MAX_VALUE, 3)).isEqualTo(of(Integer.MAX_VALUE - 3, Integer.MAX_VALUE));
-        assertThat(rangeClosedBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 2, 1)).isEqualTo(of(Integer.MIN_VALUE, Integer.MIN_VALUE + 1, Integer.MIN_VALUE + 2));
-        assertThat(rangeClosedBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 2, 3)).isEqualTo(of(Integer.MIN_VALUE));
         assertThat(rangeClosedBy(3, 1, -1)).isEqualTo(of(3, 2, 1));
         assertThat(rangeClosedBy(5, 1, -2)).isEqualTo(of(5, 3, 1));
         assertThat(rangeClosedBy(5, 0, -2)).isEqualTo(of(5, 3, 1));
+
         assertThat(rangeClosedBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 2, -1)).isEqualTo(of(Integer.MAX_VALUE, Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 2));
         assertThat(rangeClosedBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 2, -3)).isEqualTo(of(Integer.MAX_VALUE));
+        assertThat(rangeClosedBy(Integer.MAX_VALUE - 2, Integer.MAX_VALUE, 3)).isEqualTo(of(Integer.MAX_VALUE - 2));
+        assertThat(rangeClosedBy(Integer.MAX_VALUE - 3, Integer.MAX_VALUE, 3)).isEqualTo(of(Integer.MAX_VALUE - 3, Integer.MAX_VALUE));
+        assertThat(rangeClosedBy(Integer.MAX_VALUE, -5, Integer.MAX_VALUE)).isEmpty();
+        assertThat(rangeClosedBy(Integer.MAX_VALUE, -5, -Integer.MAX_VALUE)).isEqualTo(of(Integer.MAX_VALUE, 0));
+
+        assertThat(rangeClosedBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 2, 1)).isEqualTo(of(Integer.MIN_VALUE, Integer.MIN_VALUE + 1, Integer.MIN_VALUE + 2));
+        assertThat(rangeClosedBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 2, 3)).isEqualTo(of(Integer.MIN_VALUE));
         assertThat(rangeClosedBy(Integer.MIN_VALUE + 2, Integer.MIN_VALUE, -3)).isEqualTo(of(Integer.MIN_VALUE + 2));
         assertThat(rangeClosedBy(Integer.MIN_VALUE + 3, Integer.MIN_VALUE, -3)).isEqualTo(of(Integer.MIN_VALUE + 3, Integer.MIN_VALUE));
+        assertThat(rangeClosedBy(Integer.MIN_VALUE, 5, Integer.MAX_VALUE)).isEqualTo(of(Integer.MIN_VALUE, -1));
+        assertThat(rangeClosedBy(Integer.MIN_VALUE, 5, -Integer.MAX_VALUE)).isEmpty();
 
         // long
         assertThat(rangeClosedBy(1L, 3L, 1)).isEqualTo(of(1L, 2L, 3L));
@@ -419,14 +425,20 @@ public abstract class AbstractTraversableRangeTest extends AbstractTraversableTe
         assertThat(rangeBy(1, 4, 2)).isEqualTo(of(1, 3));
         assertThat(rangeBy(3, 1, -1)).isEqualTo(of(3, 2));
         assertThat(rangeBy(4, 1, -2)).isEqualTo(of(4, 2));
+
         assertThat(rangeBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 3, -1)).isEqualTo(of(Integer.MAX_VALUE, Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 2));
         assertThat(rangeBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 3, -3)).isEqualTo(of(Integer.MAX_VALUE));
         assertThat(rangeBy(Integer.MAX_VALUE - 3, Integer.MAX_VALUE, 3)).isEqualTo(of(Integer.MAX_VALUE - 3));
         assertThat(rangeBy(Integer.MAX_VALUE - 4, Integer.MAX_VALUE, 3)).isEqualTo(of(Integer.MAX_VALUE - 4, Integer.MAX_VALUE - 1));
+        assertThat(rangeBy(Integer.MAX_VALUE, -5, Integer.MAX_VALUE)).isEmpty();
+        assertThat(rangeBy(Integer.MAX_VALUE, -5, -Integer.MAX_VALUE)).isEqualTo(of(Integer.MAX_VALUE, 0));
+
         assertThat(rangeBy(Integer.MIN_VALUE + 3, Integer.MIN_VALUE, -3)).isEqualTo(of(Integer.MIN_VALUE + 3));
         assertThat(rangeBy(Integer.MIN_VALUE + 4, Integer.MIN_VALUE, -3)).isEqualTo(of(Integer.MIN_VALUE + 4, Integer.MIN_VALUE + 1));
         assertThat(rangeBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 3, 1)).isEqualTo(of(Integer.MIN_VALUE, Integer.MIN_VALUE + 1, Integer.MIN_VALUE + 2));
         assertThat(rangeBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 3, 3)).isEqualTo(of(Integer.MIN_VALUE));
+        assertThat(rangeBy(Integer.MIN_VALUE, 5, Integer.MAX_VALUE)).isEqualTo(of(Integer.MIN_VALUE, -1));
+        assertThat(rangeBy(Integer.MIN_VALUE, 5, -Integer.MAX_VALUE)).isEmpty();
 
         // long
         assertThat(rangeBy(1L, 3L, 1L)).isEqualTo(of(1L, 2L));

--- a/src/test/java/io/vavr/collection/AbstractTraversableRangeTest.java
+++ b/src/test/java/io/vavr/collection/AbstractTraversableRangeTest.java
@@ -210,9 +210,13 @@ public abstract class AbstractTraversableRangeTest extends AbstractTraversableTe
         assertThat(rangeClosedBy(1, 6, 2)).isEqualTo(of(1, 3, 5));
         assertThat(rangeClosedBy(Integer.MAX_VALUE - 2, Integer.MAX_VALUE, 3)).isEqualTo(of(Integer.MAX_VALUE - 2));
         assertThat(rangeClosedBy(Integer.MAX_VALUE - 3, Integer.MAX_VALUE, 3)).isEqualTo(of(Integer.MAX_VALUE - 3, Integer.MAX_VALUE));
+        assertThat(rangeClosedBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 2, 1)).isEqualTo(of(Integer.MIN_VALUE, Integer.MIN_VALUE + 1, Integer.MIN_VALUE + 2));
+        assertThat(rangeClosedBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 2, 3)).isEqualTo(of(Integer.MIN_VALUE));
         assertThat(rangeClosedBy(3, 1, -1)).isEqualTo(of(3, 2, 1));
         assertThat(rangeClosedBy(5, 1, -2)).isEqualTo(of(5, 3, 1));
         assertThat(rangeClosedBy(5, 0, -2)).isEqualTo(of(5, 3, 1));
+        assertThat(rangeClosedBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 2, -1)).isEqualTo(of(Integer.MAX_VALUE, Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 2));
+        assertThat(rangeClosedBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 2, -3)).isEqualTo(of(Integer.MAX_VALUE));
         assertThat(rangeClosedBy(Integer.MIN_VALUE + 2, Integer.MIN_VALUE, -3)).isEqualTo(of(Integer.MIN_VALUE + 2));
         assertThat(rangeClosedBy(Integer.MIN_VALUE + 3, Integer.MIN_VALUE, -3)).isEqualTo(of(Integer.MIN_VALUE + 3, Integer.MIN_VALUE));
 
@@ -415,10 +419,14 @@ public abstract class AbstractTraversableRangeTest extends AbstractTraversableTe
         assertThat(rangeBy(1, 4, 2)).isEqualTo(of(1, 3));
         assertThat(rangeBy(3, 1, -1)).isEqualTo(of(3, 2));
         assertThat(rangeBy(4, 1, -2)).isEqualTo(of(4, 2));
+        assertThat(rangeBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 3, -1)).isEqualTo(of(Integer.MAX_VALUE, Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 2));
+        assertThat(rangeBy(Integer.MAX_VALUE, Integer.MAX_VALUE - 3, -3)).isEqualTo(of(Integer.MAX_VALUE));
         assertThat(rangeBy(Integer.MAX_VALUE - 3, Integer.MAX_VALUE, 3)).isEqualTo(of(Integer.MAX_VALUE - 3));
         assertThat(rangeBy(Integer.MAX_VALUE - 4, Integer.MAX_VALUE, 3)).isEqualTo(of(Integer.MAX_VALUE - 4, Integer.MAX_VALUE - 1));
         assertThat(rangeBy(Integer.MIN_VALUE + 3, Integer.MIN_VALUE, -3)).isEqualTo(of(Integer.MIN_VALUE + 3));
         assertThat(rangeBy(Integer.MIN_VALUE + 4, Integer.MIN_VALUE, -3)).isEqualTo(of(Integer.MIN_VALUE + 4, Integer.MIN_VALUE + 1));
+        assertThat(rangeBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 3, 1)).isEqualTo(of(Integer.MIN_VALUE, Integer.MIN_VALUE + 1, Integer.MIN_VALUE + 2));
+        assertThat(rangeBy(Integer.MIN_VALUE, Integer.MIN_VALUE + 3, 3)).isEqualTo(of(Integer.MIN_VALUE));
 
         // long
         assertThat(rangeBy(1L, 3L, 1L)).isEqualTo(of(1L, 2L));

--- a/src/test/java/io/vavr/collection/AbstractTraversableRangeTest.java
+++ b/src/test/java/io/vavr/collection/AbstractTraversableRangeTest.java
@@ -230,13 +230,23 @@ public abstract class AbstractTraversableRangeTest extends AbstractTraversableTe
         assertThat(rangeClosedBy(1L, 3L, 1)).isEqualTo(of(1L, 2L, 3L));
         assertThat(rangeClosedBy(1L, 5L, 2)).isEqualTo(of(1L, 3L, 5L));
         assertThat(rangeClosedBy(1L, 6L, 2)).isEqualTo(of(1L, 3L, 5L));
-        assertThat(rangeClosedBy(Long.MAX_VALUE - 2, Long.MAX_VALUE, 3)).isEqualTo(of(Long.MAX_VALUE - 2));
-        assertThat(rangeClosedBy(Long.MAX_VALUE - 3, Long.MAX_VALUE, 3)).isEqualTo(of(Long.MAX_VALUE - 3, Long.MAX_VALUE));
         assertThat(rangeClosedBy(3L, 1L, -1)).isEqualTo(of(3L, 2L, 1L));
         assertThat(rangeClosedBy(5L, 1L, -2)).isEqualTo(of(5L, 3L, 1L));
         assertThat(rangeClosedBy(5L, 0L, -2)).isEqualTo(of(5L, 3L, 1L));
-        assertThat(rangeClosedBy(Long.MIN_VALUE + 2, Long.MIN_VALUE, -3)).isEqualTo(of(Long.MIN_VALUE + 2));
-        assertThat(rangeClosedBy(Long.MIN_VALUE + 3, Long.MIN_VALUE, -3)).isEqualTo(of(Long.MIN_VALUE + 3, Long.MIN_VALUE));
+
+        assertThat(rangeClosedBy(Long.MAX_VALUE, Long.MAX_VALUE - 2, -1)).isEqualTo(of(Long.MAX_VALUE, Long.MAX_VALUE - 1, Long.MAX_VALUE - 2));
+        assertThat(rangeClosedBy(Long.MAX_VALUE, Long.MAX_VALUE - 2, -3)).isEqualTo(of(Long.MAX_VALUE));
+        assertThat(rangeClosedBy(Long.MAX_VALUE - 2, Long.MAX_VALUE, 3L)).isEqualTo(of(Long.MAX_VALUE - 2));
+        assertThat(rangeClosedBy(Long.MAX_VALUE - 3, Long.MAX_VALUE, 3L)).isEqualTo(of(Long.MAX_VALUE - 3, Long.MAX_VALUE));
+        assertThat(rangeClosedBy(Long.MAX_VALUE, -5, Long.MAX_VALUE)).isEmpty();
+        assertThat(rangeClosedBy(Long.MAX_VALUE, -5, -Long.MAX_VALUE)).isEqualTo(of(Long.MAX_VALUE, 0L));
+
+        assertThat(rangeClosedBy(Long.MIN_VALUE, Long.MIN_VALUE + 2, 1L)).isEqualTo(of(Long.MIN_VALUE, Long.MIN_VALUE + 1, Long.MIN_VALUE + 2));
+        assertThat(rangeClosedBy(Long.MIN_VALUE, Long.MIN_VALUE + 2, 3L)).isEqualTo(of(Long.MIN_VALUE));
+        assertThat(rangeClosedBy(Long.MIN_VALUE + 2, Long.MIN_VALUE, -3L)).isEqualTo(of(Long.MIN_VALUE + 2));
+        assertThat(rangeClosedBy(Long.MIN_VALUE + 3, Long.MIN_VALUE, -3L)).isEqualTo(of(Long.MIN_VALUE + 3, Long.MIN_VALUE));
+        assertThat(rangeClosedBy(Long.MIN_VALUE, 5L, Long.MAX_VALUE)).isEqualTo(of(Long.MIN_VALUE, -1L));
+        assertThat(rangeClosedBy(Long.MIN_VALUE, 5L, -Long.MAX_VALUE)).isEmpty();
     }
 
     @Test
@@ -445,10 +455,19 @@ public abstract class AbstractTraversableRangeTest extends AbstractTraversableTe
         assertThat(rangeBy(1L, 4L, 2L)).isEqualTo(of(1L, 3L));
         assertThat(rangeBy(3L, 1L, -1L)).isEqualTo(of(3L, 2L));
         assertThat(rangeBy(4L, 1L, -2L)).isEqualTo(of(4L, 2L));
+        assertThat(rangeBy(Long.MAX_VALUE, Long.MAX_VALUE - 3, -1)).isEqualTo(of(Long.MAX_VALUE, Long.MAX_VALUE - 1, Long.MAX_VALUE - 2));
+        assertThat(rangeBy(Long.MAX_VALUE, Long.MAX_VALUE - 3, -3)).isEqualTo(of(Long.MAX_VALUE));
         assertThat(rangeBy(Long.MAX_VALUE - 3, Long.MAX_VALUE, 3)).isEqualTo(of(Long.MAX_VALUE - 3));
         assertThat(rangeBy(Long.MAX_VALUE - 4, Long.MAX_VALUE, 3)).isEqualTo(of(Long.MAX_VALUE - 4, Long.MAX_VALUE - 1));
+        assertThat(rangeBy(Long.MAX_VALUE, -5, Long.MAX_VALUE)).isEmpty();
+        assertThat(rangeBy(Long.MAX_VALUE, -5, -Long.MAX_VALUE)).isEqualTo(of(Long.MAX_VALUE, 0L));
+
         assertThat(rangeBy(Long.MIN_VALUE + 3, Long.MIN_VALUE, -3)).isEqualTo(of(Long.MIN_VALUE + 3));
         assertThat(rangeBy(Long.MIN_VALUE + 4, Long.MIN_VALUE, -3)).isEqualTo(of(Long.MIN_VALUE + 4, Long.MIN_VALUE + 1));
+        assertThat(rangeBy(Long.MIN_VALUE, Long.MIN_VALUE + 3, 1)).isEqualTo(of(Long.MIN_VALUE, Long.MIN_VALUE + 1, Long.MIN_VALUE + 2));
+        assertThat(rangeBy(Long.MIN_VALUE, Long.MIN_VALUE + 3, 3)).isEqualTo(of(Long.MIN_VALUE));
+        assertThat(rangeBy(Long.MIN_VALUE, 5, Long.MAX_VALUE)).isEqualTo(of(Long.MIN_VALUE, -1L));
+        assertThat(rangeBy(Long.MIN_VALUE, 5, -Long.MAX_VALUE)).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
This is a draft pull request for handling https://github.com/vavr-io/vavr/issues/2263 Integer overflow problem in `Stream.rangeClosedBy`. Note that, this draft PR does not cover all acceptance criteria from the issue. It's mainly for discussion purpose. It means:

- It only contains changes for integer, need to extend to long, char, big integer and other types.
- It doesn't address overflow problem in `Integer.signum(from - toInclusive)`.
- It doesn't check / fix other similar APIs where addition / subtraction is performed.

In term of implementation, this PR uses the same overflow detection mechanism as method [`java.lang.Math#addExact(int, int)`](https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#addExact-int-int-), available since Java 8:

```java
int r = x + y;
// HD 2-12 Overflow iff both arguments have the opposite sign of the result
if (((x ^ r) & (y ^ r)) < 0) {
    // overflow
} else {
    ...
}
```

Compared to Scala, which does convert the int values to long and performs some checks (https://github.com/scala/scala/blob/2.13.x/src/library/scala/collection/immutable/Range.scala#L84-L87), this approach avoid changing type, thus the solution can be applied to all other similar numeric types.
