### PR TITLE
Deprecate current for-comprehension API

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -838,7 +838,6 @@ def generateMainClasses(): Unit = {
                      *
                      * @return an {@code Iterator} of mapped results
                      *
-                     *
                      * @deprecated to be replaced with revised JDK13-compliant API
                      */
                     @Deprecated

--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -818,7 +818,7 @@ def generateMainClasses(): Unit = {
                    * @param <R> type of the resulting {@code $rtype} elements
                    * @return an {@code $rtype} of mapped results
                    *
-                   * @deprecated marked for removal
+                   * @deprecated to be replaced with revised JDK13-compliant API
                    */
                   @Deprecated
                   public <R> ${if(mtype == "Either") s"$rtype<L, R>" else s"$rtype<R>"} yield($functionType<$args, ? extends R> f) {

--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -756,7 +756,7 @@ def generateMainClasses(): Unit = {
            * @param <U> component type of the resulting {@code Iterator}
            * @return A new Iterator
            *
-           * @deprecated marked for removal
+           * @deprecated to be replaced with revised JDK13-compliant API
            */
           @Deprecated
           public static <T, U> $IteratorType<U> For(Iterable<T> ts, Function<? super T, ? extends Iterable<U>> f) {
@@ -775,7 +775,7 @@ def generateMainClasses(): Unit = {
                ${(1 to i).gen(j => s"* @param <T$j> right component type of the ${j.ordinal} $mtype")("\n")}
                * @return a new {@code For}-comprehension of arity $i
                *
-               * @deprecated marked for removal
+               * @deprecated to be replaced with revised JDK13-compliant API
                */
               @Deprecated
               public static <${if(mtype == "Either") "L, " else ""}$generics> $forClassName<${if(mtype == "Either") "L, " else ""}$generics> For($params) {
@@ -800,7 +800,7 @@ def generateMainClasses(): Unit = {
               /$javadoc
                * For-comprehension with ${i.numerus(mtype)}.
                *
-               * @deprecated marked for removal
+               * @deprecated to be replaced with revised JDK13-compliant API
                */
               @Deprecated
               public static class $forClassName<${(if(mtype == "Either") "L, " else "") + generics}> {
@@ -839,7 +839,7 @@ def generateMainClasses(): Unit = {
                      * @return an {@code Iterator} of mapped results
                      *
                      *
-                     * @deprecated marked for removal
+                     * @deprecated to be replaced with revised JDK13-compliant API
                      */
                     @Deprecated
                     public ${if(mtype == "Either") s"$rtype<L, T1>" else s"$rtype<T1>"} yield() {

--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -755,7 +755,10 @@ def generateMainClasses(): Unit = {
            * @param <T> element type of {@code ts}
            * @param <U> component type of the resulting {@code Iterator}
            * @return A new Iterator
+           *
+           * @deprecated marked for removal
            */
+          @Deprecated
           public static <T, U> $IteratorType<U> For(Iterable<T> ts, Function<? super T, ? extends Iterable<U>> f) {
               return $IteratorType.ofAll(ts).flatMap(f);
           }
@@ -771,7 +774,10 @@ def generateMainClasses(): Unit = {
                ${(mtype == "Either").gen("@param <L> left component type of the given Either types")}
                ${(1 to i).gen(j => s"* @param <T$j> right component type of the ${j.ordinal} $mtype")("\n")}
                * @return a new {@code For}-comprehension of arity $i
+               *
+               * @deprecated marked for removal
                */
+              @Deprecated
               public static <${if(mtype == "Either") "L, " else ""}$generics> $forClassName<${if(mtype == "Either") "L, " else ""}$generics> For($params) {
                   ${(1 to i).gen(j => xs"""$Objects.requireNonNull(ts$j, "ts$j is null");""")("\n")}
                   return new $forClassName<>(${(1 to i).gen(j => s"ts$j")(", ")});
@@ -793,7 +799,10 @@ def generateMainClasses(): Unit = {
             xs"""
               /$javadoc
                * For-comprehension with ${i.numerus(mtype)}.
+               *
+               * @deprecated marked for removal
                */
+              @Deprecated
               public static class $forClassName<${(if(mtype == "Either") "L, " else "") + generics}> {
 
                   ${(1 to i).gen(j => xs"""private final $mtype<${(if(mtype == "Either") "L, " else "") + s"T$j"}> ts$j;""")("\n")}
@@ -808,7 +817,10 @@ def generateMainClasses(): Unit = {
                    * @param f a function that maps an element of the cross product to a result
                    * @param <R> type of the resulting {@code $rtype} elements
                    * @return an {@code $rtype} of mapped results
+                   *
+                   * @deprecated marked for removal
                    */
+                  @Deprecated
                   public <R> ${if(mtype == "Either") s"$rtype<L, R>" else s"$rtype<R>"} yield($functionType<$args, ? extends R> f) {
                       $Objects.requireNonNull(f, "f is null");
                       ${if (i == 1) xs"""
@@ -825,7 +837,11 @@ def generateMainClasses(): Unit = {
                      * A shortcut for {@code yield(Function.identity())}.
                      *
                      * @return an {@code Iterator} of mapped results
+                     *
+                     *
+                     * @deprecated marked for removal
                      */
+                    @Deprecated
                     public ${if(mtype == "Either") s"$rtype<L, T1>" else s"$rtype<T1>"} yield() {
                         return yield(Function.identity());
                     }

--- a/src-gen/main/java/io/vavr/API.java
+++ b/src-gen/main/java/io/vavr/API.java
@@ -3629,7 +3629,7 @@ public final class API {
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Iterator<R> yield(Function<? super T1, ? extends R> f) {
@@ -3673,7 +3673,7 @@ public final class API {
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Iterator<R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
@@ -3710,7 +3710,7 @@ public final class API {
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Iterator<R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
@@ -3750,7 +3750,7 @@ public final class API {
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Iterator<R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
@@ -3793,7 +3793,7 @@ public final class API {
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Iterator<R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
@@ -3839,7 +3839,7 @@ public final class API {
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Iterator<R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
@@ -3888,7 +3888,7 @@ public final class API {
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Iterator<R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
@@ -3940,7 +3940,7 @@ public final class API {
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Iterator<R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
@@ -3979,7 +3979,7 @@ public final class API {
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Option<R> yield(Function<? super T1, ? extends R> f) {
@@ -4023,7 +4023,7 @@ public final class API {
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Option<R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
@@ -4060,7 +4060,7 @@ public final class API {
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Option<R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
@@ -4100,7 +4100,7 @@ public final class API {
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Option<R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
@@ -4143,7 +4143,7 @@ public final class API {
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Option<R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
@@ -4189,7 +4189,7 @@ public final class API {
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Option<R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
@@ -4238,7 +4238,7 @@ public final class API {
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Option<R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
@@ -4290,7 +4290,7 @@ public final class API {
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Option<R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
@@ -4329,7 +4329,7 @@ public final class API {
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Future<R> yield(Function<? super T1, ? extends R> f) {
@@ -4373,7 +4373,7 @@ public final class API {
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Future<R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
@@ -4410,7 +4410,7 @@ public final class API {
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Future<R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
@@ -4450,7 +4450,7 @@ public final class API {
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Future<R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
@@ -4493,7 +4493,7 @@ public final class API {
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Future<R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
@@ -4539,7 +4539,7 @@ public final class API {
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Future<R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
@@ -4588,7 +4588,7 @@ public final class API {
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Future<R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
@@ -4640,7 +4640,7 @@ public final class API {
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Future<R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
@@ -4679,7 +4679,7 @@ public final class API {
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Try<R> yield(Function<? super T1, ? extends R> f) {
@@ -4723,7 +4723,7 @@ public final class API {
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Try<R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
@@ -4760,7 +4760,7 @@ public final class API {
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Try<R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
@@ -4800,7 +4800,7 @@ public final class API {
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Try<R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
@@ -4843,7 +4843,7 @@ public final class API {
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Try<R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
@@ -4889,7 +4889,7 @@ public final class API {
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Try<R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
@@ -4938,7 +4938,7 @@ public final class API {
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Try<R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
@@ -4990,7 +4990,7 @@ public final class API {
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Try<R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
@@ -5029,7 +5029,7 @@ public final class API {
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Either<L, R> yield(Function<? super T1, ? extends R> f) {
@@ -5073,7 +5073,7 @@ public final class API {
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Either<L, R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
@@ -5110,7 +5110,7 @@ public final class API {
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Either<L, R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
@@ -5150,7 +5150,7 @@ public final class API {
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Either<L, R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
@@ -5193,7 +5193,7 @@ public final class API {
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Either<L, R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
@@ -5239,7 +5239,7 @@ public final class API {
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Either<L, R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
@@ -5288,7 +5288,7 @@ public final class API {
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Either<L, R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
@@ -5340,7 +5340,7 @@ public final class API {
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> Either<L, R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
@@ -5379,7 +5379,7 @@ public final class API {
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> List<R> yield(Function<? super T1, ? extends R> f) {
@@ -5423,7 +5423,7 @@ public final class API {
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> List<R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
@@ -5460,7 +5460,7 @@ public final class API {
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> List<R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
@@ -5500,7 +5500,7 @@ public final class API {
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> List<R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
@@ -5543,7 +5543,7 @@ public final class API {
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> List<R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
@@ -5589,7 +5589,7 @@ public final class API {
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> List<R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
@@ -5638,7 +5638,7 @@ public final class API {
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> List<R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
@@ -5690,7 +5690,7 @@ public final class API {
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public <R> List<R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {

--- a/src-gen/main/java/io/vavr/API.java
+++ b/src-gen/main/java/io/vavr/API.java
@@ -3642,7 +3642,6 @@ public final class API {
           *
           * @return an {@code Iterator} of mapped results
           *
-          *
           * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
@@ -3992,7 +3991,6 @@ public final class API {
           * A shortcut for {@code yield(Function.identity())}.
           *
           * @return an {@code Iterator} of mapped results
-          *
           *
           * @deprecated to be replaced with revised JDK13-compliant API
           */
@@ -4344,7 +4342,6 @@ public final class API {
           *
           * @return an {@code Iterator} of mapped results
           *
-          *
           * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
@@ -4694,7 +4691,6 @@ public final class API {
           * A shortcut for {@code yield(Function.identity())}.
           *
           * @return an {@code Iterator} of mapped results
-          *
           *
           * @deprecated to be replaced with revised JDK13-compliant API
           */
@@ -5046,7 +5042,6 @@ public final class API {
           *
           * @return an {@code Iterator} of mapped results
           *
-          *
           * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
@@ -5396,7 +5391,6 @@ public final class API {
           * A shortcut for {@code yield(Function.identity())}.
           *
           * @return an {@code Iterator} of mapped results
-          *
           *
           * @deprecated to be replaced with revised JDK13-compliant API
           */

--- a/src-gen/main/java/io/vavr/API.java
+++ b/src-gen/main/java/io/vavr/API.java
@@ -2328,7 +2328,10 @@ public final class API {
      * @param <T> element type of {@code ts}
      * @param <U> component type of the resulting {@code Iterator}
      * @return A new Iterator
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T, U> Iterator<U> For(Iterable<T> ts, Function<? super T, ? extends Iterable<U>> f) {
         return Iterator.ofAll(ts).flatMap(f);
     }
@@ -2340,7 +2343,10 @@ public final class API {
 
      * @param <T1> right component type of the 1st Iterable
      * @return a new {@code For}-comprehension of arity 1
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1> For1<T1> For(Iterable<T1> ts1) {
         Objects.requireNonNull(ts1, "ts1 is null");
         return new For1<>(ts1);
@@ -2355,7 +2361,10 @@ public final class API {
      * @param <T1> right component type of the 1st Iterable
      * @param <T2> right component type of the 2nd Iterable
      * @return a new {@code For}-comprehension of arity 2
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2> For2<T1, T2> For(Iterable<T1> ts1, Iterable<T2> ts2) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2373,7 +2382,10 @@ public final class API {
      * @param <T2> right component type of the 2nd Iterable
      * @param <T3> right component type of the 3rd Iterable
      * @return a new {@code For}-comprehension of arity 3
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3> For3<T1, T2, T3> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2394,7 +2406,10 @@ public final class API {
      * @param <T3> right component type of the 3rd Iterable
      * @param <T4> right component type of the 4th Iterable
      * @return a new {@code For}-comprehension of arity 4
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4> For4<T1, T2, T3, T4> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3, Iterable<T4> ts4) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2418,7 +2433,10 @@ public final class API {
      * @param <T4> right component type of the 4th Iterable
      * @param <T5> right component type of the 5th Iterable
      * @return a new {@code For}-comprehension of arity 5
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5> For5<T1, T2, T3, T4, T5> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3, Iterable<T4> ts4, Iterable<T5> ts5) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2445,7 +2463,10 @@ public final class API {
      * @param <T5> right component type of the 5th Iterable
      * @param <T6> right component type of the 6th Iterable
      * @return a new {@code For}-comprehension of arity 6
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6> For6<T1, T2, T3, T4, T5, T6> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3, Iterable<T4> ts4, Iterable<T5> ts5, Iterable<T6> ts6) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2475,7 +2496,10 @@ public final class API {
      * @param <T6> right component type of the 6th Iterable
      * @param <T7> right component type of the 7th Iterable
      * @return a new {@code For}-comprehension of arity 7
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7> For7<T1, T2, T3, T4, T5, T6, T7> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3, Iterable<T4> ts4, Iterable<T5> ts5, Iterable<T6> ts6, Iterable<T7> ts7) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2508,7 +2532,10 @@ public final class API {
      * @param <T7> right component type of the 7th Iterable
      * @param <T8> right component type of the 8th Iterable
      * @return a new {@code For}-comprehension of arity 8
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7, T8> For8<T1, T2, T3, T4, T5, T6, T7, T8> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3, Iterable<T4> ts4, Iterable<T5> ts5, Iterable<T6> ts6, Iterable<T7> ts7, Iterable<T8> ts8) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2528,7 +2555,10 @@ public final class API {
 
      * @param <T1> right component type of the 1st Option
      * @return a new {@code For}-comprehension of arity 1
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1> For1Option<T1> For(Option<T1> ts1) {
         Objects.requireNonNull(ts1, "ts1 is null");
         return new For1Option<>(ts1);
@@ -2543,7 +2573,10 @@ public final class API {
      * @param <T1> right component type of the 1st Option
      * @param <T2> right component type of the 2nd Option
      * @return a new {@code For}-comprehension of arity 2
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2> For2Option<T1, T2> For(Option<T1> ts1, Option<T2> ts2) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2561,7 +2594,10 @@ public final class API {
      * @param <T2> right component type of the 2nd Option
      * @param <T3> right component type of the 3rd Option
      * @return a new {@code For}-comprehension of arity 3
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3> For3Option<T1, T2, T3> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2582,7 +2618,10 @@ public final class API {
      * @param <T3> right component type of the 3rd Option
      * @param <T4> right component type of the 4th Option
      * @return a new {@code For}-comprehension of arity 4
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4> For4Option<T1, T2, T3, T4> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3, Option<T4> ts4) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2606,7 +2645,10 @@ public final class API {
      * @param <T4> right component type of the 4th Option
      * @param <T5> right component type of the 5th Option
      * @return a new {@code For}-comprehension of arity 5
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5> For5Option<T1, T2, T3, T4, T5> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3, Option<T4> ts4, Option<T5> ts5) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2633,7 +2675,10 @@ public final class API {
      * @param <T5> right component type of the 5th Option
      * @param <T6> right component type of the 6th Option
      * @return a new {@code For}-comprehension of arity 6
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6> For6Option<T1, T2, T3, T4, T5, T6> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3, Option<T4> ts4, Option<T5> ts5, Option<T6> ts6) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2663,7 +2708,10 @@ public final class API {
      * @param <T6> right component type of the 6th Option
      * @param <T7> right component type of the 7th Option
      * @return a new {@code For}-comprehension of arity 7
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7> For7Option<T1, T2, T3, T4, T5, T6, T7> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3, Option<T4> ts4, Option<T5> ts5, Option<T6> ts6, Option<T7> ts7) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2696,7 +2744,10 @@ public final class API {
      * @param <T7> right component type of the 7th Option
      * @param <T8> right component type of the 8th Option
      * @return a new {@code For}-comprehension of arity 8
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7, T8> For8Option<T1, T2, T3, T4, T5, T6, T7, T8> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3, Option<T4> ts4, Option<T5> ts5, Option<T6> ts6, Option<T7> ts7, Option<T8> ts8) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2716,7 +2767,10 @@ public final class API {
 
      * @param <T1> right component type of the 1st Future
      * @return a new {@code For}-comprehension of arity 1
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1> For1Future<T1> For(Future<T1> ts1) {
         Objects.requireNonNull(ts1, "ts1 is null");
         return new For1Future<>(ts1);
@@ -2731,7 +2785,10 @@ public final class API {
      * @param <T1> right component type of the 1st Future
      * @param <T2> right component type of the 2nd Future
      * @return a new {@code For}-comprehension of arity 2
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2> For2Future<T1, T2> For(Future<T1> ts1, Future<T2> ts2) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2749,7 +2806,10 @@ public final class API {
      * @param <T2> right component type of the 2nd Future
      * @param <T3> right component type of the 3rd Future
      * @return a new {@code For}-comprehension of arity 3
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3> For3Future<T1, T2, T3> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2770,7 +2830,10 @@ public final class API {
      * @param <T3> right component type of the 3rd Future
      * @param <T4> right component type of the 4th Future
      * @return a new {@code For}-comprehension of arity 4
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4> For4Future<T1, T2, T3, T4> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3, Future<T4> ts4) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2794,7 +2857,10 @@ public final class API {
      * @param <T4> right component type of the 4th Future
      * @param <T5> right component type of the 5th Future
      * @return a new {@code For}-comprehension of arity 5
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5> For5Future<T1, T2, T3, T4, T5> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3, Future<T4> ts4, Future<T5> ts5) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2821,7 +2887,10 @@ public final class API {
      * @param <T5> right component type of the 5th Future
      * @param <T6> right component type of the 6th Future
      * @return a new {@code For}-comprehension of arity 6
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6> For6Future<T1, T2, T3, T4, T5, T6> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3, Future<T4> ts4, Future<T5> ts5, Future<T6> ts6) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2851,7 +2920,10 @@ public final class API {
      * @param <T6> right component type of the 6th Future
      * @param <T7> right component type of the 7th Future
      * @return a new {@code For}-comprehension of arity 7
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7> For7Future<T1, T2, T3, T4, T5, T6, T7> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3, Future<T4> ts4, Future<T5> ts5, Future<T6> ts6, Future<T7> ts7) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2884,7 +2956,10 @@ public final class API {
      * @param <T7> right component type of the 7th Future
      * @param <T8> right component type of the 8th Future
      * @return a new {@code For}-comprehension of arity 8
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7, T8> For8Future<T1, T2, T3, T4, T5, T6, T7, T8> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3, Future<T4> ts4, Future<T5> ts5, Future<T6> ts6, Future<T7> ts7, Future<T8> ts8) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2904,7 +2979,10 @@ public final class API {
 
      * @param <T1> right component type of the 1st Try
      * @return a new {@code For}-comprehension of arity 1
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1> For1Try<T1> For(Try<T1> ts1) {
         Objects.requireNonNull(ts1, "ts1 is null");
         return new For1Try<>(ts1);
@@ -2919,7 +2997,10 @@ public final class API {
      * @param <T1> right component type of the 1st Try
      * @param <T2> right component type of the 2nd Try
      * @return a new {@code For}-comprehension of arity 2
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2> For2Try<T1, T2> For(Try<T1> ts1, Try<T2> ts2) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2937,7 +3018,10 @@ public final class API {
      * @param <T2> right component type of the 2nd Try
      * @param <T3> right component type of the 3rd Try
      * @return a new {@code For}-comprehension of arity 3
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3> For3Try<T1, T2, T3> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2958,7 +3042,10 @@ public final class API {
      * @param <T3> right component type of the 3rd Try
      * @param <T4> right component type of the 4th Try
      * @return a new {@code For}-comprehension of arity 4
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4> For4Try<T1, T2, T3, T4> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3, Try<T4> ts4) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -2982,7 +3069,10 @@ public final class API {
      * @param <T4> right component type of the 4th Try
      * @param <T5> right component type of the 5th Try
      * @return a new {@code For}-comprehension of arity 5
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5> For5Try<T1, T2, T3, T4, T5> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3, Try<T4> ts4, Try<T5> ts5) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3009,7 +3099,10 @@ public final class API {
      * @param <T5> right component type of the 5th Try
      * @param <T6> right component type of the 6th Try
      * @return a new {@code For}-comprehension of arity 6
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6> For6Try<T1, T2, T3, T4, T5, T6> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3, Try<T4> ts4, Try<T5> ts5, Try<T6> ts6) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3039,7 +3132,10 @@ public final class API {
      * @param <T6> right component type of the 6th Try
      * @param <T7> right component type of the 7th Try
      * @return a new {@code For}-comprehension of arity 7
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7> For7Try<T1, T2, T3, T4, T5, T6, T7> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3, Try<T4> ts4, Try<T5> ts5, Try<T6> ts6, Try<T7> ts7) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3072,7 +3168,10 @@ public final class API {
      * @param <T7> right component type of the 7th Try
      * @param <T8> right component type of the 8th Try
      * @return a new {@code For}-comprehension of arity 8
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7, T8> For8Try<T1, T2, T3, T4, T5, T6, T7, T8> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3, Try<T4> ts4, Try<T5> ts5, Try<T6> ts6, Try<T7> ts7, Try<T8> ts8) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3092,7 +3191,10 @@ public final class API {
      @param <L> left component type of the given Either types
      * @param <T1> right component type of the 1st Either
      * @return a new {@code For}-comprehension of arity 1
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <L, T1> For1Either<L, T1> For(Either<L, T1> ts1) {
         Objects.requireNonNull(ts1, "ts1 is null");
         return new For1Either<>(ts1);
@@ -3107,7 +3209,10 @@ public final class API {
      * @param <T1> right component type of the 1st Either
      * @param <T2> right component type of the 2nd Either
      * @return a new {@code For}-comprehension of arity 2
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <L, T1, T2> For2Either<L, T1, T2> For(Either<L, T1> ts1, Either<L, T2> ts2) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3125,7 +3230,10 @@ public final class API {
      * @param <T2> right component type of the 2nd Either
      * @param <T3> right component type of the 3rd Either
      * @return a new {@code For}-comprehension of arity 3
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <L, T1, T2, T3> For3Either<L, T1, T2, T3> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3146,7 +3254,10 @@ public final class API {
      * @param <T3> right component type of the 3rd Either
      * @param <T4> right component type of the 4th Either
      * @return a new {@code For}-comprehension of arity 4
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <L, T1, T2, T3, T4> For4Either<L, T1, T2, T3, T4> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3, Either<L, T4> ts4) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3170,7 +3281,10 @@ public final class API {
      * @param <T4> right component type of the 4th Either
      * @param <T5> right component type of the 5th Either
      * @return a new {@code For}-comprehension of arity 5
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <L, T1, T2, T3, T4, T5> For5Either<L, T1, T2, T3, T4, T5> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3, Either<L, T4> ts4, Either<L, T5> ts5) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3197,7 +3311,10 @@ public final class API {
      * @param <T5> right component type of the 5th Either
      * @param <T6> right component type of the 6th Either
      * @return a new {@code For}-comprehension of arity 6
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <L, T1, T2, T3, T4, T5, T6> For6Either<L, T1, T2, T3, T4, T5, T6> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3, Either<L, T4> ts4, Either<L, T5> ts5, Either<L, T6> ts6) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3227,7 +3344,10 @@ public final class API {
      * @param <T6> right component type of the 6th Either
      * @param <T7> right component type of the 7th Either
      * @return a new {@code For}-comprehension of arity 7
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <L, T1, T2, T3, T4, T5, T6, T7> For7Either<L, T1, T2, T3, T4, T5, T6, T7> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3, Either<L, T4> ts4, Either<L, T5> ts5, Either<L, T6> ts6, Either<L, T7> ts7) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3260,7 +3380,10 @@ public final class API {
      * @param <T7> right component type of the 7th Either
      * @param <T8> right component type of the 8th Either
      * @return a new {@code For}-comprehension of arity 8
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <L, T1, T2, T3, T4, T5, T6, T7, T8> For8Either<L, T1, T2, T3, T4, T5, T6, T7, T8> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3, Either<L, T4> ts4, Either<L, T5> ts5, Either<L, T6> ts6, Either<L, T7> ts7, Either<L, T8> ts8) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3280,7 +3403,10 @@ public final class API {
 
      * @param <T1> right component type of the 1st List
      * @return a new {@code For}-comprehension of arity 1
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1> For1List<T1> For(List<T1> ts1) {
         Objects.requireNonNull(ts1, "ts1 is null");
         return new For1List<>(ts1);
@@ -3295,7 +3421,10 @@ public final class API {
      * @param <T1> right component type of the 1st List
      * @param <T2> right component type of the 2nd List
      * @return a new {@code For}-comprehension of arity 2
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2> For2List<T1, T2> For(List<T1> ts1, List<T2> ts2) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3313,7 +3442,10 @@ public final class API {
      * @param <T2> right component type of the 2nd List
      * @param <T3> right component type of the 3rd List
      * @return a new {@code For}-comprehension of arity 3
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3> For3List<T1, T2, T3> For(List<T1> ts1, List<T2> ts2, List<T3> ts3) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3334,7 +3466,10 @@ public final class API {
      * @param <T3> right component type of the 3rd List
      * @param <T4> right component type of the 4th List
      * @return a new {@code For}-comprehension of arity 4
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4> For4List<T1, T2, T3, T4> For(List<T1> ts1, List<T2> ts2, List<T3> ts3, List<T4> ts4) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3358,7 +3493,10 @@ public final class API {
      * @param <T4> right component type of the 4th List
      * @param <T5> right component type of the 5th List
      * @return a new {@code For}-comprehension of arity 5
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5> For5List<T1, T2, T3, T4, T5> For(List<T1> ts1, List<T2> ts2, List<T3> ts3, List<T4> ts4, List<T5> ts5) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3385,7 +3523,10 @@ public final class API {
      * @param <T5> right component type of the 5th List
      * @param <T6> right component type of the 6th List
      * @return a new {@code For}-comprehension of arity 6
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6> For6List<T1, T2, T3, T4, T5, T6> For(List<T1> ts1, List<T2> ts2, List<T3> ts3, List<T4> ts4, List<T5> ts5, List<T6> ts6) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3415,7 +3556,10 @@ public final class API {
      * @param <T6> right component type of the 6th List
      * @param <T7> right component type of the 7th List
      * @return a new {@code For}-comprehension of arity 7
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7> For7List<T1, T2, T3, T4, T5, T6, T7> For(List<T1> ts1, List<T2> ts2, List<T3> ts3, List<T4> ts4, List<T5> ts5, List<T6> ts6, List<T7> ts7) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3448,7 +3592,10 @@ public final class API {
      * @param <T7> right component type of the 7th List
      * @param <T8> right component type of the 8th List
      * @return a new {@code For}-comprehension of arity 8
+     *
+     * @deprecated marked for removal
      */
+    @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7, T8> For8List<T1, T2, T3, T4, T5, T6, T7, T8> For(List<T1> ts1, List<T2> ts2, List<T3> ts3, List<T4> ts4, List<T5> ts5, List<T6> ts6, List<T7> ts7, List<T8> ts8) {
         Objects.requireNonNull(ts1, "ts1 is null");
         Objects.requireNonNull(ts2, "ts2 is null");
@@ -3463,7 +3610,10 @@ public final class API {
 
      /**
       * For-comprehension with one Iterable.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For1<T1> {
 
          private final Iterable<T1> ts1;
@@ -3478,7 +3628,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Iterator<R> yield(Function<? super T1, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return Iterator.ofAll(ts1).map(f);
@@ -3488,7 +3641,11 @@ public final class API {
           * A shortcut for {@code yield(Function.identity())}.
           *
           * @return an {@code Iterator} of mapped results
+          *
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public Iterator<T1> yield() {
              return yield(Function.identity());
          }
@@ -3496,7 +3653,10 @@ public final class API {
 
      /**
       * For-comprehension with two Iterables.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For2<T1, T2> {
 
          private final Iterable<T1> ts1;
@@ -3513,7 +3673,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Iterator<R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3525,7 +3688,10 @@ public final class API {
 
      /**
       * For-comprehension with three Iterables.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For3<T1, T2, T3> {
 
          private final Iterable<T1> ts1;
@@ -3544,7 +3710,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Iterator<R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3557,7 +3726,10 @@ public final class API {
 
      /**
       * For-comprehension with 4 Iterables.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For4<T1, T2, T3, T4> {
 
          private final Iterable<T1> ts1;
@@ -3578,7 +3750,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Iterator<R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3592,7 +3767,10 @@ public final class API {
 
      /**
       * For-comprehension with 5 Iterables.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For5<T1, T2, T3, T4, T5> {
 
          private final Iterable<T1> ts1;
@@ -3615,7 +3793,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Iterator<R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3630,7 +3811,10 @@ public final class API {
 
      /**
       * For-comprehension with 6 Iterables.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For6<T1, T2, T3, T4, T5, T6> {
 
          private final Iterable<T1> ts1;
@@ -3655,7 +3839,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Iterator<R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3671,7 +3858,10 @@ public final class API {
 
      /**
       * For-comprehension with 7 Iterables.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For7<T1, T2, T3, T4, T5, T6, T7> {
 
          private final Iterable<T1> ts1;
@@ -3698,7 +3888,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Iterator<R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3715,7 +3908,10 @@ public final class API {
 
      /**
       * For-comprehension with 8 Iterables.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For8<T1, T2, T3, T4, T5, T6, T7, T8> {
 
          private final Iterable<T1> ts1;
@@ -3744,7 +3940,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Iterator} elements
           * @return an {@code Iterator} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Iterator<R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3762,7 +3961,10 @@ public final class API {
 
      /**
       * For-comprehension with one Option.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For1Option<T1> {
 
          private final Option<T1> ts1;
@@ -3777,7 +3979,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Option<R> yield(Function<? super T1, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return ts1.map(f);
@@ -3787,7 +3992,11 @@ public final class API {
           * A shortcut for {@code yield(Function.identity())}.
           *
           * @return an {@code Iterator} of mapped results
+          *
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public Option<T1> yield() {
              return yield(Function.identity());
          }
@@ -3795,7 +4004,10 @@ public final class API {
 
      /**
       * For-comprehension with two Options.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For2Option<T1, T2> {
 
          private final Option<T1> ts1;
@@ -3812,7 +4024,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Option<R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3824,7 +4039,10 @@ public final class API {
 
      /**
       * For-comprehension with three Options.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For3Option<T1, T2, T3> {
 
          private final Option<T1> ts1;
@@ -3843,7 +4061,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Option<R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3856,7 +4077,10 @@ public final class API {
 
      /**
       * For-comprehension with 4 Options.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For4Option<T1, T2, T3, T4> {
 
          private final Option<T1> ts1;
@@ -3877,7 +4101,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Option<R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3891,7 +4118,10 @@ public final class API {
 
      /**
       * For-comprehension with 5 Options.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For5Option<T1, T2, T3, T4, T5> {
 
          private final Option<T1> ts1;
@@ -3914,7 +4144,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Option<R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3929,7 +4162,10 @@ public final class API {
 
      /**
       * For-comprehension with 6 Options.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For6Option<T1, T2, T3, T4, T5, T6> {
 
          private final Option<T1> ts1;
@@ -3954,7 +4190,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Option<R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -3970,7 +4209,10 @@ public final class API {
 
      /**
       * For-comprehension with 7 Options.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For7Option<T1, T2, T3, T4, T5, T6, T7> {
 
          private final Option<T1> ts1;
@@ -3997,7 +4239,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Option<R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4014,7 +4259,10 @@ public final class API {
 
      /**
       * For-comprehension with 8 Options.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For8Option<T1, T2, T3, T4, T5, T6, T7, T8> {
 
          private final Option<T1> ts1;
@@ -4043,7 +4291,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Option} elements
           * @return an {@code Option} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Option<R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4061,7 +4312,10 @@ public final class API {
 
      /**
       * For-comprehension with one Future.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For1Future<T1> {
 
          private final Future<T1> ts1;
@@ -4076,7 +4330,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Future<R> yield(Function<? super T1, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return ts1.map(f);
@@ -4086,7 +4343,11 @@ public final class API {
           * A shortcut for {@code yield(Function.identity())}.
           *
           * @return an {@code Iterator} of mapped results
+          *
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public Future<T1> yield() {
              return yield(Function.identity());
          }
@@ -4094,7 +4355,10 @@ public final class API {
 
      /**
       * For-comprehension with two Futures.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For2Future<T1, T2> {
 
          private final Future<T1> ts1;
@@ -4111,7 +4375,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Future<R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4123,7 +4390,10 @@ public final class API {
 
      /**
       * For-comprehension with three Futures.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For3Future<T1, T2, T3> {
 
          private final Future<T1> ts1;
@@ -4142,7 +4412,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Future<R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4155,7 +4428,10 @@ public final class API {
 
      /**
       * For-comprehension with 4 Futures.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For4Future<T1, T2, T3, T4> {
 
          private final Future<T1> ts1;
@@ -4176,7 +4452,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Future<R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4190,7 +4469,10 @@ public final class API {
 
      /**
       * For-comprehension with 5 Futures.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For5Future<T1, T2, T3, T4, T5> {
 
          private final Future<T1> ts1;
@@ -4213,7 +4495,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Future<R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4228,7 +4513,10 @@ public final class API {
 
      /**
       * For-comprehension with 6 Futures.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For6Future<T1, T2, T3, T4, T5, T6> {
 
          private final Future<T1> ts1;
@@ -4253,7 +4541,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Future<R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4269,7 +4560,10 @@ public final class API {
 
      /**
       * For-comprehension with 7 Futures.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For7Future<T1, T2, T3, T4, T5, T6, T7> {
 
          private final Future<T1> ts1;
@@ -4296,7 +4590,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Future<R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4313,7 +4610,10 @@ public final class API {
 
      /**
       * For-comprehension with 8 Futures.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For8Future<T1, T2, T3, T4, T5, T6, T7, T8> {
 
          private final Future<T1> ts1;
@@ -4342,7 +4642,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Future} elements
           * @return an {@code Future} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Future<R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4360,7 +4663,10 @@ public final class API {
 
      /**
       * For-comprehension with one Try.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For1Try<T1> {
 
          private final Try<T1> ts1;
@@ -4375,7 +4681,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Try<R> yield(Function<? super T1, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return ts1.map(f);
@@ -4385,7 +4694,11 @@ public final class API {
           * A shortcut for {@code yield(Function.identity())}.
           *
           * @return an {@code Iterator} of mapped results
+          *
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public Try<T1> yield() {
              return yield(Function.identity());
          }
@@ -4393,7 +4706,10 @@ public final class API {
 
      /**
       * For-comprehension with two Trys.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For2Try<T1, T2> {
 
          private final Try<T1> ts1;
@@ -4410,7 +4726,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Try<R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4422,7 +4741,10 @@ public final class API {
 
      /**
       * For-comprehension with three Trys.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For3Try<T1, T2, T3> {
 
          private final Try<T1> ts1;
@@ -4441,7 +4763,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Try<R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4454,7 +4779,10 @@ public final class API {
 
      /**
       * For-comprehension with 4 Trys.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For4Try<T1, T2, T3, T4> {
 
          private final Try<T1> ts1;
@@ -4475,7 +4803,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Try<R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4489,7 +4820,10 @@ public final class API {
 
      /**
       * For-comprehension with 5 Trys.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For5Try<T1, T2, T3, T4, T5> {
 
          private final Try<T1> ts1;
@@ -4512,7 +4846,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Try<R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4527,7 +4864,10 @@ public final class API {
 
      /**
       * For-comprehension with 6 Trys.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For6Try<T1, T2, T3, T4, T5, T6> {
 
          private final Try<T1> ts1;
@@ -4552,7 +4892,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Try<R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4568,7 +4911,10 @@ public final class API {
 
      /**
       * For-comprehension with 7 Trys.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For7Try<T1, T2, T3, T4, T5, T6, T7> {
 
          private final Try<T1> ts1;
@@ -4595,7 +4941,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Try<R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4612,7 +4961,10 @@ public final class API {
 
      /**
       * For-comprehension with 8 Trys.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For8Try<T1, T2, T3, T4, T5, T6, T7, T8> {
 
          private final Try<T1> ts1;
@@ -4641,7 +4993,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Try} elements
           * @return an {@code Try} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Try<R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4659,7 +5014,10 @@ public final class API {
 
      /**
       * For-comprehension with one Either.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For1Either<L, T1> {
 
          private final Either<L, T1> ts1;
@@ -4674,7 +5032,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Either<L, R> yield(Function<? super T1, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return ts1.map(f);
@@ -4684,7 +5045,11 @@ public final class API {
           * A shortcut for {@code yield(Function.identity())}.
           *
           * @return an {@code Iterator} of mapped results
+          *
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public Either<L, T1> yield() {
              return yield(Function.identity());
          }
@@ -4692,7 +5057,10 @@ public final class API {
 
      /**
       * For-comprehension with two Eithers.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For2Either<L, T1, T2> {
 
          private final Either<L, T1> ts1;
@@ -4709,7 +5077,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Either<L, R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4721,7 +5092,10 @@ public final class API {
 
      /**
       * For-comprehension with three Eithers.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For3Either<L, T1, T2, T3> {
 
          private final Either<L, T1> ts1;
@@ -4740,7 +5114,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Either<L, R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4753,7 +5130,10 @@ public final class API {
 
      /**
       * For-comprehension with 4 Eithers.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For4Either<L, T1, T2, T3, T4> {
 
          private final Either<L, T1> ts1;
@@ -4774,7 +5154,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Either<L, R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4788,7 +5171,10 @@ public final class API {
 
      /**
       * For-comprehension with 5 Eithers.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For5Either<L, T1, T2, T3, T4, T5> {
 
          private final Either<L, T1> ts1;
@@ -4811,7 +5197,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Either<L, R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4826,7 +5215,10 @@ public final class API {
 
      /**
       * For-comprehension with 6 Eithers.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For6Either<L, T1, T2, T3, T4, T5, T6> {
 
          private final Either<L, T1> ts1;
@@ -4851,7 +5243,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Either<L, R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4867,7 +5262,10 @@ public final class API {
 
      /**
       * For-comprehension with 7 Eithers.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For7Either<L, T1, T2, T3, T4, T5, T6, T7> {
 
          private final Either<L, T1> ts1;
@@ -4894,7 +5292,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Either<L, R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4911,7 +5312,10 @@ public final class API {
 
      /**
       * For-comprehension with 8 Eithers.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For8Either<L, T1, T2, T3, T4, T5, T6, T7, T8> {
 
          private final Either<L, T1> ts1;
@@ -4940,7 +5344,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code Either} elements
           * @return an {@code Either} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> Either<L, R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -4958,7 +5365,10 @@ public final class API {
 
      /**
       * For-comprehension with one List.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For1List<T1> {
 
          private final List<T1> ts1;
@@ -4973,7 +5383,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> List<R> yield(Function<? super T1, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return ts1.map(f);
@@ -4983,7 +5396,11 @@ public final class API {
           * A shortcut for {@code yield(Function.identity())}.
           *
           * @return an {@code Iterator} of mapped results
+          *
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public List<T1> yield() {
              return yield(Function.identity());
          }
@@ -4991,7 +5408,10 @@ public final class API {
 
      /**
       * For-comprehension with two Lists.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For2List<T1, T2> {
 
          private final List<T1> ts1;
@@ -5008,7 +5428,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> List<R> yield(BiFunction<? super T1, ? super T2, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -5020,7 +5443,10 @@ public final class API {
 
      /**
       * For-comprehension with three Lists.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For3List<T1, T2, T3> {
 
          private final List<T1> ts1;
@@ -5039,7 +5465,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> List<R> yield(Function3<? super T1, ? super T2, ? super T3, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -5052,7 +5481,10 @@ public final class API {
 
      /**
       * For-comprehension with 4 Lists.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For4List<T1, T2, T3, T4> {
 
          private final List<T1> ts1;
@@ -5073,7 +5505,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> List<R> yield(Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -5087,7 +5522,10 @@ public final class API {
 
      /**
       * For-comprehension with 5 Lists.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For5List<T1, T2, T3, T4, T5> {
 
          private final List<T1> ts1;
@@ -5110,7 +5548,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> List<R> yield(Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -5125,7 +5566,10 @@ public final class API {
 
      /**
       * For-comprehension with 6 Lists.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For6List<T1, T2, T3, T4, T5, T6> {
 
          private final List<T1> ts1;
@@ -5150,7 +5594,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> List<R> yield(Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -5166,7 +5613,10 @@ public final class API {
 
      /**
       * For-comprehension with 7 Lists.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For7List<T1, T2, T3, T4, T5, T6, T7> {
 
          private final List<T1> ts1;
@@ -5193,7 +5643,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> List<R> yield(Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return
@@ -5210,7 +5663,10 @@ public final class API {
 
      /**
       * For-comprehension with 8 Lists.
+      *
+      * @deprecated marked for removal
       */
+     @Deprecated
      public static class For8List<T1, T2, T3, T4, T5, T6, T7, T8> {
 
          private final List<T1> ts1;
@@ -5239,7 +5695,10 @@ public final class API {
           * @param f a function that maps an element of the cross product to a result
           * @param <R> type of the resulting {@code List} elements
           * @return an {@code List} of mapped results
+          *
+          * @deprecated marked for removal
           */
+         @Deprecated
          public <R> List<R> yield(Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? extends R> f) {
              Objects.requireNonNull(f, "f is null");
              return

--- a/src-gen/main/java/io/vavr/API.java
+++ b/src-gen/main/java/io/vavr/API.java
@@ -2329,7 +2329,7 @@ public final class API {
      * @param <U> component type of the resulting {@code Iterator}
      * @return A new Iterator
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T, U> Iterator<U> For(Iterable<T> ts, Function<? super T, ? extends Iterable<U>> f) {
@@ -2344,7 +2344,7 @@ public final class API {
      * @param <T1> right component type of the 1st Iterable
      * @return a new {@code For}-comprehension of arity 1
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1> For1<T1> For(Iterable<T1> ts1) {
@@ -2362,7 +2362,7 @@ public final class API {
      * @param <T2> right component type of the 2nd Iterable
      * @return a new {@code For}-comprehension of arity 2
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2> For2<T1, T2> For(Iterable<T1> ts1, Iterable<T2> ts2) {
@@ -2383,7 +2383,7 @@ public final class API {
      * @param <T3> right component type of the 3rd Iterable
      * @return a new {@code For}-comprehension of arity 3
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3> For3<T1, T2, T3> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3) {
@@ -2407,7 +2407,7 @@ public final class API {
      * @param <T4> right component type of the 4th Iterable
      * @return a new {@code For}-comprehension of arity 4
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4> For4<T1, T2, T3, T4> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3, Iterable<T4> ts4) {
@@ -2434,7 +2434,7 @@ public final class API {
      * @param <T5> right component type of the 5th Iterable
      * @return a new {@code For}-comprehension of arity 5
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5> For5<T1, T2, T3, T4, T5> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3, Iterable<T4> ts4, Iterable<T5> ts5) {
@@ -2464,7 +2464,7 @@ public final class API {
      * @param <T6> right component type of the 6th Iterable
      * @return a new {@code For}-comprehension of arity 6
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6> For6<T1, T2, T3, T4, T5, T6> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3, Iterable<T4> ts4, Iterable<T5> ts5, Iterable<T6> ts6) {
@@ -2497,7 +2497,7 @@ public final class API {
      * @param <T7> right component type of the 7th Iterable
      * @return a new {@code For}-comprehension of arity 7
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7> For7<T1, T2, T3, T4, T5, T6, T7> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3, Iterable<T4> ts4, Iterable<T5> ts5, Iterable<T6> ts6, Iterable<T7> ts7) {
@@ -2533,7 +2533,7 @@ public final class API {
      * @param <T8> right component type of the 8th Iterable
      * @return a new {@code For}-comprehension of arity 8
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7, T8> For8<T1, T2, T3, T4, T5, T6, T7, T8> For(Iterable<T1> ts1, Iterable<T2> ts2, Iterable<T3> ts3, Iterable<T4> ts4, Iterable<T5> ts5, Iterable<T6> ts6, Iterable<T7> ts7, Iterable<T8> ts8) {
@@ -2556,7 +2556,7 @@ public final class API {
      * @param <T1> right component type of the 1st Option
      * @return a new {@code For}-comprehension of arity 1
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1> For1Option<T1> For(Option<T1> ts1) {
@@ -2574,7 +2574,7 @@ public final class API {
      * @param <T2> right component type of the 2nd Option
      * @return a new {@code For}-comprehension of arity 2
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2> For2Option<T1, T2> For(Option<T1> ts1, Option<T2> ts2) {
@@ -2595,7 +2595,7 @@ public final class API {
      * @param <T3> right component type of the 3rd Option
      * @return a new {@code For}-comprehension of arity 3
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3> For3Option<T1, T2, T3> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3) {
@@ -2619,7 +2619,7 @@ public final class API {
      * @param <T4> right component type of the 4th Option
      * @return a new {@code For}-comprehension of arity 4
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4> For4Option<T1, T2, T3, T4> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3, Option<T4> ts4) {
@@ -2646,7 +2646,7 @@ public final class API {
      * @param <T5> right component type of the 5th Option
      * @return a new {@code For}-comprehension of arity 5
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5> For5Option<T1, T2, T3, T4, T5> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3, Option<T4> ts4, Option<T5> ts5) {
@@ -2676,7 +2676,7 @@ public final class API {
      * @param <T6> right component type of the 6th Option
      * @return a new {@code For}-comprehension of arity 6
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6> For6Option<T1, T2, T3, T4, T5, T6> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3, Option<T4> ts4, Option<T5> ts5, Option<T6> ts6) {
@@ -2709,7 +2709,7 @@ public final class API {
      * @param <T7> right component type of the 7th Option
      * @return a new {@code For}-comprehension of arity 7
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7> For7Option<T1, T2, T3, T4, T5, T6, T7> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3, Option<T4> ts4, Option<T5> ts5, Option<T6> ts6, Option<T7> ts7) {
@@ -2745,7 +2745,7 @@ public final class API {
      * @param <T8> right component type of the 8th Option
      * @return a new {@code For}-comprehension of arity 8
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7, T8> For8Option<T1, T2, T3, T4, T5, T6, T7, T8> For(Option<T1> ts1, Option<T2> ts2, Option<T3> ts3, Option<T4> ts4, Option<T5> ts5, Option<T6> ts6, Option<T7> ts7, Option<T8> ts8) {
@@ -2768,7 +2768,7 @@ public final class API {
      * @param <T1> right component type of the 1st Future
      * @return a new {@code For}-comprehension of arity 1
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1> For1Future<T1> For(Future<T1> ts1) {
@@ -2786,7 +2786,7 @@ public final class API {
      * @param <T2> right component type of the 2nd Future
      * @return a new {@code For}-comprehension of arity 2
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2> For2Future<T1, T2> For(Future<T1> ts1, Future<T2> ts2) {
@@ -2807,7 +2807,7 @@ public final class API {
      * @param <T3> right component type of the 3rd Future
      * @return a new {@code For}-comprehension of arity 3
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3> For3Future<T1, T2, T3> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3) {
@@ -2831,7 +2831,7 @@ public final class API {
      * @param <T4> right component type of the 4th Future
      * @return a new {@code For}-comprehension of arity 4
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4> For4Future<T1, T2, T3, T4> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3, Future<T4> ts4) {
@@ -2858,7 +2858,7 @@ public final class API {
      * @param <T5> right component type of the 5th Future
      * @return a new {@code For}-comprehension of arity 5
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5> For5Future<T1, T2, T3, T4, T5> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3, Future<T4> ts4, Future<T5> ts5) {
@@ -2888,7 +2888,7 @@ public final class API {
      * @param <T6> right component type of the 6th Future
      * @return a new {@code For}-comprehension of arity 6
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6> For6Future<T1, T2, T3, T4, T5, T6> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3, Future<T4> ts4, Future<T5> ts5, Future<T6> ts6) {
@@ -2921,7 +2921,7 @@ public final class API {
      * @param <T7> right component type of the 7th Future
      * @return a new {@code For}-comprehension of arity 7
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7> For7Future<T1, T2, T3, T4, T5, T6, T7> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3, Future<T4> ts4, Future<T5> ts5, Future<T6> ts6, Future<T7> ts7) {
@@ -2957,7 +2957,7 @@ public final class API {
      * @param <T8> right component type of the 8th Future
      * @return a new {@code For}-comprehension of arity 8
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7, T8> For8Future<T1, T2, T3, T4, T5, T6, T7, T8> For(Future<T1> ts1, Future<T2> ts2, Future<T3> ts3, Future<T4> ts4, Future<T5> ts5, Future<T6> ts6, Future<T7> ts7, Future<T8> ts8) {
@@ -2980,7 +2980,7 @@ public final class API {
      * @param <T1> right component type of the 1st Try
      * @return a new {@code For}-comprehension of arity 1
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1> For1Try<T1> For(Try<T1> ts1) {
@@ -2998,7 +2998,7 @@ public final class API {
      * @param <T2> right component type of the 2nd Try
      * @return a new {@code For}-comprehension of arity 2
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2> For2Try<T1, T2> For(Try<T1> ts1, Try<T2> ts2) {
@@ -3019,7 +3019,7 @@ public final class API {
      * @param <T3> right component type of the 3rd Try
      * @return a new {@code For}-comprehension of arity 3
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3> For3Try<T1, T2, T3> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3) {
@@ -3043,7 +3043,7 @@ public final class API {
      * @param <T4> right component type of the 4th Try
      * @return a new {@code For}-comprehension of arity 4
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4> For4Try<T1, T2, T3, T4> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3, Try<T4> ts4) {
@@ -3070,7 +3070,7 @@ public final class API {
      * @param <T5> right component type of the 5th Try
      * @return a new {@code For}-comprehension of arity 5
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5> For5Try<T1, T2, T3, T4, T5> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3, Try<T4> ts4, Try<T5> ts5) {
@@ -3100,7 +3100,7 @@ public final class API {
      * @param <T6> right component type of the 6th Try
      * @return a new {@code For}-comprehension of arity 6
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6> For6Try<T1, T2, T3, T4, T5, T6> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3, Try<T4> ts4, Try<T5> ts5, Try<T6> ts6) {
@@ -3133,7 +3133,7 @@ public final class API {
      * @param <T7> right component type of the 7th Try
      * @return a new {@code For}-comprehension of arity 7
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7> For7Try<T1, T2, T3, T4, T5, T6, T7> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3, Try<T4> ts4, Try<T5> ts5, Try<T6> ts6, Try<T7> ts7) {
@@ -3169,7 +3169,7 @@ public final class API {
      * @param <T8> right component type of the 8th Try
      * @return a new {@code For}-comprehension of arity 8
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7, T8> For8Try<T1, T2, T3, T4, T5, T6, T7, T8> For(Try<T1> ts1, Try<T2> ts2, Try<T3> ts3, Try<T4> ts4, Try<T5> ts5, Try<T6> ts6, Try<T7> ts7, Try<T8> ts8) {
@@ -3192,7 +3192,7 @@ public final class API {
      * @param <T1> right component type of the 1st Either
      * @return a new {@code For}-comprehension of arity 1
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <L, T1> For1Either<L, T1> For(Either<L, T1> ts1) {
@@ -3210,7 +3210,7 @@ public final class API {
      * @param <T2> right component type of the 2nd Either
      * @return a new {@code For}-comprehension of arity 2
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <L, T1, T2> For2Either<L, T1, T2> For(Either<L, T1> ts1, Either<L, T2> ts2) {
@@ -3231,7 +3231,7 @@ public final class API {
      * @param <T3> right component type of the 3rd Either
      * @return a new {@code For}-comprehension of arity 3
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <L, T1, T2, T3> For3Either<L, T1, T2, T3> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3) {
@@ -3255,7 +3255,7 @@ public final class API {
      * @param <T4> right component type of the 4th Either
      * @return a new {@code For}-comprehension of arity 4
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <L, T1, T2, T3, T4> For4Either<L, T1, T2, T3, T4> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3, Either<L, T4> ts4) {
@@ -3282,7 +3282,7 @@ public final class API {
      * @param <T5> right component type of the 5th Either
      * @return a new {@code For}-comprehension of arity 5
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <L, T1, T2, T3, T4, T5> For5Either<L, T1, T2, T3, T4, T5> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3, Either<L, T4> ts4, Either<L, T5> ts5) {
@@ -3312,7 +3312,7 @@ public final class API {
      * @param <T6> right component type of the 6th Either
      * @return a new {@code For}-comprehension of arity 6
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <L, T1, T2, T3, T4, T5, T6> For6Either<L, T1, T2, T3, T4, T5, T6> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3, Either<L, T4> ts4, Either<L, T5> ts5, Either<L, T6> ts6) {
@@ -3345,7 +3345,7 @@ public final class API {
      * @param <T7> right component type of the 7th Either
      * @return a new {@code For}-comprehension of arity 7
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <L, T1, T2, T3, T4, T5, T6, T7> For7Either<L, T1, T2, T3, T4, T5, T6, T7> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3, Either<L, T4> ts4, Either<L, T5> ts5, Either<L, T6> ts6, Either<L, T7> ts7) {
@@ -3381,7 +3381,7 @@ public final class API {
      * @param <T8> right component type of the 8th Either
      * @return a new {@code For}-comprehension of arity 8
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <L, T1, T2, T3, T4, T5, T6, T7, T8> For8Either<L, T1, T2, T3, T4, T5, T6, T7, T8> For(Either<L, T1> ts1, Either<L, T2> ts2, Either<L, T3> ts3, Either<L, T4> ts4, Either<L, T5> ts5, Either<L, T6> ts6, Either<L, T7> ts7, Either<L, T8> ts8) {
@@ -3404,7 +3404,7 @@ public final class API {
      * @param <T1> right component type of the 1st List
      * @return a new {@code For}-comprehension of arity 1
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1> For1List<T1> For(List<T1> ts1) {
@@ -3422,7 +3422,7 @@ public final class API {
      * @param <T2> right component type of the 2nd List
      * @return a new {@code For}-comprehension of arity 2
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2> For2List<T1, T2> For(List<T1> ts1, List<T2> ts2) {
@@ -3443,7 +3443,7 @@ public final class API {
      * @param <T3> right component type of the 3rd List
      * @return a new {@code For}-comprehension of arity 3
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3> For3List<T1, T2, T3> For(List<T1> ts1, List<T2> ts2, List<T3> ts3) {
@@ -3467,7 +3467,7 @@ public final class API {
      * @param <T4> right component type of the 4th List
      * @return a new {@code For}-comprehension of arity 4
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4> For4List<T1, T2, T3, T4> For(List<T1> ts1, List<T2> ts2, List<T3> ts3, List<T4> ts4) {
@@ -3494,7 +3494,7 @@ public final class API {
      * @param <T5> right component type of the 5th List
      * @return a new {@code For}-comprehension of arity 5
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5> For5List<T1, T2, T3, T4, T5> For(List<T1> ts1, List<T2> ts2, List<T3> ts3, List<T4> ts4, List<T5> ts5) {
@@ -3524,7 +3524,7 @@ public final class API {
      * @param <T6> right component type of the 6th List
      * @return a new {@code For}-comprehension of arity 6
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6> For6List<T1, T2, T3, T4, T5, T6> For(List<T1> ts1, List<T2> ts2, List<T3> ts3, List<T4> ts4, List<T5> ts5, List<T6> ts6) {
@@ -3557,7 +3557,7 @@ public final class API {
      * @param <T7> right component type of the 7th List
      * @return a new {@code For}-comprehension of arity 7
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7> For7List<T1, T2, T3, T4, T5, T6, T7> For(List<T1> ts1, List<T2> ts2, List<T3> ts3, List<T4> ts4, List<T5> ts5, List<T6> ts6, List<T7> ts7) {
@@ -3593,7 +3593,7 @@ public final class API {
      * @param <T8> right component type of the 8th List
      * @return a new {@code For}-comprehension of arity 8
      *
-     * @deprecated marked for removal
+     * @deprecated to be replaced with revised JDK13-compliant API
      */
     @Deprecated
     public static <T1, T2, T3, T4, T5, T6, T7, T8> For8List<T1, T2, T3, T4, T5, T6, T7, T8> For(List<T1> ts1, List<T2> ts2, List<T3> ts3, List<T4> ts4, List<T5> ts5, List<T6> ts6, List<T7> ts7, List<T8> ts8) {
@@ -3611,7 +3611,7 @@ public final class API {
      /**
       * For-comprehension with one Iterable.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For1<T1> {
@@ -3643,7 +3643,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           *
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public Iterator<T1> yield() {
@@ -3654,7 +3654,7 @@ public final class API {
      /**
       * For-comprehension with two Iterables.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For2<T1, T2> {
@@ -3689,7 +3689,7 @@ public final class API {
      /**
       * For-comprehension with three Iterables.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For3<T1, T2, T3> {
@@ -3727,7 +3727,7 @@ public final class API {
      /**
       * For-comprehension with 4 Iterables.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For4<T1, T2, T3, T4> {
@@ -3768,7 +3768,7 @@ public final class API {
      /**
       * For-comprehension with 5 Iterables.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For5<T1, T2, T3, T4, T5> {
@@ -3812,7 +3812,7 @@ public final class API {
      /**
       * For-comprehension with 6 Iterables.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For6<T1, T2, T3, T4, T5, T6> {
@@ -3859,7 +3859,7 @@ public final class API {
      /**
       * For-comprehension with 7 Iterables.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For7<T1, T2, T3, T4, T5, T6, T7> {
@@ -3909,7 +3909,7 @@ public final class API {
      /**
       * For-comprehension with 8 Iterables.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For8<T1, T2, T3, T4, T5, T6, T7, T8> {
@@ -3962,7 +3962,7 @@ public final class API {
      /**
       * For-comprehension with one Option.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For1Option<T1> {
@@ -3994,7 +3994,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           *
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public Option<T1> yield() {
@@ -4005,7 +4005,7 @@ public final class API {
      /**
       * For-comprehension with two Options.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For2Option<T1, T2> {
@@ -4040,7 +4040,7 @@ public final class API {
      /**
       * For-comprehension with three Options.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For3Option<T1, T2, T3> {
@@ -4078,7 +4078,7 @@ public final class API {
      /**
       * For-comprehension with 4 Options.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For4Option<T1, T2, T3, T4> {
@@ -4119,7 +4119,7 @@ public final class API {
      /**
       * For-comprehension with 5 Options.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For5Option<T1, T2, T3, T4, T5> {
@@ -4163,7 +4163,7 @@ public final class API {
      /**
       * For-comprehension with 6 Options.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For6Option<T1, T2, T3, T4, T5, T6> {
@@ -4210,7 +4210,7 @@ public final class API {
      /**
       * For-comprehension with 7 Options.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For7Option<T1, T2, T3, T4, T5, T6, T7> {
@@ -4260,7 +4260,7 @@ public final class API {
      /**
       * For-comprehension with 8 Options.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For8Option<T1, T2, T3, T4, T5, T6, T7, T8> {
@@ -4313,7 +4313,7 @@ public final class API {
      /**
       * For-comprehension with one Future.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For1Future<T1> {
@@ -4345,7 +4345,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           *
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public Future<T1> yield() {
@@ -4356,7 +4356,7 @@ public final class API {
      /**
       * For-comprehension with two Futures.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For2Future<T1, T2> {
@@ -4391,7 +4391,7 @@ public final class API {
      /**
       * For-comprehension with three Futures.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For3Future<T1, T2, T3> {
@@ -4429,7 +4429,7 @@ public final class API {
      /**
       * For-comprehension with 4 Futures.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For4Future<T1, T2, T3, T4> {
@@ -4470,7 +4470,7 @@ public final class API {
      /**
       * For-comprehension with 5 Futures.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For5Future<T1, T2, T3, T4, T5> {
@@ -4514,7 +4514,7 @@ public final class API {
      /**
       * For-comprehension with 6 Futures.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For6Future<T1, T2, T3, T4, T5, T6> {
@@ -4561,7 +4561,7 @@ public final class API {
      /**
       * For-comprehension with 7 Futures.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For7Future<T1, T2, T3, T4, T5, T6, T7> {
@@ -4611,7 +4611,7 @@ public final class API {
      /**
       * For-comprehension with 8 Futures.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For8Future<T1, T2, T3, T4, T5, T6, T7, T8> {
@@ -4664,7 +4664,7 @@ public final class API {
      /**
       * For-comprehension with one Try.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For1Try<T1> {
@@ -4696,7 +4696,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           *
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public Try<T1> yield() {
@@ -4707,7 +4707,7 @@ public final class API {
      /**
       * For-comprehension with two Trys.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For2Try<T1, T2> {
@@ -4742,7 +4742,7 @@ public final class API {
      /**
       * For-comprehension with three Trys.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For3Try<T1, T2, T3> {
@@ -4780,7 +4780,7 @@ public final class API {
      /**
       * For-comprehension with 4 Trys.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For4Try<T1, T2, T3, T4> {
@@ -4821,7 +4821,7 @@ public final class API {
      /**
       * For-comprehension with 5 Trys.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For5Try<T1, T2, T3, T4, T5> {
@@ -4865,7 +4865,7 @@ public final class API {
      /**
       * For-comprehension with 6 Trys.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For6Try<T1, T2, T3, T4, T5, T6> {
@@ -4912,7 +4912,7 @@ public final class API {
      /**
       * For-comprehension with 7 Trys.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For7Try<T1, T2, T3, T4, T5, T6, T7> {
@@ -4962,7 +4962,7 @@ public final class API {
      /**
       * For-comprehension with 8 Trys.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For8Try<T1, T2, T3, T4, T5, T6, T7, T8> {
@@ -5015,7 +5015,7 @@ public final class API {
      /**
       * For-comprehension with one Either.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For1Either<L, T1> {
@@ -5047,7 +5047,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           *
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public Either<L, T1> yield() {
@@ -5058,7 +5058,7 @@ public final class API {
      /**
       * For-comprehension with two Eithers.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For2Either<L, T1, T2> {
@@ -5093,7 +5093,7 @@ public final class API {
      /**
       * For-comprehension with three Eithers.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For3Either<L, T1, T2, T3> {
@@ -5131,7 +5131,7 @@ public final class API {
      /**
       * For-comprehension with 4 Eithers.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For4Either<L, T1, T2, T3, T4> {
@@ -5172,7 +5172,7 @@ public final class API {
      /**
       * For-comprehension with 5 Eithers.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For5Either<L, T1, T2, T3, T4, T5> {
@@ -5216,7 +5216,7 @@ public final class API {
      /**
       * For-comprehension with 6 Eithers.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For6Either<L, T1, T2, T3, T4, T5, T6> {
@@ -5263,7 +5263,7 @@ public final class API {
      /**
       * For-comprehension with 7 Eithers.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For7Either<L, T1, T2, T3, T4, T5, T6, T7> {
@@ -5313,7 +5313,7 @@ public final class API {
      /**
       * For-comprehension with 8 Eithers.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For8Either<L, T1, T2, T3, T4, T5, T6, T7, T8> {
@@ -5366,7 +5366,7 @@ public final class API {
      /**
       * For-comprehension with one List.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For1List<T1> {
@@ -5398,7 +5398,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           *
           *
-          * @deprecated marked for removal
+          * @deprecated to be replaced with revised JDK13-compliant API
           */
          @Deprecated
          public List<T1> yield() {
@@ -5409,7 +5409,7 @@ public final class API {
      /**
       * For-comprehension with two Lists.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For2List<T1, T2> {
@@ -5444,7 +5444,7 @@ public final class API {
      /**
       * For-comprehension with three Lists.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For3List<T1, T2, T3> {
@@ -5482,7 +5482,7 @@ public final class API {
      /**
       * For-comprehension with 4 Lists.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For4List<T1, T2, T3, T4> {
@@ -5523,7 +5523,7 @@ public final class API {
      /**
       * For-comprehension with 5 Lists.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For5List<T1, T2, T3, T4, T5> {
@@ -5567,7 +5567,7 @@ public final class API {
      /**
       * For-comprehension with 6 Lists.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For6List<T1, T2, T3, T4, T5, T6> {
@@ -5614,7 +5614,7 @@ public final class API {
      /**
       * For-comprehension with 7 Lists.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For7List<T1, T2, T3, T4, T5, T6, T7> {
@@ -5664,7 +5664,7 @@ public final class API {
      /**
       * For-comprehension with 8 Lists.
       *
-      * @deprecated marked for removal
+      * @deprecated to be replaced with revised JDK13-compliant API
       */
      @Deprecated
      public static class For8List<T1, T2, T3, T4, T5, T6, T7, T8> {


### PR DESCRIPTION
Preparation towards #2441 and #2346 by deprecating the current For/yield API.

The actual incompatible changes (deleting current For API, introducing new For API) will be performed in Vavr 2.0.0.