### PR TITLE
Fix for Gradle deprecation warning on `testCompile` usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    testCompile "junit:junit:$junitVersion"
-    testCompile "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
 jacocoTestReport {


### PR DESCRIPTION
Expected behavior: compilation goes without Gradle warnings

Observed behavior: several Gradle deprecation warnings, including:
    ./gradlew check --warning-mode all

    The testCompile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the testImplementation configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.3/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations

Fix: replacing `testCompile` with `testImplementation` in `build.gradle`.

Result: the Gradle warning observed before is no longer displayed (but there're still another one, unrelated to this issue).