### PR TITLE
Fixes OpenJDK early access builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,12 @@ cache:
   - "$HOME/.gradle/caches/"
   - "$HOME/.gradle/wrapper/"
 
-before_install: unset _JAVA_OPTIONS
+before_install:
+- export GRADLE_JAVA_HOME="$JAVA_HOME"
+- unset _JAVA_OPTIONS
 
 script:
-- ./gradlew check
+- ./gradlew check -Dorg.gradle.java.home="$GRADLE_JAVA_HOME"
 - if [ -n "$(git status -su src-gen)" ]; then exit 1; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
 - unset _JAVA_OPTIONS
 
 script:
-- ./gradlew check -Dorg.gradle.java.home="$GRADLE_JAVA_HOME"
+- ./gradlew check --info -Dorg.gradle.java.home="$GRADLE_JAVA_HOME"
 - if [ -n "$(git status -su src-gen)" ]; then exit 1; fi
 
 after_success:


### PR DESCRIPTION
… by starting Gradle with the default Java version instead of the JDK used for the VAVR build.