### PR TITLE
Configure basic GitHub Actions workflow: release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,10 @@
+template: |
+  ## Info
+  // ...
+
+  ## Committers
+  🎉 MANY THANKS TO ALL COMMITTERS! 🎉
+  $CONTRIBUTORS
+
+  ## Changes
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,5 @@
+name-template: v$NEXT_PATCH_VERSION
+tag-template: v$NEXT_PATCH_VERSION
 template: |
   ## Info
   // ...

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Configured basic [release-drafter](https://probot.github.io/apps/release-drafter/) for the master branch.

____

It's a simple but super handy GitHub Actions automation that does a mutable accumulation on the diff between tags, and prepares a handy release draft. 

Merge, wait for a second and look for a ready release draft 🎉 

I based the template on this release's notes: [link](https://github.com/vavr-io/vavr/releases/tag/vavr-1.0.0-alpha-3). 

It will probably need some tuning, but I think it could potentially save a lot of time by automating the tedious job of gathering all the changes, or the list of contributors.
