### PR TITLE
space detection looks wrong

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -4101,7 +4101,7 @@ object Generator {
         (part, arg) <- sc.parts zip args.map(s => if (s == null) "" else s.toString)
       } yield {
         // get the leading space of last line of current part
-        val space = """([ \t]*)[^\s]*$""".r.findFirstMatchIn(part).map(_.group(1)).getOrElse("")
+        val space = """([ \t]*)[^\n]*$""".r.findFirstMatchIn(part).map(_.group(1)).getOrElse("")
         // add this leading space to each line (except the first) of current arg
         arg.split("\r?\n") match {
           case lines: Array[String] if lines.nonEmpty => lines reduce (_ + lineSeparator + space + _)


### PR DESCRIPTION
just '\n' like i added is probably not enough in the presence of a CRLF, but as it is this would not do as said in the comment:
for example if part were `foo\ttest test` then space would now be `" "` instead of `"\t"`.