### PR TITLE
Adjust Javadoc of LinkedHashSet::add.

### DIFF
--- a/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -483,7 +483,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
     }
 
     /**
-     * Add the given element to this set, replacing existing one if it is already contained.
+     * Add the given element to this set, doing nothing if it is already contained.
      * <p>
      * Note that this method has a worst-case linear complexity.
      *


### PR DESCRIPTION
Hello, I'd like to commit a minor adjustment.

I find this particular Javadoc misleading since it would not replace but ignore an element being added if it is already contained.

```java
    @Override
    public LinkedHashSet<T> add(T element) {
        return contains(element) ? this : new LinkedHashSet<>(map.put(element, element));
    }
```