### PR TITLE
Option<>.collect() not to call PartialFunction on args where it is not defined

### DIFF
--- a/src/main/java/io/vavr/PartialFunction.java
+++ b/src/main/java/io/vavr/PartialFunction.java
@@ -123,7 +123,7 @@ public interface PartialFunction<T, R> extends Function1<T, R> {
      *         if the function is defined for the given arguments, and {@code None} otherwise.
      */
     default Function1<T, Option<R>> lift() {
-        return t -> Option.when(isDefinedAt(t), apply(t));
+        return t -> Option.when(isDefinedAt(t), () -> apply(t));
     }
 
 }

--- a/src/test/java/io/vavr/control/OptionTest.java
+++ b/src/test/java/io/vavr/control/OptionTest.java
@@ -563,6 +563,12 @@ public class OptionTest extends AbstractValueTest {
         Option.some(1).collect(pf);
     }
 
+    @Test
+    public void shouldNotCallPartialFunctionOnUndefinedArg() {
+        final PartialFunction<Integer, Integer> pf = Function1.<Integer, Integer> of(x -> 1/x).partial(i -> i != 0);
+        assertThat(Option.of(0).collect(pf)).isEqualTo(Option.none());
+    }
+
     // -- iterator
 
     @Test


### PR DESCRIPTION
Fixes ##2579

Expected behavior: Option<>.collect() calls PartialFunction passed as argument only for the value on which this PartialFunction is defined.

Observed behavior: PartialFunction called on values for which it is not defined, resulting in undesired behavior (i.e. unchecked exception thrown).

Example code which fails with arithmetic exception (division by zero):

    @Test
    void collect() {
		PartialFunction<Integer, Integer> undefinedFor0 = new PartialFunction<>() {
			private static final long serialVersionUID = 1L;
			@Override public Integer apply(Integer t) {return 1/t;}
			@Override public boolean isDefinedAt(Integer value) {return value != 0;}
		};

		Option<Integer> zero = Option.some(0);
		assertTrue(zero.collect(undefinedFor0).isEmpty());
    }

Using io.vavr:vavr:0.10.2

I've checked the code and this is what I've found:

1) Optiona<>.collect() eventually calls PartialFunction.lift(), here https://github.com/vavr-io/vavr/blob/0b7a72c8c801999538dda1e3413a6063aadab934/src/main/java/io/vavr/control/Option.java#L288

2) in turn, PartialFunction.lift() looks like this:

    default Function1<T, Option<R>> lift() {
        return t -> Option.when(isDefinedAt(t), apply(t));
    }

— meaning `apply(t)` will be always called, no matter if `isDefinedAt(t)` returns `true` or `false`.
https://github.com/vavr-io/vavr/blob/0b7a72c8c801999538dda1e3413a6063aadab934/src/main/java/io/vavr/PartialFunction.java#L126

The proposed fix: changing the code to

    default Function1<T, Option<R>> lift() {
        return t -> Option.when(isDefinedAt(t), () -> apply(t));
    }
