### PR TITLE
Simplify internal implementation of Tuple#hash static methods

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -2255,7 +2255,10 @@ def generateMainClasses(): Unit = {
            * Return the order-dependent hash of the ${i.numerus("given value")}.
            ${(0 to i).gen(j => if (j == 0) "*" else s"* @param o$j the ${j.ordinal} value to hash")("\n")}
            * @return the same result as {@link $Objects#${if (i == 1) "hashCode(Object)" else "hash(Object...)"}}
+           *
+           * @deprecated use {@link Objects#hash} instead
            */
+          @Deprecated
           static int hash($paramsDecl) {
               ${if (i == 1) {
                 s"return $Objects.hashCode(o1);"

--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -2261,9 +2261,7 @@ def generateMainClasses(): Unit = {
                 s"return $Objects.hashCode(o1);"
               } else {
                 xs"""
-                  int result = 1;
-                  ${(1 to i).gen(j => s"result = 31 * result + hash(o$j);")("\n")}
-                  return result;
+                  return Objects.hash(${(1 to i).gen(j => s"o$j")(", ")});
                 """
               }}
           }

--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -2195,7 +2195,7 @@ def generateMainClasses(): Unit = {
 
             @Override
             public int hashCode() {
-                return ${if (i == 0) "1" else s"""Tuple.hash(${(1 to i).gen(j => s"_$j")(", ")})"""};
+                return ${if (i == 0) "1" else s"""Objects.hash(${(1 to i).gen(j => s"_$j")(", ")})"""};
             }
 
             @Override

--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -2195,7 +2195,7 @@ def generateMainClasses(): Unit = {
 
             @Override
             public int hashCode() {
-                return ${if (i == 0) "1" else s"""Objects.hash(${(1 to i).gen(j => s"_$j")(", ")})"""};
+                return ${if (i == 0) "1" else if (i == 1) "Objects.hashCode(_1)" else s"""Objects.hash(${(1 to i).gen(j => s"_$j")(", ")})"""};
             }
 
             @Override

--- a/src-gen/main/java/io/vavr/Tuple.java
+++ b/src-gen/main/java/io/vavr/Tuple.java
@@ -242,10 +242,7 @@ public interface Tuple {
      * @return the same result as {@link Objects#hash(Object...)}
      */
     static int hash(Object o1, Object o2) {
-        int result = 1;
-        result = 31 * result + hash(o1);
-        result = 31 * result + hash(o2);
-        return result;
+        return Objects.hash(o1, o2);
     }
 
     /**
@@ -257,11 +254,7 @@ public interface Tuple {
      * @return the same result as {@link Objects#hash(Object...)}
      */
     static int hash(Object o1, Object o2, Object o3) {
-        int result = 1;
-        result = 31 * result + hash(o1);
-        result = 31 * result + hash(o2);
-        result = 31 * result + hash(o3);
-        return result;
+        return Objects.hash(o1, o2, o3);
     }
 
     /**
@@ -274,12 +267,7 @@ public interface Tuple {
      * @return the same result as {@link Objects#hash(Object...)}
      */
     static int hash(Object o1, Object o2, Object o3, Object o4) {
-        int result = 1;
-        result = 31 * result + hash(o1);
-        result = 31 * result + hash(o2);
-        result = 31 * result + hash(o3);
-        result = 31 * result + hash(o4);
-        return result;
+        return Objects.hash(o1, o2, o3, o4);
     }
 
     /**
@@ -293,13 +281,7 @@ public interface Tuple {
      * @return the same result as {@link Objects#hash(Object...)}
      */
     static int hash(Object o1, Object o2, Object o3, Object o4, Object o5) {
-        int result = 1;
-        result = 31 * result + hash(o1);
-        result = 31 * result + hash(o2);
-        result = 31 * result + hash(o3);
-        result = 31 * result + hash(o4);
-        result = 31 * result + hash(o5);
-        return result;
+        return Objects.hash(o1, o2, o3, o4, o5);
     }
 
     /**
@@ -314,14 +296,7 @@ public interface Tuple {
      * @return the same result as {@link Objects#hash(Object...)}
      */
     static int hash(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6) {
-        int result = 1;
-        result = 31 * result + hash(o1);
-        result = 31 * result + hash(o2);
-        result = 31 * result + hash(o3);
-        result = 31 * result + hash(o4);
-        result = 31 * result + hash(o5);
-        result = 31 * result + hash(o6);
-        return result;
+        return Objects.hash(o1, o2, o3, o4, o5, o6);
     }
 
     /**
@@ -337,15 +312,7 @@ public interface Tuple {
      * @return the same result as {@link Objects#hash(Object...)}
      */
     static int hash(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6, Object o7) {
-        int result = 1;
-        result = 31 * result + hash(o1);
-        result = 31 * result + hash(o2);
-        result = 31 * result + hash(o3);
-        result = 31 * result + hash(o4);
-        result = 31 * result + hash(o5);
-        result = 31 * result + hash(o6);
-        result = 31 * result + hash(o7);
-        return result;
+        return Objects.hash(o1, o2, o3, o4, o5, o6, o7);
     }
 
     /**
@@ -362,16 +329,7 @@ public interface Tuple {
      * @return the same result as {@link Objects#hash(Object...)}
      */
     static int hash(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6, Object o7, Object o8) {
-        int result = 1;
-        result = 31 * result + hash(o1);
-        result = 31 * result + hash(o2);
-        result = 31 * result + hash(o3);
-        result = 31 * result + hash(o4);
-        result = 31 * result + hash(o5);
-        result = 31 * result + hash(o6);
-        result = 31 * result + hash(o7);
-        result = 31 * result + hash(o8);
-        return result;
+        return Objects.hash(o1, o2, o3, o4, o5, o6, o7, o8);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple.java
+++ b/src-gen/main/java/io/vavr/Tuple.java
@@ -229,7 +229,10 @@ public interface Tuple {
      *
      * @param o1 the 1st value to hash
      * @return the same result as {@link Objects#hashCode(Object)}
+     *
+     * @deprecated use {@link Objects#hash} instead
      */
+    @Deprecated
     static int hash(Object o1) {
         return Objects.hashCode(o1);
     }
@@ -240,7 +243,10 @@ public interface Tuple {
      * @param o1 the 1st value to hash
      * @param o2 the 2nd value to hash
      * @return the same result as {@link Objects#hash(Object...)}
+     *
+     * @deprecated use {@link Objects#hash} instead
      */
+    @Deprecated
     static int hash(Object o1, Object o2) {
         return Objects.hash(o1, o2);
     }
@@ -252,7 +258,10 @@ public interface Tuple {
      * @param o2 the 2nd value to hash
      * @param o3 the 3rd value to hash
      * @return the same result as {@link Objects#hash(Object...)}
+     *
+     * @deprecated use {@link Objects#hash} instead
      */
+    @Deprecated
     static int hash(Object o1, Object o2, Object o3) {
         return Objects.hash(o1, o2, o3);
     }
@@ -265,7 +274,10 @@ public interface Tuple {
      * @param o3 the 3rd value to hash
      * @param o4 the 4th value to hash
      * @return the same result as {@link Objects#hash(Object...)}
+     *
+     * @deprecated use {@link Objects#hash} instead
      */
+    @Deprecated
     static int hash(Object o1, Object o2, Object o3, Object o4) {
         return Objects.hash(o1, o2, o3, o4);
     }
@@ -279,7 +291,10 @@ public interface Tuple {
      * @param o4 the 4th value to hash
      * @param o5 the 5th value to hash
      * @return the same result as {@link Objects#hash(Object...)}
+     *
+     * @deprecated use {@link Objects#hash} instead
      */
+    @Deprecated
     static int hash(Object o1, Object o2, Object o3, Object o4, Object o5) {
         return Objects.hash(o1, o2, o3, o4, o5);
     }
@@ -294,7 +309,10 @@ public interface Tuple {
      * @param o5 the 5th value to hash
      * @param o6 the 6th value to hash
      * @return the same result as {@link Objects#hash(Object...)}
+     *
+     * @deprecated use {@link Objects#hash} instead
      */
+    @Deprecated
     static int hash(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6) {
         return Objects.hash(o1, o2, o3, o4, o5, o6);
     }
@@ -310,7 +328,10 @@ public interface Tuple {
      * @param o6 the 6th value to hash
      * @param o7 the 7th value to hash
      * @return the same result as {@link Objects#hash(Object...)}
+     *
+     * @deprecated use {@link Objects#hash} instead
      */
+    @Deprecated
     static int hash(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6, Object o7) {
         return Objects.hash(o1, o2, o3, o4, o5, o6, o7);
     }
@@ -327,7 +348,10 @@ public interface Tuple {
      * @param o7 the 7th value to hash
      * @param o8 the 8th value to hash
      * @return the same result as {@link Objects#hash(Object...)}
+     *
+     * @deprecated use {@link Objects#hash} instead
      */
+    @Deprecated
     static int hash(Object o1, Object o2, Object o3, Object o4, Object o5, Object o6, Object o7, Object o8) {
         return Objects.hash(o1, o2, o3, o4, o5, o6, o7, o8);
     }

--- a/src-gen/main/java/io/vavr/Tuple1.java
+++ b/src-gen/main/java/io/vavr/Tuple1.java
@@ -281,7 +281,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
 
     @Override
     public int hashCode() {
-        return Tuple.hash(_1);
+        return Objects.hash(_1);
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple1.java
+++ b/src-gen/main/java/io/vavr/Tuple1.java
@@ -281,7 +281,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
 
     @Override
     public int hashCode() {
-        return Objects.hash(_1);
+        return Objects.hashCode(_1);
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple2.java
+++ b/src-gen/main/java/io/vavr/Tuple2.java
@@ -364,7 +364,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
 
     @Override
     public int hashCode() {
-        return Tuple.hash(_1, _2);
+        return Objects.hash(_1, _2);
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple3.java
+++ b/src-gen/main/java/io/vavr/Tuple3.java
@@ -379,7 +379,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
 
     @Override
     public int hashCode() {
-        return Tuple.hash(_1, _2, _3);
+        return Objects.hash(_1, _2, _3);
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple4.java
+++ b/src-gen/main/java/io/vavr/Tuple4.java
@@ -417,7 +417,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
 
     @Override
     public int hashCode() {
-        return Tuple.hash(_1, _2, _3, _4);
+        return Objects.hash(_1, _2, _3, _4);
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple5.java
+++ b/src-gen/main/java/io/vavr/Tuple5.java
@@ -456,7 +456,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
 
     @Override
     public int hashCode() {
-        return Tuple.hash(_1, _2, _3, _4, _5);
+        return Objects.hash(_1, _2, _3, _4, _5);
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple6.java
+++ b/src-gen/main/java/io/vavr/Tuple6.java
@@ -496,7 +496,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
 
     @Override
     public int hashCode() {
-        return Tuple.hash(_1, _2, _3, _4, _5, _6);
+        return Objects.hash(_1, _2, _3, _4, _5, _6);
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple7.java
+++ b/src-gen/main/java/io/vavr/Tuple7.java
@@ -537,7 +537,7 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
 
     @Override
     public int hashCode() {
-        return Tuple.hash(_1, _2, _3, _4, _5, _6, _7);
+        return Objects.hash(_1, _2, _3, _4, _5, _6, _7);
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple8.java
+++ b/src-gen/main/java/io/vavr/Tuple8.java
@@ -569,7 +569,7 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
 
     @Override
     public int hashCode() {
-        return Tuple.hash(_1, _2, _3, _4, _5, _6, _7, _8);
+        return Objects.hash(_1, _2, _3, _4, _5, _6, _7, _8);
     }
 
     @Override


### PR DESCRIPTION
Since `TupleN` hash tests use `Objects#hash()` to validate calculated hashes, why not just reuse it in the internal implementation? 

```assertThat(t.hashCode()).isEqualTo(Objects.hash(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8));```

I assume that we need these helper methods only to provide an abstraction layer in case someone wants to swap the hashing strategy.