### PR TITLE
Define CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @danieldietrich


### PR DESCRIPTION
That's a handy GitHub feature that allows configuring explicitly who owns the codebase.

Works great with a setting that enforces code review from owners - then they get assigned to PRs automatically.

For example, here:
https://github.com/testcontainers/testcontainers-java/blob/master/.github/CODEOWNERS
https://github.com/testcontainers/testcontainers-java/pull/2175

<img width="300" alt="image" src="https://user-images.githubusercontent.com/2182533/70844755-b666f980-1e45-11ea-8c74-7bf2bc06ca32.png">
