### PR TITLE
Resolving 'yield may become a restricted identifier in a future releases' warning

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -843,7 +843,7 @@ def generateMainClasses(): Unit = {
                      */
                     @Deprecated
                     public ${if(mtype == "Either") s"$rtype<L, T1>" else s"$rtype<T1>"} yield() {
-                        return yield(Function.identity());
+                        return this.yield(Function.identity());
                     }
                   """)}
               }

--- a/src-gen/main/java/io/vavr/API.java
+++ b/src-gen/main/java/io/vavr/API.java
@@ -3646,7 +3646,7 @@ public final class API {
           */
          @Deprecated
          public Iterator<T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 
@@ -3996,7 +3996,7 @@ public final class API {
           */
          @Deprecated
          public Option<T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 
@@ -4346,7 +4346,7 @@ public final class API {
           */
          @Deprecated
          public Future<T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 
@@ -4696,7 +4696,7 @@ public final class API {
           */
          @Deprecated
          public Try<T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 
@@ -5046,7 +5046,7 @@ public final class API {
           */
          @Deprecated
          public Either<L, T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 
@@ -5396,7 +5396,7 @@ public final class API {
           */
          @Deprecated
          public List<T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 


### PR DESCRIPTION
With javac 13.0.2 `./gradlew check` results in several warnings like this:

    ...../vavr/src-gen/main/java/io/vavr/API.java:4699: warning: 'yield' may become a restricted identifier in a future release
             return yield(Function.identity());
    (to invoke a method called yield, qualify the yield with a receiver or type name)

(Please note that with current `build.gradle` setup warnings are treated as errors.)

This commit fixes the issue by qualifying the call with `this.`
