### PR TITLE
Add missing Automatic-Module-Name (io.vavr)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,12 @@ check {
     dependsOn javadoc
 }
 
+jar {
+    manifest {
+        attributes "Automatic-Module-Name": "io.vavr"
+    }
+}
+
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
     archiveClassifier = 'sources'


### PR DESCRIPTION
## Overview

Fix https://github.com/vavr-io/vavr/issues/2573. This is done by adding attribute "Automatic-Module-Name: io.vavr" in the manifest, similar to https://github.com/vavr-io/vavr/pull/2104.

## Testing

The goal is to see if the module "io.vavr" works by using it in JShell. Build the JAR with command `./gradlew build` and use it.

Before this PR:

```
vavr (master u=) $ java -version
openjdk version "14" 2020-03-17
OpenJDK Runtime Environment (build 14+36-1461)
OpenJDK 64-Bit Server VM (build 14+36-1461, mixed mode, sharing)

vavr (master u=) $ jshell --module-path build/libs/vavr-1.0.0-SNAPSHOT.jar --add-modules io.vavr
Launching JShell execution engine threw: Error occurred during initialization of boot layer
java.lang.module.FindException: Module io.vavr not found
```

After the PR:

```
vavr (issue-2573-AutomaticModuleName u=) $ jshell --module-path build/libs/vavr-1.0.0-SNAPSHOT.jar --add-modules io.vavr
|  Welcome to JShell -- Version 14
|  For an introduction type: /help intro

jshell> io.vavr.control.Option.of("Yeah")
$1 ==> Some(Yeah)
```

Also, inspect the JAR content to see if the attribute is added into the manifest. As you can see, only the main JAR is concerned:

```
vavr (issue-2573-AutomaticModuleName u=) $ find build/libs -name *.jar -print -exec unzip -p {} META-INF/MANIFEST.MF \;
build/libs/vavr-1.0.0-SNAPSHOT-javadoc.jar
Manifest-Version: 1.0

build/libs/vavr-1.0.0-SNAPSHOT-sources.jar
Manifest-Version: 1.0

build/libs/vavr-1.0.0-SNAPSHOT-test-sources.jar
Manifest-Version: 1.0

build/libs/vavr-1.0.0-SNAPSHOT.jar
Manifest-Version: 1.0
Automatic-Module-Name: io.vavr
```