### PR TITLE
Javadoc error fix 'heading used out of sequence' (JDK 13.0.2)

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -1374,7 +1374,7 @@ def generateMainClasses(): Unit = {
          * import static io.vavr.API.*;
          * </code></pre>
          *
-         * <h3>For-comprehension</h3>
+         * <h2>For-comprehension</h2>
          * <p>
          * The {@code For}-comprehension is syntactic sugar for nested for-loops. We write
          *

--- a/src-gen/main/java/io/vavr/API.java
+++ b/src-gen/main/java/io/vavr/API.java
@@ -47,7 +47,7 @@ import java.util.function.Supplier;
  * import static io.vavr.API.*;
  * </code></pre>
  *
- * <h3>For-comprehension</h3>
+ * <h2>For-comprehension</h2>
  * <p>
  * The {@code For}-comprehension is syntactic sugar for nested for-loops. We write
  *

--- a/src/main/java/io/vavr/concurrent/Promise.java
+++ b/src/main/java/io/vavr/concurrent/Promise.java
@@ -34,7 +34,7 @@ import static io.vavr.concurrent.Future.DEFAULT_EXECUTOR;
  * The underlying {@code Executor} is used to execute asynchronous handlers, e.g. via
  * {@code promise.future().onComplete(...)}.
  *
- * <h3>Creation</h3>
+ * <h2>Creation</h2>
  * <p>
  * Promise offers static factory methods to create new promises which hasn't been fulfilled yet:
  * <ul>
@@ -49,7 +49,7 @@ import static io.vavr.concurrent.Future.DEFAULT_EXECUTOR;
  * All the static factory methods mentioned above have additional versions which take an {@link Executor} as
  * argument. This gives us more control over thread creation and thread pool sizes.
  *
- * <h3>One-shot API</h3>
+ * <h2>One-shot API</h2>
  * <p>
  * The main purpose of a {@code Promise} is to complete its underlying {@code Future}. When only a single {@code Thread}
  * will eventually complete the {@code Promise}, we use one of these methods. Calls will throw if the {@code Promise} is already
@@ -61,7 +61,7 @@ import static io.vavr.concurrent.Future.DEFAULT_EXECUTOR;
  * <li>{@link #success(Object)}</li>
  * </ul>
  *
- * <h3>API for competing threads</h3>
+ * <h2>API for competing threads</h2>
  * <p>
  * When multiple {@code Thread}s may complete our {@code Promise}, we typically use one of these methods. Calls will
  * gracefully return {@code false} if the {@code Promise} is already completed.


### PR DESCRIPTION
Expected behavior (javac 13.0.2): `./gradlew check` runs without errors

Observed behavior:

    > Task :javadoc
    .../vavr/src/main/java/io/vavr/concurrent/Promise.java:37: 
    error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>
     * <h3>Creation</h3>
    ^
    .../vavr/src-gen/main/java/io/vavr/API.java:50: error: 
    heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>
     * <h3>For-comprehension</h3>
       ^
    2 errors

    > Task :javadoc FAILED

    FAILURE: Build failed with an exception.

Fix: both error cases a result of \<h3\> header going right after \<h1\> header, so the fix is to change \<h3\> to \<h2\> in those two cases.

Observed behavior after fix:

    ./gradlew javadoc

    > Task :generateSources
    Starting code generator...

    Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
    Use '--warning-mode all' to show the individual deprecation warnings.
    See     https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings

    BUILD SUCCESSFUL in 5s
    3 actionable tasks: 1 executed, 2 up-to-date
