### PR TITLE
Backport "Avoid unnecessary copy in 'ofAll()' methods" to v0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
     </parent>
     <groupId>io.vavr</groupId>
     <artifactId>vavr-parent</artifactId>
-    <version>0.10.2</version>
+    <version>0.10.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Vavr Parent</name>
     <description>Vavr (formerly called Javaslang) is an object-functional language extension to Java 8+.</description>

--- a/vavr-benchmark/pom.xml
+++ b/vavr-benchmark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.vavr</groupId>
         <artifactId>vavr-parent</artifactId>
-        <version>0.10.2</version>
+        <version>0.10.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>vavr-benchmark</artifactId>

--- a/vavr-match-processor/pom.xml
+++ b/vavr-match-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.vavr</groupId>
         <artifactId>vavr-parent</artifactId>
-        <version>0.10.2</version>
+        <version>0.10.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>vavr-match-processor</artifactId>

--- a/vavr-match/pom.xml
+++ b/vavr-match/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.vavr</groupId>
         <artifactId>vavr-parent</artifactId>
-        <version>0.10.2</version>
+        <version>0.10.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>vavr-match</artifactId>

--- a/vavr-test/pom.xml
+++ b/vavr-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.vavr</groupId>
         <artifactId>vavr-parent</artifactId>
-        <version>0.10.2</version>
+        <version>0.10.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>vavr-test</artifactId>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.vavr</groupId>
         <artifactId>vavr-parent</artifactId>
-        <version>0.10.2</version>
+        <version>0.10.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>vavr</artifactId>

--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -21,6 +21,7 @@ package io.vavr.collection;
 
 import io.vavr.*;
 import io.vavr.collection.ArrayModule.Combinations;
+import io.vavr.collection.JavaConverters.ListView;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
@@ -131,9 +132,14 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     @SuppressWarnings("unchecked")
     public static <T> Array<T> ofAll(Iterable<? extends T> elements) {
         Objects.requireNonNull(elements, "elements is null");
-        return elements instanceof Array
-               ? (Array<T>) elements
-               : wrap(toArray(elements));
+        if (elements instanceof Array) {
+            return (Array<T>) elements;
+        }
+        if (elements instanceof ListView
+                && ((ListView<T, ?>) elements).getDelegate() instanceof Array) {
+            return (Array<T>) ((ListView<T, ?>) elements).getDelegate();
+        }
+        return wrap(toArray(elements));
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -21,6 +21,7 @@ package io.vavr.collection;
 
 import io.vavr.*;
 import io.vavr.collection.CharSeqModule.Combinations;
+import io.vavr.collection.JavaConverters.ListView;
 import io.vavr.control.Option;
 
 import java.io.Serializable;
@@ -132,6 +133,7 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
      * @return A string containing the given elements in the same order.
      * @throws NullPointerException if {@code elements} is null or {@code elements} contains null
      */
+    @SuppressWarnings("unchecked")
     public static CharSeq ofAll(Iterable<? extends Character> elements) {
         Objects.requireNonNull(elements, "elements is null");
         if (Collections.isEmpty(elements)){
@@ -139,6 +141,10 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
         }
         if (elements instanceof CharSeq) {
             return (CharSeq) elements;
+        }
+        if (elements instanceof ListView
+                && ((ListView<Character, ?>) elements).getDelegate() instanceof CharSeq) {
+            return (CharSeq) ((ListView<Character, ?>) elements).getDelegate();
         }
         final StringBuilder sb = new StringBuilder();
         for (char character : elements) {

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -35,6 +35,7 @@ import java.util.stream.Collector;
 
 import static io.vavr.collection.JavaConverters.ChangePolicy.IMMUTABLE;
 import static io.vavr.collection.JavaConverters.ChangePolicy.MUTABLE;
+import static io.vavr.collection.JavaConverters.ListView;
 
 /**
  * An immutable {@code List} is an eager sequence of elements. Its immutability makes it suitable for concurrent programming.
@@ -249,6 +250,9 @@ public interface List<T> extends LinearSeq<T> {
         Objects.requireNonNull(elements, "elements is null");
         if (elements instanceof List) {
             return (List<T>) elements;
+        } else if (elements instanceof ListView
+                && ((ListView<T, ?>) elements).getDelegate() instanceof List) {
+            return (List<T>) ((ListView<T, ?>) elements).getDelegate();
         } else if (elements instanceof java.util.List) {
             List<T> result = Nil.instance();
             final java.util.List<T> list = (java.util.List<T>) elements;

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -28,6 +28,7 @@ import java.util.stream.Collector;
 
 import static io.vavr.collection.JavaConverters.ChangePolicy.IMMUTABLE;
 import static io.vavr.collection.JavaConverters.ChangePolicy.MUTABLE;
+import static io.vavr.collection.JavaConverters.ListView;
 
 /**
  * An immutable {@code Queue} stores elements allowing a first-in-first-out (FIFO) retrieval.
@@ -162,6 +163,9 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
         Objects.requireNonNull(elements, "elements is null");
         if (elements instanceof Queue) {
             return (Queue<T>) elements;
+        } else if (elements instanceof ListView
+                && ((ListView<T, ?>) elements).getDelegate() instanceof Queue) {
+            return (Queue<T>) ((ListView<T, ?>) elements).getDelegate();
         } else if (!elements.iterator().hasNext()) {
             return empty();
         } else if (elements instanceof io.vavr.collection.List) {
@@ -702,7 +706,7 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     public <R> Queue<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         return ofAll(iterator().<R> collect(partialFunction));
     }
-    
+
     @Override
     public Queue<Queue<T>> combinations() {
         return ofAll(toList().combinations().map(Queue::ofAll));

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -32,6 +32,7 @@ import java.util.stream.Collector;
 
 import static io.vavr.collection.JavaConverters.ChangePolicy.IMMUTABLE;
 import static io.vavr.collection.JavaConverters.ChangePolicy.MUTABLE;
+import static io.vavr.collection.JavaConverters.ListView;
 
 /**
  * An immutable {@code Stream} is lazy sequence of elements which may be infinitely long.
@@ -384,6 +385,9 @@ public interface Stream<T> extends LinearSeq<T> {
         Objects.requireNonNull(elements, "elements is null");
         if (elements instanceof Stream) {
             return (Stream<T>) elements;
+        } else if (elements instanceof ListView
+                && ((ListView<T, ?>) elements).getDelegate() instanceof Stream) {
+            return (Stream<T>) ((ListView<T, ?>) elements).getDelegate();
         } else {
             return StreamFactory.create(elements.iterator());
         }
@@ -891,7 +895,7 @@ public interface Stream<T> extends LinearSeq<T> {
     default <R> Stream<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         return ofAll(iterator().<R> collect(partialFunction));
     }
-    
+
     @Override
     default Stream<Stream<T>> combinations() {
         return Stream.rangeClosed(0, length()).map(this::combinations).flatMap(Function.identity());

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -20,6 +20,7 @@
 package io.vavr.collection;
 
 import io.vavr.*;
+import io.vavr.collection.JavaConverters.ListView;
 import io.vavr.collection.VectorModule.Combinations;
 import io.vavr.control.Option;
 
@@ -183,11 +184,15 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     @SuppressWarnings("unchecked")
     public static <T> Vector<T> ofAll(Iterable<? extends T> iterable) {
         Objects.requireNonNull(iterable, "iterable is null");
-        if (iterable instanceof Traversable && io.vavr.collection.Collections.isEmpty(iterable)){
+        if (iterable instanceof Traversable && io.vavr.collection.Collections.isEmpty(iterable)) {
             return empty();
         }
         if (iterable instanceof Vector) {
             return (Vector<T>) iterable;
+        }
+        if (iterable instanceof ListView
+                && ((ListView<T, ?>) iterable).getDelegate() instanceof Vector) {
+            return (Vector<T>) ((ListView<T, ?>) iterable).getDelegate();
         }
         final Object[] values = withSize(iterable).toArray();
         return ofAll(BitMappedTrie.ofAll(values));
@@ -651,7 +656,7 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     public Vector<T> asJavaMutable(Consumer<? super java.util.List<T>> action) {
         return Collections.asJava(this, action, MUTABLE);
     }
-    
+
     @Override
     public <R> Vector<R> collect(PartialFunction<? super T, ? extends R> partialFunction) {
         return ofAll(iterator().<R> collect(partialFunction));

--- a/vavr/src/test/java/io/vavr/collection/ArrayTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ArrayTest.java
@@ -21,7 +21,10 @@ package io.vavr.collection;
 
 import io.vavr.Value;
 import io.vavr.Tuple2;
+import io.vavr.collection.JavaConverters.ChangePolicy;
+import io.vavr.collection.JavaConverters.ListView;
 import io.vavr.control.Option;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -214,6 +217,32 @@ public class ArrayTest extends AbstractIndexedSeqTest {
         final Array<Number> numbers = Array.narrow(doubles);
         final int actual = numbers.append(new BigDecimal("2.0")).sum().intValue();
         assertThat(actual).isEqualTo(3);
+    }
+
+    // -- static ofAll
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfArray() {
+        final Array<Integer> source = ofAll(1, 2, 3);
+        final Array<Integer> target = Array.ofAll(source);
+        assertThat(target).isSameAs(source);
+    }
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfListView() {
+        final ListView<Integer, Array<Integer>> source = JavaConverters
+                .asJava(ofAll(1, 2, 3), ChangePolicy.IMMUTABLE);
+        final Array<Integer> target = Array.ofAll(source);
+        assertThat(target).isSameAs(source.getDelegate());
+    }
+
+    // -- get()
+
+    @Test
+    public void shouldThrowExceptionWhenGetIndexEqualToLength() {
+        final Array<Integer> array = of(1);
+        Assertions.assertThatThrownBy(() -> array.get(1))
+            .isInstanceOf(IndexOutOfBoundsException.class).hasMessage("get(1)");
     }
 
     // -- transform()

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -22,13 +22,12 @@ package io.vavr.collection;
 import io.vavr.Serializables;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
+import io.vavr.collection.JavaConverters.ChangePolicy;
+import io.vavr.collection.JavaConverters.ListView;
 import io.vavr.control.Option;
 import org.assertj.core.api.*;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -68,11 +67,26 @@ public class CharSeqTest {
         return new StringAssert(actual) {};
     }
 
-    // -- ofAll
+    // -- static ofAll
 
     @Test
     public void shouldThrowWhenCreatingCharSeqFromIterableThatContainsNull() {
         assertThatThrownBy(() -> CharSeq.ofAll(Arrays.asList('1', null))).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfCharSeq() {
+        final CharSeq source = CharSeq.ofAll(Arrays.asList('a', 'b', 'c'));
+        final CharSeq target = CharSeq.ofAll(source);
+        assertThat(target).isSameAs(source);
+    }
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfListView() {
+        final ListView<Character, CharSeq> source = JavaConverters
+                .asJava(CharSeq.ofAll(asList('a', 'b', 'c')), ChangePolicy.IMMUTABLE);
+        final CharSeq target = CharSeq.ofAll(source);
+        assertThat(target).isSameAs(source.getDelegate());
     }
 
     // -- asJavaMutable*
@@ -2135,16 +2149,6 @@ public class CharSeqTest {
         assertThat(actual).isEqualTo(expected);
     }
 
-    // helpers
-
-    static PrintStream failingPrintStream() {
-        return new PrintStream(new OutputStream() {
-            @Override
-            public void write(int b) throws IOException {
-                throw new IOException();
-            }
-        });
-    }
     // -- append
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/ListTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ListTest.java
@@ -217,7 +217,7 @@ public class ListTest extends AbstractLinearSeqTest {
         assertThat(actual).isEqualTo(3);
     }
 
-    // -- ofAll(NavigableSet)
+    // -- static ofAll
 
     @Test
     public void shouldAcceptNavigableSet() {
@@ -225,6 +225,21 @@ public class ListTest extends AbstractLinearSeqTest {
         javaSet.add(2);
         javaSet.add(1);
         assertThat(List.ofAll(javaSet)).isEqualTo(List.of(1, 2));
+    }
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfList() {
+        final List<Integer> source = ofAll(1, 2, 3);
+        final List<Integer> target = List.ofAll(source);
+        assertThat(target).isSameAs(source);
+    }
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfListView() {
+        final JavaConverters.ListView<Integer, List<Integer>> source = JavaConverters
+                .asJava(ofAll(1, 2, 3), JavaConverters.ChangePolicy.IMMUTABLE);
+        final List<Integer> target = List.ofAll(source);
+        assertThat(target).isSameAs(source.getDelegate());
     }
 
     // -- peek

--- a/vavr/src/test/java/io/vavr/collection/QueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/QueueTest.java
@@ -221,6 +221,23 @@ public class QueueTest extends AbstractLinearSeqTest {
         assertThat(actual).isEqualTo(3);
     }
 
+    // -- static ofAll
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfQueue() {
+        final Queue<Integer> source = ofAll(1, 2, 3);
+        final Queue<Integer> target = Queue.ofAll(source);
+        assertThat(target).isSameAs(source);
+    }
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfListView() {
+        final JavaConverters.ListView<Integer, Queue<Integer>> source = JavaConverters
+                .asJava(ofAll(1, 2, 3), JavaConverters.ChangePolicy.IMMUTABLE);
+        final Queue<Integer> target = Queue.ofAll(source);
+        assertThat(target).isSameAs(source.getDelegate());
+    }
+
     // -- peek
 
     @Test(expected = NoSuchElementException.class)

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -389,6 +389,23 @@ public class StreamTest extends AbstractLinearSeqTest {
         assertThat(actual).isEqualTo(3);
     }
 
+    // -- static ofAll
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfStream() {
+        final Stream<Integer> source = ofAll(1, 2, 3);
+        final Stream<Integer> target = Stream.ofAll(source);
+        assertThat(target).isSameAs(source);
+    }
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfListView() {
+        final JavaConverters.ListView<Integer, Stream<Integer>> source = JavaConverters
+                .asJava(ofAll(1, 2, 3), JavaConverters.ChangePolicy.IMMUTABLE);
+        final Stream<Integer> target = Stream.ofAll(source);
+        assertThat(target).isSameAs(source.getDelegate());
+    }
+
     // -- append
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/VectorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/VectorTest.java
@@ -22,6 +22,8 @@ package io.vavr.collection;
 import io.vavr.Serializables;
 import io.vavr.Value;
 import io.vavr.Tuple2;
+import io.vavr.collection.JavaConverters.ChangePolicy;
+import io.vavr.collection.JavaConverters.ListView;
 import io.vavr.control.Option;
 import org.junit.Test;
 
@@ -216,6 +218,23 @@ public class VectorTest extends AbstractIndexedSeqTest {
         final Vector<Number> numbers = Vector.narrow(doubles);
         final int actual = numbers.append(new BigDecimal("2.0")).sum().intValue();
         assertThat(actual).isEqualTo(3);
+    }
+
+    // -- static ofAll
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfVector() {
+        final Vector<Integer> source = ofAll(1, 2, 3);
+        final Vector<Integer> target = Vector.ofAll(source);
+        assertThat(target).isSameAs(source);
+    }
+
+    @Test
+    public void shouldReturnSelfWhenIterableIsInstanceOfListView() {
+        final ListView<Integer, Vector<Integer>> source = JavaConverters
+                .asJava(ofAll(1, 2, 3), ChangePolicy.IMMUTABLE);
+        final Vector<Integer> target = Vector.ofAll(source);
+        assertThat(target).isSameAs(source.getDelegate());
     }
 
     // -- primitives


### PR DESCRIPTION
Fix #2568 