### PR TITLE
No more failures in the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ matrix:
     env: DEPLOY=true
   - jdk: openjdk14
   - jdk: openjdk-ea
-  allow_failures:
-  - jdk: openjdk14
-  - jdk: openjdk-ea
 
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     env: DEPLOY=true
   - jdk: openjdk14
   - jdk: openjdk-ea
+  allow_failures:
+  - jdk: openjdk-ea
 
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Thanks to the following PRs, the build are no longer failing on JDK 14 and JDK EA:

- https://github.com/vavr-io/vavr/pull/2578 Upgrade to Gradle 6.3
- https://github.com/vavr-io/vavr/pull/2581 Resolving 'yield may become a restricted identifier in a future releases' warning
- https://github.com/vavr-io/vavr/pull/2585 Javadoc error fix 'heading used out of sequence' (JDK 13.0.2)