### PR TITLE
Removes the automatic module name (JPMS) because of a name clash.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,12 +83,6 @@ jacocoTestReport {
 
 check.dependsOn jacocoTestReport
 
-jar {
-    manifest {
-        attributes('Automatic-Module-Name': 'io.vavr')
-    }
-}
-
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
     classifier = 'sources'


### PR DESCRIPTION
We created overlapping modules names in VAVR 0.10.* The only way to fix that (without renaming packages in a backward incompatible way) is to remove the automatic module name. Starting with VAVR 2.0, we will ship proper modules.