### PR TITLE
Add reverse() in Set, And Implement it in TreeSet and LinkedHashSet

### DIFF
--- a/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -22,10 +22,7 @@ import io.vavr.*;
 import io.vavr.control.Option;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collector;
 
@@ -796,6 +793,11 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
     @Override
     public LinkedHashSet<T> retainAll(Iterable<? extends T> elements) {
         return Collections.retainAll(this, elements);
+    }
+
+    @Override
+    public LinkedHashSet<T> reverse() {
+        return Collections.reverseIterator(this).collect(collector());
     }
 
     @Override

--- a/src/main/java/io/vavr/collection/Set.java
+++ b/src/main/java/io/vavr/collection/Set.java
@@ -164,6 +164,15 @@ public interface Set<T> extends Traversable<T>, Function1<T, Boolean>, Serializa
     Set<T> removeAll(Iterable<? extends T> elements);
 
     /**
+     * Reverse the order of all given elements in this set, if present.
+     *
+     * @return A new set consisting of the elements in reverse order of this set
+     */
+    default Set<T> reverse() {
+        throw new UnsupportedOperationException("Operation not supported");
+    }
+
+    /**
      * Converts this Vavr {@code Set} to a {@code java.util.Set} while preserving characteristics
      * like insertion order ({@code LinkedHashSet}) and sort order ({@code SortedSet}).
      *

--- a/src/main/java/io/vavr/collection/TreeSet.java
+++ b/src/main/java/io/vavr/collection/TreeSet.java
@@ -845,6 +845,11 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     }
 
     @Override
+    public TreeSet<T> reverse() {
+        return ofAll(comparator().reversed(), this);
+    }
+
+    @Override
     public TreeSet<T> scan(T zero, BiFunction<? super T, ? super T, ? extends T> operation) {
         return Collections.scanLeft(this, zero, operation, iter -> TreeSet.ofAll(comparator(), iter));
     }

--- a/src/test/java/io/vavr/collection/LinkedHashSetTest.java
+++ b/src/test/java/io/vavr/collection/LinkedHashSetTest.java
@@ -229,6 +229,15 @@ public class LinkedHashSetTest extends AbstractSetTest {
         assertThat(actual).isSameAs(set);
     }
 
+    @Test
+    public void shouldReverseLinkedHashSet() {
+        final LinkedHashSet<Integer> actual = LinkedHashSet.ofAll(1, 2, 3);
+        final LinkedHashSet<Integer> notExpected = actual.reverse();
+        final LinkedHashSet<Integer> expected = notExpected.reverse();
+        assertThat(actual).isNotEqualTo(notExpected);
+        assertThat(actual).isEqualTo(expected);
+    }
+
     // -- transform
 
     @Test

--- a/src/test/java/io/vavr/collection/TreeSetTest.java
+++ b/src/test/java/io/vavr/collection/TreeSetTest.java
@@ -293,6 +293,15 @@ public class TreeSetTest extends AbstractSortedSetTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    public void shouldReverseTreeSet() {
+        final TreeSet<Integer> actual = TreeSet.ofAll(1, 2, 3);
+        final TreeSet<Integer> notExpected = actual.reverse();
+        final TreeSet<Integer> expected = notExpected.reverse();
+        assertThat(actual).isNotEqualTo(notExpected);
+        assertThat(actual).isEqualTo(expected);
+    }
+
     // -- zip
 
     @Override


### PR DESCRIPTION
**What does this PR do?**
* It adds `reverse()` in `Set`, And Implement it in `LinkedHashSet` and `TreeSet`.

**What issue does this fix or reference to?**
* It reference to [Issue-2514](https://github.com/vavr-io/vavr/issues/2514)