### PR TITLE
Avoid redundant indirection by passing Function object directly instead of delegating to it through a lambda expression

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -1609,7 +1609,7 @@ def generateMainClasses(): Unit = {
               static $fullGenerics ${im.getType(s"io.vavr.Function$i")}$genericsTryReturnType liftTry($fullGenericsType partialFunction) {
                   ${
                     val func = "partialFunction"
-                    val supplier = if (!checked && i == 0) s"$func::get" else if (checked && i == 0) func else s"() -> partialFunction.apply($params)"
+                    val supplier = if (!checked && i == 0) s"$func::get" else if (checked && i == 0) func else s"() -> $func.apply($params)"
                     val lambdaArgs = if (i == 1) params else s"($params)"
                     xs"""
                       return $lambdaArgs -> ${im.getType("io.vavr.control.Try")}.of($supplier);

--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -1590,7 +1590,7 @@ def generateMainClasses(): Unit = {
               static $fullGenerics ${im.getType(s"io.vavr.Function$i")}$genericsOptionReturnType lift($fullGenericsType partialFunction) {
                   ${
                     val func = "partialFunction"
-                    val supplier = if (!checked && i == 0) s"$func::get" else if (checked && i == 0) s"$func" else s"() -> $func.apply($params)"
+                    val supplier = if (!checked && i == 0) s"$func::get" else if (checked && i == 0) func else s"() -> $func.apply($params)"
                     val lambdaArgs = if (i == 1) params else s"($params)"
                     xs"""
                       return $lambdaArgs -> ${im.getType("io.vavr.control.Try")}.<R>of($supplier).toOption();
@@ -1608,7 +1608,8 @@ def generateMainClasses(): Unit = {
                */
               static $fullGenerics ${im.getType(s"io.vavr.Function$i")}$genericsTryReturnType liftTry($fullGenericsType partialFunction) {
                   ${
-                    val supplier = if (!checked && i == 0) "partialFunction::get" else if (checked && i == 0) "partialFunction" else s"() -> partialFunction.apply($params)"
+                    val func = "partialFunction"
+                    val supplier = if (!checked && i == 0) s"$func::get" else if (checked && i == 0) func else s"() -> partialFunction.apply($params)"
                     val lambdaArgs = if (i == 1) params else s"($params)"
                     xs"""
                       return $lambdaArgs -> ${im.getType("io.vavr.control.Try")}.of($supplier);

--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -1590,7 +1590,7 @@ def generateMainClasses(): Unit = {
               static $fullGenerics ${im.getType(s"io.vavr.Function$i")}$genericsOptionReturnType lift($fullGenericsType partialFunction) {
                   ${
                     val func = "partialFunction"
-                    val supplier = if (!checked && i == 0) s"$func::get" else if (checked && i == 0) s"$func::apply" else s"() -> $func.apply($params)"
+                    val supplier = if (!checked && i == 0) s"$func::get" else if (checked && i == 0) s"$func" else s"() -> $func.apply($params)"
                     val lambdaArgs = if (i == 1) params else s"($params)"
                     xs"""
                       return $lambdaArgs -> ${im.getType("io.vavr.control.Try")}.<R>of($supplier).toOption();
@@ -1608,7 +1608,7 @@ def generateMainClasses(): Unit = {
                */
               static $fullGenerics ${im.getType(s"io.vavr.Function$i")}$genericsTryReturnType liftTry($fullGenericsType partialFunction) {
                   ${
-                    val supplier = if (!checked && i == 0) "partialFunction::get" else if (checked && i == 0) "partialFunction::apply" else s"() -> partialFunction.apply($params)"
+                    val supplier = if (!checked && i == 0) "partialFunction::get" else if (checked && i == 0) "partialFunction" else s"() -> partialFunction.apply($params)"
                     val lambdaArgs = if (i == 1) params else s"($params)"
                     xs"""
                       return $lambdaArgs -> ${im.getType("io.vavr.control.Try")}.of($supplier);

--- a/src-gen/main/java/io/vavr/CheckedFunction0.java
+++ b/src-gen/main/java/io/vavr/CheckedFunction0.java
@@ -104,7 +104,7 @@ public interface CheckedFunction0<R> extends Serializable {
      */
     @SuppressWarnings("RedundantTypeArguments")
     static <R> Function0<Option<R>> lift(CheckedFunction0<? extends R> partialFunction) {
-        return () -> Try.<R>of(partialFunction::apply).toOption();
+        return () -> Try.<R>of(partialFunction).toOption();
     }
 
     /**
@@ -116,7 +116,7 @@ public interface CheckedFunction0<R> extends Serializable {
      *         if the function is defined for the given arguments, and {@code Failure(throwable)} otherwise.
      */
     static <R> Function0<Try<R>> liftTry(CheckedFunction0<? extends R> partialFunction) {
-        return () -> Try.of(partialFunction::apply);
+        return () -> Try.of(partialFunction);
     }
 
     /**

--- a/src/main/java/io/vavr/collection/Iterator.java
+++ b/src/main/java/io/vavr/collection/Iterator.java
@@ -1044,7 +1044,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     @Override
     default <R> Iterator<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         Objects.requireNonNull(partialFunction, "partialFunction is null");
-        return filter(partialFunction::isDefinedAt).map(partialFunction::apply);
+        return filter(partialFunction::isDefinedAt).map(partialFunction);
     }
 
     // DEV-NOTE: cannot use arg Iterable, it would be ambiguous

--- a/src/main/java/io/vavr/control/Option.java
+++ b/src/main/java/io/vavr/control/Option.java
@@ -285,7 +285,7 @@ public abstract class Option<T> implements Iterable<T>, io.vavr.Value<T>, Serial
      */
     public final <R> Option<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         Objects.requireNonNull(partialFunction, "partialFunction is null");
-        return flatMap(partialFunction.lift()::apply);
+        return flatMap(partialFunction.lift());
     }
 
     /**

--- a/src/main/java/io/vavr/control/Try.java
+++ b/src/main/java/io/vavr/control/Try.java
@@ -419,7 +419,7 @@ public abstract class Try<T> implements Iterable<T>, io.vavr.Value<T>, Serializa
     @SuppressWarnings("unchecked")
     public final <R> Try<R> collect(PartialFunction<? super T, ? extends R> partialFunction){
         Objects.requireNonNull(partialFunction, "partialFunction is null");
-        return filter(partialFunction::isDefinedAt).map(partialFunction::apply);
+        return filter(partialFunction::isDefinedAt).map(partialFunction);
     }
 
     /**


### PR DESCRIPTION
There's no point in wrapping `Function` in another `Function` when the original `Function` could be passed directly.