### PR TITLE
Make SortedSet#map/flatMap return unsorted set 

### DIFF
--- a/src/main/java/io/vavr/collection/BitSet.java
+++ b/src/main/java/io/vavr/collection/BitSet.java
@@ -492,7 +492,7 @@ public abstract class BitSet<T> implements SortedSet<T>, Serializable {
     @Override
     public final <U> Set<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return this.isEmpty() ? HashSet.empty() : HashSet.ofAll(this).map(mapper);
+        return isEmpty() ? HashSet.empty() : HashSet.ofAll(this).map(mapper);
     }
 
     @Override

--- a/src/main/java/io/vavr/collection/BitSet.java
+++ b/src/main/java/io/vavr/collection/BitSet.java
@@ -401,8 +401,9 @@ public abstract class BitSet<T> implements SortedSet<T>, Serializable {
     }
 
     @Override
-    public final <U> SortedSet<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        return flatMap(Comparators.naturalComparator(), mapper);
+    public final <U> Set<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return HashSet.ofAll(this).flatMap(mapper);
     }
 
     @Override
@@ -489,8 +490,9 @@ public abstract class BitSet<T> implements SortedSet<T>, Serializable {
     }
 
     @Override
-    public final <U> SortedSet<U> map(Function<? super T, ? extends U> mapper) {
-        return map(Comparators.naturalComparator(), mapper);
+    public final <U> Set<U> map(Function<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return HashSet.ofAll(this).map(mapper);
     }
 
     @Override

--- a/src/main/java/io/vavr/collection/BitSet.java
+++ b/src/main/java/io/vavr/collection/BitSet.java
@@ -403,7 +403,7 @@ public abstract class BitSet<T> implements SortedSet<T>, Serializable {
     @Override
     public final <U> Set<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return HashSet.ofAll(this).flatMap(mapper);
+        return isEmpty() ? HashSet.empty() : HashSet.ofAll(this).flatMap(mapper);
     }
 
     @Override
@@ -492,7 +492,7 @@ public abstract class BitSet<T> implements SortedSet<T>, Serializable {
     @Override
     public final <U> Set<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return HashSet.ofAll(this).map(mapper);
+        return this.isEmpty() ? HashSet.empty() : HashSet.ofAll(this).map(mapper);
     }
 
     @Override

--- a/src/main/java/io/vavr/collection/SortedSet.java
+++ b/src/main/java/io/vavr/collection/SortedSet.java
@@ -126,7 +126,7 @@ public interface SortedSet<T> extends Set<T>, Ordered<T> {
     SortedSet<T> reject(Predicate<? super T> predicate);
 
     @Override
-    <U> SortedSet<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
+    <U> Set<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper);
 
     @Override
     <C> Map<C, ? extends SortedSet<T>> groupBy(Function<? super T, ? extends C> classifier);
@@ -149,7 +149,7 @@ public interface SortedSet<T> extends Set<T>, Ordered<T> {
     }
 
     @Override
-    <U> SortedSet<U> map(Function<? super T, ? extends U> mapper);
+    <U> Set<U> map(Function<? super T, ? extends U> mapper);
 
     @Override
     SortedSet<T> orElse(Iterable<? extends T> other);

--- a/src/main/java/io/vavr/collection/TreeSet.java
+++ b/src/main/java/io/vavr/collection/TreeSet.java
@@ -645,7 +645,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     @Override
     public <U> Set<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return HashSet.ofAll(this).flatMap(mapper);
+        return isEmpty() ? HashSet.empty() : HashSet.ofAll(this).flatMap(mapper);
     }
 
     @Override
@@ -769,9 +769,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     @Override
     public <U> Set<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return tree.isEmpty()
-          ? HashSet.empty()
-          : HashSet.ofAll(this).map(mapper);
+        return tree.isEmpty() ? HashSet.empty() : HashSet.ofAll(this).map(mapper);
     }
 
     /**

--- a/src/main/java/io/vavr/collection/TreeSet.java
+++ b/src/main/java/io/vavr/collection/TreeSet.java
@@ -643,8 +643,9 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     }
 
     @Override
-    public <U> TreeSet<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        return flatMap(Comparators.naturalComparator(), mapper);
+    public <U> Set<U> flatMap(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return HashSet.ofAll(this).flatMap(mapper);
     }
 
     @Override
@@ -766,8 +767,11 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     }
 
     @Override
-    public <U> TreeSet<U> map(Function<? super T, ? extends U> mapper) {
-        return map(Comparators.naturalComparator(), mapper);
+    public <U> Set<U> map(Function<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return tree.isEmpty()
+          ? HashSet.empty()
+          : HashSet.ofAll(this).map(mapper);
     }
 
     /**

--- a/src/main/java/io/vavr/collection/TreeSet.java
+++ b/src/main/java/io/vavr/collection/TreeSet.java
@@ -769,7 +769,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     @Override
     public <U> Set<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return tree.isEmpty() ? HashSet.empty() : HashSet.ofAll(this).map(mapper);
+        return isEmpty() ? HashSet.empty() : HashSet.ofAll(this).map(mapper);
     }
 
     /**

--- a/src/test/java/io/vavr/collection/BitSetTest.java
+++ b/src/test/java/io/vavr/collection/BitSetTest.java
@@ -20,6 +20,7 @@ import java.util.stream.Collector;
 import static java.util.stream.Collectors.toList;
 import static io.vavr.Serializables.deserialize;
 import static io.vavr.Serializables.serialize;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class BitSetTest extends AbstractSortedSetTest {
 
@@ -540,6 +541,20 @@ public class BitSetTest extends AbstractSortedSetTest {
         } else {
             assertThat(queue).isEqualTo(PriorityQueue.of(comparator, 1, 2, 3));
         }
+    }
+
+    // -- map()
+
+    @Test
+    public void shouldMapElementsToUncomparableType() {
+        assertThatCode(() -> of(1, 2, 3).map(i -> new Object())).doesNotThrowAnyException();
+    }
+
+    // -- flatMap()
+
+    @Test
+    public void shouldFlatMapToUncomparableType() {
+        assertThatCode(() -> of(1, 2, 3).flatMap(i -> HashSet.of(new Object()))).doesNotThrowAnyException();
     }
 
     // -- transform()

--- a/src/test/java/io/vavr/collection/TreeSetTest.java
+++ b/src/test/java/io/vavr/collection/TreeSetTest.java
@@ -30,9 +30,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
+import static io.vavr.TestComparators.toStringComparator;
 import static io.vavr.collection.Comparators.naturalComparator;
 import static java.util.Comparator.nullsFirst;
-import static io.vavr.TestComparators.toStringComparator;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class TreeSetTest extends AbstractSortedSetTest {
 
@@ -439,6 +440,20 @@ public class TreeSetTest extends AbstractSortedSetTest {
     public void shouldPreserveComparatorOnConvertToSortedSetWithoutDistinctComparator() {
         final TreeSet<Integer> value = TreeSet.of(naturalComparator().reversed(), 1, 2, 3);
         assertThat(value.toSortedSet().mkString(",")).isEqualTo("3,2,1");
+    }
+
+    // -- map()
+
+    @Test
+    public void shouldMapElementsToUncomparableType() {
+        assertThatCode(() -> of(1, 2, 3).map(i -> new Object())).doesNotThrowAnyException();
+    }
+
+    // -- flatMap()
+
+    @Test
+    public void shouldFlatMapToUncomparableType() {
+        assertThatCode(() -> of(1, 2, 3).flatMap(i -> HashSet.of(new Object()))).doesNotThrowAnyException();
     }
 
     // -- transform()


### PR DESCRIPTION
related to: https://github.com/vavr-io/vavr/issues/1226 https://github.com/vavr-io/vavr/issues/1226#issuecomment-568864583

Make SortedSet#map/flatMap return unordered set to avoid runtime errors when working with non-comparable objects.
