### PR TITLE
Introduce Either.recover method

### DIFF
--- a/src/main/java/io/vavr/control/Either.java
+++ b/src/main/java/io/vavr/control/Either.java
@@ -484,7 +484,7 @@ public abstract class Either<L, R> implements Iterable<R>, io.vavr.Value<R>, Ser
     }
 
     /**
-     * Calls recoverFunction if the projected Either is a Left, performs no operation if this is a Right. This is
+     * Calls recoveryFunction if the projected Either is a Left, performs no operation if this is a Right. This is
      * similar to {@code getOrElseGet} where the fallback method also returns an Either.
      *
      * <pre>{@code
@@ -496,19 +496,21 @@ public abstract class Either<L, R> implements Iterable<R>, io.vavr.Value<R>, Ser
      * tryGetString().recover(this::tryGetStringAnotherWay);
      * }</pre>
      *
-     * @param recoverFunction a function which accepts a Left value and returns an Either
+     * @param recoveryFunction a function which accepts a Left value and returns an Either
      * @return an {@code Either<L, R>} instance
      */
-    public final Either<L, R> recover(Function<L, Either<L, R>> recoverFunction) {
+    @SuppressWarnings("unchecked")
+    public final Either<L, R> recoverWith(Function<? super L, ? extends Either<? extends L, ? extends R>> recoveryFunction) {
+        Objects.requireNonNull(recoveryFunction, "recoveryFunction is null");
         if (isLeft()) {
-            return recoverFunction.apply(getLeft());
+            return (Either<L, R>) recoveryFunction.apply(getLeft());
         } else {
             return this;
         }
     }
 
     /**
-     * Calls recoverSupplier if the projected Either is a Left, performs no operation if this is a Right. This is
+     * Calls recoverySupplier if the projected Either is a Left, performs no operation if this is a Right. This is
      * similar to {@code getOrElseGet} where the fallback method also returns an Either.
      *
      * <pre>{@code
@@ -520,11 +522,12 @@ public abstract class Either<L, R> implements Iterable<R>, io.vavr.Value<R>, Ser
      * tryGetString().recover(this::tryGetStringAnotherWay);
      * }</pre>
      *
-     * @param recoverSupplier a {@code Supplier} which returns an Either
+     * @param recoverySupplier a {@code Supplier} which returns an Either
      * @return an {@code Either<L, R>} instance
      */
-    public final Either<L, R> recover(Supplier<Either<L, R>> recoverSupplier) {
-        return this.recover(l -> recoverSupplier.get());
+    public final Either<L, R> recoverWith(Supplier<? extends Either<? extends L, ? extends R>> recoverySupplier) {
+        Objects.requireNonNull(recoverySupplier, "recoverySupplier is null");
+        return this.recoverWith(l -> recoverySupplier.get());
     }
 
     // -- Adjusted return types of Monad methods

--- a/src/main/java/io/vavr/control/Either.java
+++ b/src/main/java/io/vavr/control/Either.java
@@ -483,6 +483,50 @@ public abstract class Either<L, R> implements Iterable<R>, io.vavr.Value<R>, Ser
         }
     }
 
+    /**
+     * Calls recoverFunction if the projected Either is a Left, performs no operation if this is a Right. This is
+     * similar to {@code getOrElseGet} where the fallback method also returns an Either.
+     *
+     * <pre>{@code
+     * Either<Integer, String> tryGetString() { return Either.left(1); }
+     *
+     * Either<Integer, String> tryGetStringAnotherWay(Integer lvalue) { return Either.right("yo " + lvalue); }
+     *
+     * = Right("yo 1")
+     * tryGetString().recover(this::tryGetStringAnotherWay);
+     * }</pre>
+     *
+     * @param recoverFunction a function which accepts a Left value and returns an Either
+     * @return an {@code Either<L, R>} instance
+     */
+    public final Either<L, R> recover(Function<L, Either<L, R>> recoverFunction) {
+        if (isLeft()) {
+            return recoverFunction.apply(getLeft());
+        } else {
+            return this;
+        }
+    }
+
+    /**
+     * Calls recoverSupplier if the projected Either is a Left, performs no operation if this is a Right. This is
+     * similar to {@code getOrElseGet} where the fallback method also returns an Either.
+     *
+     * <pre>{@code
+     * Either<Integer, String> tryGetString() { return Either.left(1); }
+     *
+     * Either<Integer, String> tryGetStringAnotherWay() { return Either.right("yo"); }
+     *
+     * = Right("yo")
+     * tryGetString().recover(this::tryGetStringAnotherWay);
+     * }</pre>
+     *
+     * @param recoverSupplier a {@code Supplier} which returns an Either
+     * @return an {@code Either<L, R>} instance
+     */
+    public final Either<L, R> recover(Supplier<Either<L, R>> recoverSupplier) {
+        return this.recover(l -> recoverSupplier.get());
+    }
+
     // -- Adjusted return types of Monad methods
 
     /**

--- a/src/main/java/io/vavr/control/Either.java
+++ b/src/main/java/io/vavr/control/Either.java
@@ -485,7 +485,7 @@ public abstract class Either<L, R> implements Iterable<R>, io.vavr.Value<R>, Ser
 
     /**
      * Calls recoveryFunction if the projected Either is a Left, performs no operation if this is a Right. This is
-     * similar to {@code getOrElseGet} where the fallback method also returns an Either.
+     * similar to {@code getOrElseGet}, but where the fallback method also returns an Either.
      *
      * <pre>{@code
      * Either<Integer, String> tryGetString() { return Either.left(1); }
@@ -498,6 +498,7 @@ public abstract class Either<L, R> implements Iterable<R>, io.vavr.Value<R>, Ser
      *
      * @param recoveryFunction a function which accepts a Left value and returns an Either
      * @return an {@code Either<L, R>} instance
+     * @throws NullPointerException if the given {@code recoveryFunction} is null
      */
     @SuppressWarnings("unchecked")
     public final Either<L, R> recoverWith(Function<? super L, ? extends Either<? extends L, ? extends R>> recoveryFunction) {
@@ -510,24 +511,29 @@ public abstract class Either<L, R> implements Iterable<R>, io.vavr.Value<R>, Ser
     }
 
     /**
-     * Calls recoverySupplier if the projected Either is a Left, performs no operation if this is a Right. This is
-     * similar to {@code getOrElseGet} where the fallback method also returns an Either.
+     * Calls {@code recoveryFunction} if the projected Either is a Left, or returns {@code this} if Right. The result
+     * of {@code recoveryFunction} will be projected as a Right.
      *
      * <pre>{@code
      * Either<Integer, String> tryGetString() { return Either.left(1); }
      *
-     * Either<Integer, String> tryGetStringAnotherWay() { return Either.right("yo"); }
+     * String getStringAnotherWay() { return "yo"; }
      *
      * = Right("yo")
-     * tryGetString().recover(this::tryGetStringAnotherWay);
+     * tryGetString().recover(this::getStringAnotherWay);
      * }</pre>
      *
-     * @param recoverySupplier a {@code Supplier} which returns an Either
+     * @param recoveryFunction a function which accepts a Left value and returns a Right value
      * @return an {@code Either<L, R>} instance
+     * @throws NullPointerException if the given {@code recoveryFunction} is null
      */
-    public final Either<L, R> recoverWith(Supplier<? extends Either<? extends L, ? extends R>> recoverySupplier) {
-        Objects.requireNonNull(recoverySupplier, "recoverySupplier is null");
-        return this.recoverWith(l -> recoverySupplier.get());
+    public final Either<L, R> recover(Function<? super L, ? extends R> recoveryFunction) {
+        Objects.requireNonNull(recoveryFunction, "recoveryFunction is null");
+        if (isLeft()) {
+            return Either.right(recoveryFunction.apply(getLeft()));
+        } else {
+            return this;
+        }
     }
 
     // -- Adjusted return types of Monad methods

--- a/src/test/java/io/vavr/control/EitherTest.java
+++ b/src/test/java/io/vavr/control/EitherTest.java
@@ -319,6 +319,34 @@ public class EitherTest extends AbstractValueTest {
         assertThat(Either.right(1).swap()).isEqualTo(Either.left(1));
     }
 
+    // -- recover
+
+    @Test
+    public void shouldRecoverLeftToRight() {
+        assertThat(Either.left(1).recover(() -> Either.right(2))).isEqualTo(Either.right(2));
+    }
+
+    @Test
+    public void shouldRecoverLeftToLeft() {
+        assertThat(Either.left(1).recover(() -> Either.left(2))).isEqualTo(Either.left(2));
+    }
+
+    @Test
+    public void shouldRecoverLeftToRightWithLValue() {
+        assertThat(Either.left(1).recover(lvalue -> Either.right(lvalue + 1))).isEqualTo(Either.right(2));
+    }
+
+    @Test
+    public void shouldRecoverLeftToLeftWithLValue() {
+        assertThat(Either.left(1).recover(lvalue -> Either.left(lvalue + 1))).isEqualTo(Either.left(2));
+    }
+
+    @Test
+    public void shouldRecoverRightNoOp() {
+        final Either<String, String> value = Either.<String, String>right("R").recover(() -> Either.left("L"));
+        assertThat(value).isEqualTo(Either.right("R"));
+    }
+
     // -- Either.narrow
 
     @Test

--- a/src/test/java/io/vavr/control/EitherTest.java
+++ b/src/test/java/io/vavr/control/EitherTest.java
@@ -323,27 +323,27 @@ public class EitherTest extends AbstractValueTest {
 
     @Test
     public void shouldRecoverLeftToRight() {
-        assertThat(Either.left(1).recover(() -> Either.right(2))).isEqualTo(Either.right(2));
+        assertThat(Either.left(1).recoverWith(() -> Either.right(2))).isEqualTo(Either.right(2));
     }
 
     @Test
     public void shouldRecoverLeftToLeft() {
-        assertThat(Either.left(1).recover(() -> Either.left(2))).isEqualTo(Either.left(2));
+        assertThat(Either.left(1).recoverWith(() -> Either.left(2))).isEqualTo(Either.left(2));
     }
 
     @Test
     public void shouldRecoverLeftToRightWithLValue() {
-        assertThat(Either.left(1).recover(lvalue -> Either.right(lvalue + 1))).isEqualTo(Either.right(2));
+        assertThat(Either.left(1).recoverWith(lvalue -> Either.right(lvalue + 1))).isEqualTo(Either.right(2));
     }
 
     @Test
     public void shouldRecoverLeftToLeftWithLValue() {
-        assertThat(Either.left(1).recover(lvalue -> Either.left(lvalue + 1))).isEqualTo(Either.left(2));
+        assertThat(Either.left(1).recoverWith(lvalue -> Either.left(lvalue + 1))).isEqualTo(Either.left(2));
     }
 
     @Test
     public void shouldRecoverRightNoOp() {
-        final Either<String, String> value = Either.<String, String>right("R").recover(() -> Either.left("L"));
+        final Either<String, String> value = Either.<String, String>right("R").recoverWith(() -> Either.left("L"));
         assertThat(value).isEqualTo(Either.right("R"));
     }
 

--- a/src/test/java/io/vavr/control/EitherTest.java
+++ b/src/test/java/io/vavr/control/EitherTest.java
@@ -322,29 +322,34 @@ public class EitherTest extends AbstractValueTest {
     // -- recover
 
     @Test
-    public void shouldRecoverLeftToRight() {
-        assertThat(Either.left(1).recoverWith(() -> Either.right(2))).isEqualTo(Either.right(2));
-    }
-
-    @Test
-    public void shouldRecoverLeftToLeft() {
-        assertThat(Either.left(1).recoverWith(() -> Either.left(2))).isEqualTo(Either.left(2));
-    }
-
-    @Test
-    public void shouldRecoverLeftToRightWithLValue() {
+    public void shouldRecoverWithLeftToRightEither() {
         assertThat(Either.left(1).recoverWith(lvalue -> Either.right(lvalue + 1))).isEqualTo(Either.right(2));
     }
 
     @Test
-    public void shouldRecoverLeftToLeftWithLValue() {
+    public void shouldRecoverWithLeftToLeftEither() {
         assertThat(Either.left(1).recoverWith(lvalue -> Either.left(lvalue + 1))).isEqualTo(Either.left(2));
     }
 
     @Test
-    public void shouldRecoverRightNoOp() {
-        final Either<String, String> value = Either.<String, String>right("R").recoverWith(() -> Either.left("L"));
+    public void shouldRecoverWithRight() {
+        final Either<String, String> value = Either.<String, String>right("R").recoverWith(lvalue -> Either.left("L"));
         assertThat(value).isEqualTo(Either.right("R"));
+    }
+
+    @Test
+    public void shouldRecoverLeft() {
+        assertThat(Either.left(1).recover(lvalue -> "R")).isEqualTo(Either.right("R"));
+    }
+
+    @Test
+    public void shouldRecoverRightWithoutInvokingRecovery() {
+        // Recover function should not be invoked, so hardcode it to fail
+        Function<Object, String> recoveryFunction = $ -> {
+            throw new RuntimeException("Lazy recovery function should not be invoked for a Right!");
+        };
+
+        assertThat(Either.right("R").recover(recoveryFunction)).isEqualTo(Either.right("R"));
     }
 
     // -- Either.narrow


### PR DESCRIPTION
This method is useful if you have a Left and want to try and convert it to a Right by calling a fallback method like `getOrElseGet`, but your fallback method might also fail and return another Left. I've been using something like this to conveniently implement read-through caches, but it would be nicer if it was built into vavr.