### PR TITLE
Fix Traversable#sliding documentation

### DIFF
--- a/src/main/java/io/vavr/collection/Traversable.java
+++ b/src/main/java/io/vavr/collection/Traversable.java
@@ -1454,7 +1454,7 @@ public interface Traversable<T> extends Iterable<T>, Foldable<T>, io.vavr.Value<
      * [1,2,3,4,5].sliding(2,3) = [[1,2],[4,5]]
      * [1,2,3,4,5].sliding(2,4) = [[1,2],[5]]
      * [1,2,3,4,5].sliding(2,5) = [[1,2]]
-     * [1,2,3,4].sliding(5,3) = [[1,2,3,4],[4]]
+     * [1,2,3,4].sliding(5,3) = [[1,2,3,4]]
      * </code>
      * </pre>
      *


### PR DESCRIPTION
closes https://github.com/vavr-io/vavr/issues/2518
----
The following behaviour is enforced by a test:

https://github.com/vavr-io/vavr/blob/a53c966a27eb3ddbf88cab3de31801a35d29ea9e/src/test/java/io/vavr/collection/AbstractTraversableTest.java#L2034-L2039

