### PR TITLE
Add test for Array#get()

### DIFF
--- a/src/test/java/io/vavr/collection/ArrayTest.java
+++ b/src/test/java/io/vavr/collection/ArrayTest.java
@@ -20,13 +20,13 @@ package io.vavr.collection;
 
 import io.vavr.Tuple2;
 import io.vavr.control.Option;
-import org.junit.Test;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
 
 public class ArrayTest extends AbstractIndexedSeqTest {
 
@@ -212,6 +212,15 @@ public class ArrayTest extends AbstractIndexedSeqTest {
         final Array<Number> numbers = Array.narrow(doubles);
         final int actual = numbers.append(new BigDecimal("2.0")).sum().intValue();
         assertThat(actual).isEqualTo(3);
+    }
+
+    // -- get()
+
+    @Test
+    public void shouldThrowExceptionWhenGetIndexEqualToLength() {
+        final Array<Integer> array = of(1);
+        Assertions.assertThatThrownBy(() -> array.get(1))
+            .isInstanceOf(IndexOutOfBoundsException.class).hasMessage("get(1)");
     }
 
     // -- transform()


### PR DESCRIPTION
Add test for `io.vavr.collection.Array#get(int)` as described in #2497. The two screenshots below show the pitest result before and after the commit changes.

Before:

<img width="789" alt="Screenshot 2019-08-24 at 20 55 50" src="https://user-images.githubusercontent.com/10179217/63650139-abc60e80-c747-11e9-8ae2-cb145e84374b.png">

After:

![Screenshot 2019-08-25 at 14 06 25](https://user-images.githubusercontent.com/10179217/63650142-b41e4980-c747-11e9-85af-42f94c5cb3fd.png)
