### PR TITLE
Execute generateSources task inside a doLast block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,19 +42,21 @@ sourceSets {
 }
 
 task generateSources() {
-    delete 'src-gen'
-    def ammoniteDir = file("generator/bin")
-    if (!ammoniteDir.exists()) {
-        ammoniteDir.mkdirs()
-    }
-    def ammoniteJar = new File(ammoniteDir, "amm-${ammoniteScalaVersion}-${ammoniteVersion}.jar")
-    if (!ammoniteJar.exists()) {
-        def ammoniteReleaseUrl = "https://github.com/lihaoyi/Ammonite/releases/download/${ammoniteVersion}/${ammoniteScalaVersion}-${ammoniteVersion}"
-        ant.get(src: ammoniteReleaseUrl, dest: ammoniteJar)
-    }
-    javaexec {
-        main = "-jar"
-        args = [ammoniteJar, "generator/Generator.sc"]
+    doLast {
+        delete 'src-gen'
+        def ammoniteDir = file("generator/bin")
+        if (!ammoniteDir.exists()) {
+            ammoniteDir.mkdirs()
+        }
+        def ammoniteJar = new File(ammoniteDir, "amm-${ammoniteScalaVersion}-${ammoniteVersion}.jar")
+        if (!ammoniteJar.exists()) {
+            def ammoniteReleaseUrl = "https://github.com/lihaoyi/Ammonite/releases/download/${ammoniteVersion}/${ammoniteScalaVersion}-${ammoniteVersion}"
+            ant.get(src: ammoniteReleaseUrl, dest: ammoniteJar)
+        }
+        javaexec {
+            main = "-jar"
+            args = [ammoniteJar, "generator/Generator.sc"]
+        }
     }
 }
 


### PR DESCRIPTION
This fixes https://github.com/vavr-io/vavr/issues/2550 
There are no other custom tasks in `build.gradle` that need to be executed under `doLast`.
Please let me know if anything needs changing.
Thank you.