### PR TITLE
Removed Map/Seq withDefault & withDefaultValue

### DIFF
--- a/src/main/java/io/vavr/collection/Map.java
+++ b/src/main/java/io/vavr/collection/Map.java
@@ -86,8 +86,6 @@ import java.util.function.*;
  * <li>{@link #transform(Function)}</li>
  * <li>{@link #unzip(BiFunction)}</li>
  * <li>{@link #unzip3(BiFunction)}</li>
- * <li>{@link #withDefault(Function)}</li>
- * <li>{@link #withDefaultValue(Object)}</li>
  * </ul>
  *
  * @param <K> Key type
@@ -712,33 +710,6 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
      */
     default Iterator<V> valuesIterator() {
         return iterator().map(Tuple2::_2);
-    }
-
-    /**
-     * Turns this map from a partial function into a total function that
-     * returns a value computed by defaultFunction for all keys
-     * absent from the map.
-     *
-     * @param defaultFunction function to evaluate for all keys not present in the map
-     * @return a total function from K to T
-     * @deprecated Will be removed
-     */
-    @Deprecated
-    default Function1<K, V> withDefault(Function<? super K, ? extends V> defaultFunction) {
-        return k -> get(k).getOrElse(() -> defaultFunction.apply(k));
-    }
-
-    /**
-     * Turns this map from a partial function into a total function that
-     * returns defaultValue for all keys absent from the map.
-     *
-     * @param defaultValue default value to return for all keys not present in the map
-     * @return a total function from K to T
-     * @deprecated Will be removed
-     */
-    @Deprecated
-    default Function1<K, V> withDefaultValue(V defaultValue) {
-        return k -> get(k).getOrElse(defaultValue);
     }
 
     @Override

--- a/src/main/java/io/vavr/collection/Seq.java
+++ b/src/main/java/io/vavr/collection/Seq.java
@@ -1304,32 +1304,6 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
     @Override
     <U> Seq<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper);
 
-    /**
-     * Turns this sequence from a partial function into a total function that
-     * returns defaultValue for all indexes that are out of bounds.
-     *
-     * @param defaultValue default value to return for out of bound indexes
-     * @return a total function from index to T
-     * @deprecated Will be removed
-     */
-    @Deprecated
-    default Function1<Integer, T> withDefaultValue(T defaultValue) {
-        return i -> (i >= 0 && i < length()) ? apply(i) : defaultValue;
-    }
-
-    /**
-     * Turns this sequence from a partial function into a total function that
-     * returns a value computed by defaultFunction for all indexes that are out of bounds.
-     *
-     * @param defaultFunction function to evaluate for all out of bounds indexes.
-     * @return a total function from index to T
-     * @deprecated Will be removed
-     */
-    @Deprecated
-    default Function1<Integer, T> withDefault(Function<? super Integer, ? extends T> defaultFunction) {
-        return i -> (i >= 0 && i < length()) ? apply(i) : defaultFunction.apply(i);
-    }
-
     @Override
     default boolean isSequential() {
         return true;


### PR DESCRIPTION
Scala's Map.withDefault returns a dedicated type WithDefault that implements Map. We return a Function1. It isn't worth the effort to create a new collection implementation just for providing default values. It is still relatively easy for a user to create their own Function that encapsulates a default value.

## Migration guide

We assume here that #2584 has been implemented.

W.l.o.g. we are still able to create functions that return default values:

```java
void example(Map<K, V> map, V defaultValue) {
    // before
    Function1<K, V> f1 = map.withDefault(k -> defaultValue);

    // after
    Function1<K, V> f2 = k -> map.getOrElse(k, defaultValue);
}
```

### Seq.withDefault(Function)

```java
// before
Seq(1, 2, 3).widthDefault(i -> -1).get(4)

// after
Seq(1, 2, 3).getOrElse(4, -1)
```

### Seq.withDefaultValue(Object)

```java
// before
Seq(1, 2, 3).widthDefaultValue(-1).get(4)

// after
Seq(1, 2, 3).getOrElse(4, -1)
```

### Map.withDefault(Function)

```java
// before
Map(1, 'a', 2, 'b', 3, 'c').widthDefault(key -> 'x').get(4)

// after
Map(1, 'a', 2, 'b', 3, 'c').getOrElse(4, 'x')
```

### Map.withDefaultValue(Object)

```java
// before
Map(1, 'a', 2, 'b', 3, 'c').widthDefaultValue('x').get(4)

// after
Map(1, 'a', 2, 'b', 3, 'c').getOrElse(4, 'x')
```
