### PR TITLE
Avoid presizing arrays when passing them to Collection#toArray() calls

### DIFF
--- a/src/main/java/io/vavr/Value.java
+++ b/src/main/java/io/vavr/Value.java
@@ -679,7 +679,7 @@ public interface Value<T> extends Iterable<T> {
             componentType = (Class<T>) boxedType;
         }
         final java.util.List<T> list = toJavaList();
-        return list.toArray((T[]) java.lang.reflect.Array.newInstance(componentType, 0));  // toArray(new T[0]) is preferred over toArray(new T[size]) source: https://shipilev.net/blog/2016/arrays-wisdom-ancients/
+        return list.toArray((T[]) java.lang.reflect.Array.newInstance(componentType, 0)); // toArray(new T[0]) is preferred over toArray(new T[size]) source: https://shipilev.net/blog/2016/arrays-wisdom-ancients/
     }
 
     /**

--- a/src/main/java/io/vavr/Value.java
+++ b/src/main/java/io/vavr/Value.java
@@ -679,7 +679,7 @@ public interface Value<T> extends Iterable<T> {
             componentType = (Class<T>) boxedType;
         }
         final java.util.List<T> list = toJavaList();
-        return list.toArray((T[]) java.lang.reflect.Array.newInstance(componentType, 0));
+        return list.toArray((T[]) java.lang.reflect.Array.newInstance(componentType, 0));  // toArray(new T[0]) is preferred over toArray(new T[size]) source: https://shipilev.net/blog/2016/arrays-wisdom-ancients/
     }
 
     /**
@@ -707,7 +707,7 @@ public interface Value<T> extends Iterable<T> {
      */
     default T[] toJavaArray(IntFunction<T[]> arrayFactory) {
         java.util.List<T> javaList = toJavaList();
-        return javaList.toArray(arrayFactory.apply(0));
+        return javaList.toArray(arrayFactory.apply(0)); // toArray(new T[0]) is preferred over toArray(new T[size]) source: https://shipilev.net/blog/2016/arrays-wisdom-ancients/
     }
 
     /**

--- a/src/main/java/io/vavr/Value.java
+++ b/src/main/java/io/vavr/Value.java
@@ -679,7 +679,7 @@ public interface Value<T> extends Iterable<T> {
             componentType = (Class<T>) boxedType;
         }
         final java.util.List<T> list = toJavaList();
-        return list.toArray((T[]) java.lang.reflect.Array.newInstance(componentType, list.size()));
+        return list.toArray((T[]) java.lang.reflect.Array.newInstance(componentType, 0));
     }
 
     /**
@@ -707,7 +707,7 @@ public interface Value<T> extends Iterable<T> {
      */
     default T[] toJavaArray(IntFunction<T[]> arrayFactory) {
         java.util.List<T> javaList = toJavaList();
-        return javaList.toArray(arrayFactory.apply(javaList.size()));
+        return javaList.toArray(arrayFactory.apply(0));
     }
 
     /**


### PR DESCRIPTION
[Since a few versions of Java](https://bugs.openjdk.java.net/browse/JDK-6525802), it's a good idea to not pre-size arrays passed to `Collection#toArray` calls (these get _intrinsified_).

JDK9 is doing the same in the new `toArray()` overload:
```
default <T> T[] toArray(IntFunction<T[]> generator) {
    return toArray(generator.apply(0));
}
```

source: [link](https://shipilev.net/blog/2016/arrays-wisdom-ancients/)