### PR TITLE
Wrong function name in Either.filterOrElse JavaDoc

### DIFF
--- a/src/main/java/io/vavr/control/Either.java
+++ b/src/main/java/io/vavr/control/Either.java
@@ -657,7 +657,7 @@ public abstract class Either<L, R> implements Iterable<R>, io.vavr.Value<R>, Ser
      * Filters this right-biased {@code Either} by testing a predicate.
      * If the {@code Either} is a {@code Right} and the predicate doesn't match, the
      * {@code Either} will be turned into a {@code Left} with contents computed by applying
-     * the filterVal function to the {@code Either} value.
+     * the zero function to the {@code Either} value.
      *
      * <pre>{@code
      * // = Left("bad: a")


### PR DESCRIPTION
Small fix on Either.filterOrElse JavaDoc: it was referring to function filterVal while its name is zero