### PR TITLE
Replace deprecated Gradle classifier usage archiveClassifier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,17 +85,17 @@ check.dependsOn jacocoTestReport
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
-    classifier = 'sources'
+    archiveClassifier.set('sources')
 }
 
 task testSourcesJar(type: Jar) {
     from sourceSets.test.allSource
-    classifier = 'test-sources'
+    archiveClassifier.set('test-sources')
 }
 
 task javadocJar(type: Jar) {
     from javadoc
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -85,17 +85,17 @@ check.dependsOn jacocoTestReport
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
-    archiveClassifier.set('sources')
+    archiveClassifier = 'sources'
 }
 
 task testSourcesJar(type: Jar) {
     from sourceSets.test.allSource
-    archiveClassifier.set('test-sources')
+    archiveClassifier = 'test-sources'
 }
 
 task javadocJar(type: Jar) {
     from javadoc
-    archiveClassifier.set('javadoc')
+    archiveClassifier = 'javadoc'
 }
 
 artifacts {


### PR DESCRIPTION
source: [link](https://docs.gradle.org/5.1/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:classifier)

artifacts are properly generated:
```
❯ ls libs 
vavr-1.0.0-SNAPSHOT-javadoc.jar      vavr-1.0.0-SNAPSHOT-test-sources.jar
vavr-1.0.0-SNAPSHOT-sources.jar      vavr-1.0.0-SNAPSHOT.jar
```
