### PR TITLE
fixes #2584 -- Add Seq.getOption(int) and Seq.getOrElse(int, T)

### DIFF
--- a/src/main/java/io/vavr/collection/Array.java
+++ b/src/main/java/io/vavr/collection/Array.java
@@ -774,10 +774,7 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public T get(int index) {
-        if (index < 0 || index >= length()) {
-            throw new IndexOutOfBoundsException("get(" + index + ")");
-        }
+    public T apply(Integer index) {
         return (T) delegate[index];
     }
 

--- a/src/main/java/io/vavr/collection/Array.java
+++ b/src/main/java/io/vavr/collection/Array.java
@@ -781,6 +781,24 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
         return (T) delegate[index];
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public Option<T> getOption(int index) {
+        if (index < 0 || index >= length()) {
+            return Option.none();
+        }
+        return Option.some((T) delegate[index]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T getOrElse(int index, T defaultValue) {
+        if (index < 0 || index >= length()) {
+            return defaultValue;
+        }
+        return (T) delegate[index];
+    }
+
     @Override
     public Array<T> distinct() {
         return distinctBy(Function.identity());

--- a/src/main/java/io/vavr/collection/Array.java
+++ b/src/main/java/io/vavr/collection/Array.java
@@ -781,24 +781,6 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
         return (T) delegate[index];
     }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public Option<T> getOption(int index) {
-        if (index < 0 || index >= length()) {
-            return Option.none();
-        }
-        return Option.some((T) delegate[index]);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public T getOrElse(int index, T defaultValue) {
-        if (index < 0 || index >= length()) {
-            return defaultValue;
-        }
-        return (T) delegate[index];
-    }
-
     @Override
     public Array<T> distinct() {
         return distinctBy(Function.identity());

--- a/src/main/java/io/vavr/collection/CharSeq.java
+++ b/src/main/java/io/vavr/collection/CharSeq.java
@@ -1203,22 +1203,6 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
-    public Option<Character> getOption(int index) {
-        if (index < 0 || index >= back.length()) {
-            return Option.none();
-        }
-        return Option.some(back.charAt(index));
-    }
-
-    @Override
-    public Character getOrElse(int index, Character defaultValue) {
-        if (index < 0 || index >= back.length()) {
-            return defaultValue;
-        }
-        return back.charAt(index);
-    }
-
-    @Override
     public int indexOf(Character element, int from) {
         return back.indexOf(element, from);
     }

--- a/src/main/java/io/vavr/collection/CharSeq.java
+++ b/src/main/java/io/vavr/collection/CharSeq.java
@@ -1203,6 +1203,22 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
+    public Option<Character> getOption(int index) {
+        if (index < 0 || index >= back.length()) {
+            return Option.none();
+        }
+        return Option.some(back.charAt(index));
+    }
+
+    @Override
+    public Character getOrElse(int index, Character defaultValue) {
+        if (index < 0 || index >= back.length()) {
+            return defaultValue;
+        }
+        return back.charAt(index);
+    }
+
+    @Override
     public int indexOf(Character element, int from) {
         return back.indexOf(element, from);
     }

--- a/src/main/java/io/vavr/collection/CharSeq.java
+++ b/src/main/java/io/vavr/collection/CharSeq.java
@@ -1198,7 +1198,7 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
-    public Character get(int index) {
+    public Character apply(Integer index) {
         return back.charAt(index);
     }
 

--- a/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/src/main/java/io/vavr/collection/LinearSeq.java
@@ -175,13 +175,6 @@ public interface LinearSeq<T> extends Seq<T> {
     @Override
     LinearSeq<T> intersperse(T element);
 
-    @Deprecated
-    @Override
-    default boolean isDefinedAt(Integer index) {
-        // we can't use length() because of infinite long sequences
-        return 0 <= index && drop(index).nonEmpty();
-    }
-
     @Override
     default int lastIndexOfSlice(Iterable<? extends T> that, int end) {
         Objects.requireNonNull(that, "that is null");

--- a/src/main/java/io/vavr/collection/List.java
+++ b/src/main/java/io/vavr/collection/List.java
@@ -912,6 +912,36 @@ public abstract class List<T> implements LinearSeq<T> {
     }
 
     @Override
+    public final Option<T> getOption(int index) {
+        if (isEmpty() || index < 0) {
+            return Option.none();
+        }
+        List<T> list = this;
+        for (int i = index - 1; i >= 0; i--) {
+            list = list.tail();
+            if (list.isEmpty()) {
+                return Option.none();
+            }
+        }
+        return Option.some(list.head());
+    }
+
+    @Override
+    public final T getOrElse(int index, T defaultValue) {
+        if (isEmpty() || index < 0) {
+            return defaultValue;
+        }
+        List<T> list = this;
+        for (int i = index - 1; i >= 0; i--) {
+            list = list.tail();
+            if (list.isEmpty()) {
+                return defaultValue;
+            }
+        }
+        return list.head();
+    }
+
+    @Override
     public final <C> Map<C, List<T>> groupBy(Function<? super T, ? extends C> classifier) {
         return Collections.groupBy(this, classifier, List::ofAll);
     }

--- a/src/main/java/io/vavr/collection/List.java
+++ b/src/main/java/io/vavr/collection/List.java
@@ -894,19 +894,10 @@ public abstract class List<T> implements LinearSeq<T> {
     }
 
     @Override
-    public final T get(int index) {
-        if (isEmpty()) {
-            throw new IndexOutOfBoundsException("get(" + index + ") on Nil");
-        }
-        if (index < 0) {
-            throw new IndexOutOfBoundsException("get(" + index + ")");
-        }
+    public final T apply(Integer index) {
         List<T> list = this;
         for (int i = index - 1; i >= 0; i--) {
             list = list.tail();
-            if (list.isEmpty()) {
-                throw new IndexOutOfBoundsException("get(" + index + ") on List of length " + (index - i));
-            }
         }
         return list.head();
     }

--- a/src/main/java/io/vavr/collection/List.java
+++ b/src/main/java/io/vavr/collection/List.java
@@ -912,36 +912,6 @@ public abstract class List<T> implements LinearSeq<T> {
     }
 
     @Override
-    public final Option<T> getOption(int index) {
-        if (isEmpty() || index < 0) {
-            return Option.none();
-        }
-        List<T> list = this;
-        for (int i = index - 1; i >= 0; i--) {
-            list = list.tail();
-            if (list.isEmpty()) {
-                return Option.none();
-            }
-        }
-        return Option.some(list.head());
-    }
-
-    @Override
-    public final T getOrElse(int index, T defaultValue) {
-        if (isEmpty() || index < 0) {
-            return defaultValue;
-        }
-        List<T> list = this;
-        for (int i = index - 1; i >= 0; i--) {
-            list = list.tail();
-            if (list.isEmpty()) {
-                return defaultValue;
-            }
-        }
-        return list.head();
-    }
-
-    @Override
     public final <C> Map<C, List<T>> groupBy(Function<? super T, ? extends C> classifier) {
         return Collections.groupBy(this, classifier, List::ofAll);
     }
@@ -983,6 +953,12 @@ public abstract class List<T> implements LinearSeq<T> {
 
     @Override
     public abstract int length();
+
+    @Deprecated
+    @Override
+    public boolean isDefinedAt(Integer index) {
+        return index >= 0 && index < length();
+    }
 
     @Override
     public final List<T> insert(int index, T element) {

--- a/src/main/java/io/vavr/collection/Queue.java
+++ b/src/main/java/io/vavr/collection/Queue.java
@@ -791,13 +791,7 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
-    public T get(int index) {
-        if (isEmpty()) {
-            throw new IndexOutOfBoundsException("get(" + index + ") on empty Queue");
-        }
-        if (index < 0) {
-            throw new IndexOutOfBoundsException("get(" + index + ")");
-        }
+    public T apply(Integer index) {
         final int length = front.length();
         if (index < length) {
             return front.get(index);

--- a/src/main/java/io/vavr/collection/Queue.java
+++ b/src/main/java/io/vavr/collection/Queue.java
@@ -814,6 +814,46 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
+    public Option<T> getOption(int index) {
+        if (isEmpty() || index < 0) {
+             return Option.none();
+        }
+        final int length = front.length();
+        if (index < length) {
+            return Option.some(front.get(index));
+        } else {
+            final int rearIndex = index - length;
+            final int rearLength = rear.length();
+            if (rearIndex < rearLength) {
+                final int reverseRearIndex = rearLength - rearIndex - 1;
+                return Option.some(rear.get(reverseRearIndex));
+            } else {
+                return Option.none();
+            }
+        }
+    }
+
+    @Override
+    public T getOrElse(int index, T defaultValue) {
+        if (isEmpty() || index < 0) {
+             return defaultValue;
+        }
+        final int length = front.length();
+        if (index < length) {
+            return front.get(index);
+        } else {
+            final int rearIndex = index - length;
+            final int rearLength = rear.length();
+            if (rearIndex < rearLength) {
+                final int reverseRearIndex = rearLength - rearIndex - 1;
+                return rear.get(reverseRearIndex);
+            } else {
+                return defaultValue;
+            }
+        }
+    }
+
+    @Override
     public <C> Map<C, Queue<T>> groupBy(Function<? super T, ? extends C> classifier) {
         return io.vavr.collection.Collections.groupBy(this, classifier, Queue::ofAll);
     }

--- a/src/main/java/io/vavr/collection/Queue.java
+++ b/src/main/java/io/vavr/collection/Queue.java
@@ -814,46 +814,6 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
-    public Option<T> getOption(int index) {
-        if (isEmpty() || index < 0) {
-             return Option.none();
-        }
-        final int length = front.length();
-        if (index < length) {
-            return Option.some(front.get(index));
-        } else {
-            final int rearIndex = index - length;
-            final int rearLength = rear.length();
-            if (rearIndex < rearLength) {
-                final int reverseRearIndex = rearLength - rearIndex - 1;
-                return Option.some(rear.get(reverseRearIndex));
-            } else {
-                return Option.none();
-            }
-        }
-    }
-
-    @Override
-    public T getOrElse(int index, T defaultValue) {
-        if (isEmpty() || index < 0) {
-             return defaultValue;
-        }
-        final int length = front.length();
-        if (index < length) {
-            return front.get(index);
-        } else {
-            final int rearIndex = index - length;
-            final int rearLength = rear.length();
-            if (rearIndex < rearLength) {
-                final int reverseRearIndex = rearLength - rearIndex - 1;
-                return rear.get(reverseRearIndex);
-            } else {
-                return defaultValue;
-            }
-        }
-    }
-
-    @Override
     public <C> Map<C, Queue<T>> groupBy(Function<? super T, ? extends C> classifier) {
         return io.vavr.collection.Collections.groupBy(this, classifier, Queue::ofAll);
     }
@@ -1002,6 +962,12 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     @Override
     public int length() {
         return front.length() + rear.length();
+    }
+
+    @Deprecated
+    @Override
+    public boolean isDefinedAt(Integer index) {
+        return index >= 0 && index < length();
     }
 
     @Override

--- a/src/main/java/io/vavr/collection/Seq.java
+++ b/src/main/java/io/vavr/collection/Seq.java
@@ -360,6 +360,26 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
     T get(int index);
 
     /**
+     * Returns an optional value, which may element at the specified index, or be empty
+     * if the index is invalid for this collection.
+     *
+     * @param index an index
+     * @return an optional value containing the element at the given index, or being empty if this is empty, index &lt; 0 or index &gt;= length()
+     */
+    default Option<T> getOption(int index) {
+        return Option.of(getOrElse(index, null));
+    }
+
+    /**
+     * Returns the element at the specified index, or the default value you give if
+     * the index is invalid for this collection.
+     *
+     * @param index an index
+     * @return the element at the given index or the default value if this is empty, index &lt; 0 or index &gt;= length()
+     */
+    T getOrElse(int index, T defaultValue);
+
+    /**
      * Returns the index of the first occurrence of the given element or -1 if this does not contain the given element.
      *
      * @param element an element

--- a/src/main/java/io/vavr/collection/Seq.java
+++ b/src/main/java/io/vavr/collection/Seq.java
@@ -367,7 +367,7 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
      * @return an optional value containing the element at the given index, or being empty if this is empty, index &lt; 0 or index &gt;= length()
      */
     default Option<T> getOption(int index) {
-        return Option.of(getOrElse(index, null));
+        return isDefinedAt(index) ? Option.some(get(index)) : Option.none();
     }
 
     /**
@@ -375,9 +375,12 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
      * the index is invalid for this collection.
      *
      * @param index an index
+     * @param defaultValue a default value to use if the index is invalid for this collection.
      * @return the element at the given index or the default value if this is empty, index &lt; 0 or index &gt;= length()
      */
-    T getOrElse(int index, T defaultValue);
+    default T getOrElse(int index, T defaultValue) {
+        return isDefinedAt(index) ? get(index) : defaultValue;
+    }
 
     /**
      * Returns the index of the first occurrence of the given element or -1 if this does not contain the given element.

--- a/src/main/java/io/vavr/collection/Seq.java
+++ b/src/main/java/io/vavr/collection/Seq.java
@@ -147,19 +147,16 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
     Seq<T> appendAll(Iterable<? extends T> elements);
 
     /**
-     * A {@code Seq} is a partial function which returns the element at the specified index by calling
-     * {@linkplain #get(int)}.
+     * A {@code Seq} is a partial function which returns the element at the specified index if the
+     * index is valid. It's up to the caller to make sure the index is valid (for instance through
+     * {@code isDefinedAt}).
+     * The behaviour is undefined if the index is out of bounds.
+     * It will throw but you may not depend on the type of the thrown exception.
      *
      * @param index an index
      * @return the element at the given index
-     * @throws IndexOutOfBoundsException if this is empty, index &lt; 0 or index &gt;= length()
-     * @deprecated Will be removed
      */
-    @Deprecated
-    @Override
-    default T apply(Integer index) {
-        return get(index);
-    }
+    T apply(Integer index);
     
     /**
      * Creates an <strong>immutable</strong> {@link java.util.List} view on top of this {@code Seq},
@@ -357,7 +354,12 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
      * @return the element at the given index
      * @throws IndexOutOfBoundsException if this is empty, index &lt; 0 or index &gt;= length()
      */
-    T get(int index);
+    default T get(int index) {
+        if (isDefinedAt(index)) {
+            return apply(index);
+        }
+        throw new IndexOutOfBoundsException("get(" + index + ")");
+    }
 
     /**
      * Returns an optional value, which may element at the specified index, or be empty
@@ -367,7 +369,7 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
      * @return an optional value containing the element at the given index, or being empty if this is empty, index &lt; 0 or index &gt;= length()
      */
     default Option<T> getOption(int index) {
-        return isDefinedAt(index) ? Option.some(get(index)) : Option.none();
+        return isDefinedAt(index) ? Option.some(apply(index)) : Option.none();
     }
 
     /**
@@ -379,7 +381,7 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
      * @return the element at the given index or the default value if this is empty, index &lt; 0 or index &gt;= length()
      */
     default T getOrElse(int index, T defaultValue) {
-        return isDefinedAt(index) ? get(index) : defaultValue;
+        return isDefinedAt(index) ? apply(index) : defaultValue;
     }
 
     /**

--- a/src/main/java/io/vavr/collection/Stream.java
+++ b/src/main/java/io/vavr/collection/Stream.java
@@ -1086,17 +1086,7 @@ public abstract class Stream<T> implements LinearSeq<T> {
 
     @Override
     public final T getOrElse(int index, T defaultValue) {
-        if (isEmpty() || index < 0) {
-            return defaultValue;
-        }
-        Stream<T> stream = this;
-        for (int i = index - 1; i >= 0; i--) {
-            stream = stream.tail();
-            if (stream.isEmpty()) {
-                return defaultValue;
-            }
-        }
-        return stream.head();
+        return getOption(index).getOrElse(defaultValue);
     }
 
     @Override
@@ -1227,6 +1217,13 @@ public abstract class Stream<T> implements LinearSeq<T> {
     @Override
     public final int length() {
         return foldLeft(0, (n, ignored) -> n + 1);
+    }
+
+    @Override
+    @Deprecated
+    public boolean isDefinedAt(Integer index) {
+        // we can't use length() because the stream might be infinite
+        return 0 <= index && drop(index).nonEmpty();
     }
 
     @Override

--- a/src/main/java/io/vavr/collection/Stream.java
+++ b/src/main/java/io/vavr/collection/Stream.java
@@ -1052,6 +1052,11 @@ public abstract class Stream<T> implements LinearSeq<T> {
     }
 
     @Override
+    public T apply(Integer index) {
+        return get(index);
+    }
+
+    @Override
     public final T get(int index) {
         if (isEmpty()) {
             throw new IndexOutOfBoundsException("get(" + index + ") on Nil");

--- a/src/main/java/io/vavr/collection/Stream.java
+++ b/src/main/java/io/vavr/collection/Stream.java
@@ -1070,6 +1070,36 @@ public abstract class Stream<T> implements LinearSeq<T> {
     }
 
     @Override
+    public final Option<T> getOption(int index) {
+        if (isEmpty() || index < 0) {
+            return Option.none();
+        }
+        Stream<T> stream = this;
+        for (int i = index - 1; i >= 0; i--) {
+            stream = stream.tail();
+            if (stream.isEmpty()) {
+                return Option.none();
+            }
+        }
+        return Option.some(stream.head());
+    }
+
+    @Override
+    public final T getOrElse(int index, T defaultValue) {
+        if (isEmpty() || index < 0) {
+            return defaultValue;
+        }
+        Stream<T> stream = this;
+        for (int i = index - 1; i >= 0; i--) {
+            stream = stream.tail();
+            if (stream.isEmpty()) {
+                return defaultValue;
+            }
+        }
+        return stream.head();
+    }
+
+    @Override
     public final <C> Map<C, Stream<T>> groupBy(Function<? super T, ? extends C> classifier) {
         return io.vavr.collection.Collections.groupBy(this, classifier, Stream::ofAll);
     }

--- a/src/main/java/io/vavr/collection/Vector.java
+++ b/src/main/java/io/vavr/collection/Vector.java
@@ -742,24 +742,6 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     private boolean isValid(int index) { return (index >= 0) && (index < length()); }
 
     @Override
-    public Option<T> getOption(int index) {
-        if (isValid(index)) {
-            return Option.some(trie.get(index));
-        } else {
-            return Option.none();
-        }
-    }
-
-    @Override
-    public T getOrElse(int index, T defaultValue) {
-        if (isValid(index)) {
-            return trie.get(index);
-        } else {
-            return defaultValue;
-        }
-    }
-
-    @Override
     public T head() {
         if (nonEmpty()) {
             return get(0);

--- a/src/main/java/io/vavr/collection/Vector.java
+++ b/src/main/java/io/vavr/collection/Vector.java
@@ -742,6 +742,24 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     private boolean isValid(int index) { return (index >= 0) && (index < length()); }
 
     @Override
+    public Option<T> getOption(int index) {
+        if (isValid(index)) {
+            return Option.some(trie.get(index));
+        } else {
+            return Option.none();
+        }
+    }
+
+    @Override
+    public T getOrElse(int index, T defaultValue) {
+        if (isValid(index)) {
+            return trie.get(index);
+        } else {
+            return defaultValue;
+        }
+    }
+
+    @Override
     public T head() {
         if (nonEmpty()) {
             return get(0);

--- a/src/main/java/io/vavr/collection/Vector.java
+++ b/src/main/java/io/vavr/collection/Vector.java
@@ -732,14 +732,9 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
-    public T get(int index) {
-        if (isValid(index)) {
-            return trie.get(index);
-        } else {
-            throw new IndexOutOfBoundsException("get(" + index + ")");
-        }
+    public T apply(Integer index) {
+        return trie.get(index);
     }
-    private boolean isValid(int index) { return (index >= 0) && (index < length()); }
 
     @Override
     public T head() {
@@ -978,7 +973,7 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
 
     @Override
     public Vector<T> removeAt(int index) {
-        if (isValid(index)) {
+        if (isDefinedAt(index)) {
             final Vector<T> begin = take(index);
             final Vector<T> end = drop(index + 1);
             return (begin.size() > end.size())
@@ -1258,7 +1253,7 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
 
     @Override
     public Vector<T> update(int index, T element) {
-        if (isValid(index)) {
+        if (isDefinedAt(index)) {
             return wrap(trie.update(index, element));
         } else {
             throw new IndexOutOfBoundsException("update(" + index + ")");

--- a/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -541,6 +541,80 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
         assertThat(of(1, 2, 3).get(2)).isEqualTo(3);
     }
 
+    // -- getOption
+
+    @Test
+    public void shouldReturnNoneWhenGetOptionWithNegativeIndexOnNil() {
+        assertThat(empty().getOption(-1)).isEqualTo(Option.none());
+    }
+
+    @Test
+    public void shouldReturnNoneWhenGetOptionWithNegativeIndexOnNonNil() {
+        assertThat(of(1).getOption(-1)).isEqualTo(Option.none());
+    }
+
+    @Test
+    public void shouldReturnNoneWhenGetOptionOnNil() {
+        assertThat(empty().getOption(0)).isEqualTo(Option.none());
+    }
+
+    @Test
+    public void shouldReturnNoneWhenGetOptionWithTooBigIndexOnNonNil() {
+        assertThat(of(1).getOption(1)).isEqualTo(Option.none());
+    }
+
+    @Test
+    public void shouldGetOptionFirstElement() {
+        assertThat(of(1, 2, 3).getOption(0)).isEqualTo(Option.of(1));
+    }
+
+    @Test
+    public void shouldGetOptionWithNullContentsReturnSomeNull() {
+        assertThat(of(new Integer(1), null).getOption(1)).isEqualTo(Option.some(null));
+    }
+
+    @Test
+    public void shouldGetOptionLastElement() {
+        assertThat(of(1, 2, 3).getOption(2)).isEqualTo(Option.of(3));
+    }
+
+    // -- getOrElse
+
+    @Test
+    public void shouldReturnDefaultWhenGetOrElseWithNegativeIndexOnNil() {
+        assertThat(empty().getOrElse(-1, 6)).isEqualTo(6);
+    }
+
+    @Test
+    public void shouldReturnDefaultWhenGetOrElseWithNegativeIndexOnNonNil() {
+        assertThat(of(1).getOrElse(-1, 5)).isEqualTo(5);
+    }
+
+    @Test
+    public void shouldReturnDefaultWhenGetOrElseOnNil() {
+        assertThat(empty().getOrElse(0, 4)).isEqualTo(4);
+    }
+
+    @Test
+    public void shouldReturnDefaultWhenGetOrElseWithTooBigIndexOnNonNil() {
+        assertThat(of(1).getOrElse(1, 3)).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldGetOrElseFirstElement() {
+        assertThat(of(1, 2, 3).getOrElse(0, 4)).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldGetOrElseWithNullContentsReturnNull() {
+        assertThat(of(new Integer(1), null).getOrElse(1, 4)).isEqualTo(null);
+    }
+
+    @Test
+    public void shouldGetOrElseLastElement() {
+        assertThat(of(1, 2, 3).getOrElse(2, 5)).isEqualTo(3);
+    }
+
     // -- indexOf
 
     @Test

--- a/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -2401,6 +2401,70 @@ public class CharSeqTest {
         assertThat(CharSeq.of('1', '2', '3').get(2)).isEqualTo('3');
     }
 
+    // -- getOption
+
+    @Test
+    public void shouldReturnNoneWhenGetOptionWithNegativeIndexOnNil() {
+        assertThat(CharSeq.empty().getOption(-1)).isEqualTo(Option.none());
+    }
+
+    @Test
+    public void shouldReturnNoneWhenGetOptionWithNegativeIndexOnNonNil() {
+        assertThat(CharSeq.of('1').getOption(-1)).isEqualTo(Option.none());
+    }
+
+    @Test
+    public void shouldReturnNoneWhenGetOptionOnNil() {
+        assertThat(CharSeq.empty().getOption(0)).isEqualTo(Option.none());
+    }
+
+    @Test
+    public void shouldReturnNoneWhenGetOptionWithTooBigIndexOnNonNil() {
+        assertThat(CharSeq.of('1').getOption(1)).isEqualTo(Option.none());
+    }
+
+    @Test
+    public void shouldGetOptionFirstElement() {
+        assertThat(CharSeq.of('1', '2', '3').getOption(0)).isEqualTo(Option.of('1'));
+    }
+
+    @Test
+    public void shouldGetOptionLastElement() {
+        assertThat(CharSeq.of('1', '2', '3').getOption(2)).isEqualTo(Option.of('3'));
+    }
+
+    // -- getOrElse
+
+    @Test
+    public void shouldReturnDefaultWhenGetOrElseWithNegativeIndexOnNil() {
+        assertThat(CharSeq.empty().getOrElse(-1, 'x')).isEqualTo('x');
+    }
+
+    @Test
+    public void shouldReturnDefaultWhenGetOrElseWithNegativeIndexOnNonNil() {
+        assertThat(CharSeq.of('1').getOrElse(-1, 'y')).isEqualTo('y');
+    }
+
+    @Test
+    public void shouldReturnDefaultWhenGetOrElseOnNil() {
+        assertThat(CharSeq.empty().getOrElse(0, 'z')).isEqualTo('z');
+    }
+
+    @Test
+    public void shouldReturnDefaultWhenGetOrElseWithTooBigIndexOnNonNil() {
+        assertThat(CharSeq.of('1').getOrElse(1, 'z')).isEqualTo('z');
+    }
+
+    @Test
+    public void shouldGetOrElseFirstElement() {
+        assertThat(CharSeq.of('1', '2', '3').getOrElse(0, 'x')).isEqualTo('1');
+    }
+
+    @Test
+    public void shouldGetOrElseLastElement() {
+        assertThat(CharSeq.of('1', '2', '3').getOrElse(2, 'x')).isEqualTo('3');
+    }
+
     // -- grouped
 
     @Test


### PR DESCRIPTION
i believe the PR is correct, however I am annoyed by the code duplication between get, getOrElse and getOption, especially for List, Stream and Queue.

However I think it's unavoidable if we don't want to create "unnecessary" intermediary objects at runtime, which would enable code reuse (or worse, catching exceptions as part of normal operation). Since you suggested getOrElse especially for performance, I'm guessing you'd rather not to that... Unless if we did that only for List, Stream and Queue, which have less trivial get() implementations.. and List and Stream are not very performance oriented.