### PR TITLE
Add `prepend` for TupleN

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -2169,6 +2169,19 @@ def generateMainClasses(): Unit = {
 
             ${(i < N).gen(xs"""
               /$javadoc
+               * Prepend a value to this tuple.
+               *
+               * @param <T0> type of the value to prepend
+               * @param t0 the value to prepend
+               * @return a new Tuple with the value prepended
+               */
+              public <T0> Tuple${i+1}<${(0 to i).gen(j => s"T$j")(", ")}> prepend(T0 t0) {
+                  return ${im.getType("io.vavr.Tuple")}.of(t0${(i > 0).gen(", ")}${(1 to i).gen(k => s"_$k")(", ")});
+              }
+            """)}
+
+            ${(i < N).gen(xs"""
+              /$javadoc
                * Append a value to this tuple.
                *
                * @param <T${i+1}> type of the value to append

--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -3654,6 +3654,15 @@ def generateTestClasses(): Unit = {
 
               ${(i < N).gen(xs"""
                 @$test
+                public void shouldPrependValue() {
+                    final Tuple${i+1}<${(1 to i+1).gen(j => s"Integer")(", ")}> actual = ${ if (i == 0) "Tuple0.instance()" else s"Tuple.of(${(1 to i).gen(j => xs"$j")(", ")})"}.prepend(${i+1});
+                    final Tuple${i+1}<${(1 to i+1).gen(j => s"Integer")(", ")}> expected = Tuple.of(${i+1}${(i > 0).gen(", ")}${(1 to i).gen(j => xs"$j")(", ")});
+                    assertThat(actual).isEqualTo(expected);
+                }
+              """)}
+
+              ${(i < N).gen(xs"""
+                @$test
                 public void shouldAppendValue() {
                     final Tuple${i+1}<${(1 to i+1).gen(j => s"Integer")(", ")}> actual = ${ if (i == 0) "Tuple0.instance()" else s"Tuple.of(${(1 to i).gen(j => xs"$j")(", ")})"}.append(${i+1});
                     final Tuple${i+1}<${(1 to i+1).gen(j => s"Integer")(", ")}> expected = Tuple.of(${(1 to i+1).gen(j => xs"$j")(", ")});

--- a/src-gen/main/java/io/vavr/Tuple0.java
+++ b/src-gen/main/java/io/vavr/Tuple0.java
@@ -88,6 +88,17 @@ public final class Tuple0 implements Tuple, Serializable {
     }
 
     /**
+     * Prepend a value to this tuple.
+     *
+     * @param <T0> type of the value to prepend
+     * @param t0 the value to prepend
+     * @return a new Tuple with the value prepended
+     */
+    public <T0> Tuple1<T0> prepend(T0 t0) {
+        return Tuple.of(t0);
+    }
+
+    /**
      * Append a value to this tuple.
      *
      * @param <T1> type of the value to append

--- a/src-gen/main/java/io/vavr/Tuple1.java
+++ b/src-gen/main/java/io/vavr/Tuple1.java
@@ -143,6 +143,17 @@ public final class Tuple1<T1> implements Tuple, Serializable {
     }
 
     /**
+     * Prepend a value to this tuple.
+     *
+     * @param <T0> type of the value to prepend
+     * @param t0 the value to prepend
+     * @return a new Tuple with the value prepended
+     */
+    public <T0> Tuple2<T0, T1> prepend(T0 t0) {
+        return Tuple.of(t0, _1);
+    }
+
+    /**
      * Append a value to this tuple.
      *
      * @param <T2> type of the value to append

--- a/src-gen/main/java/io/vavr/Tuple2.java
+++ b/src-gen/main/java/io/vavr/Tuple2.java
@@ -255,6 +255,17 @@ public final class Tuple2<T1, T2> implements Tuple, Serializable {
     }
 
     /**
+     * Prepend a value to this tuple.
+     *
+     * @param <T0> type of the value to prepend
+     * @param t0 the value to prepend
+     * @return a new Tuple with the value prepended
+     */
+    public <T0> Tuple3<T0, T1, T2> prepend(T0 t0) {
+        return Tuple.of(t0, _1, _2);
+    }
+
+    /**
      * Append a value to this tuple.
      *
      * @param <T3> type of the value to append

--- a/src-gen/main/java/io/vavr/Tuple3.java
+++ b/src-gen/main/java/io/vavr/Tuple3.java
@@ -295,6 +295,17 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Serializable {
     }
 
     /**
+     * Prepend a value to this tuple.
+     *
+     * @param <T0> type of the value to prepend
+     * @param t0 the value to prepend
+     * @return a new Tuple with the value prepended
+     */
+    public <T0> Tuple4<T0, T1, T2, T3> prepend(T0 t0) {
+        return Tuple.of(t0, _1, _2, _3);
+    }
+
+    /**
      * Append a value to this tuple.
      *
      * @param <T4> type of the value to append

--- a/src-gen/main/java/io/vavr/Tuple4.java
+++ b/src-gen/main/java/io/vavr/Tuple4.java
@@ -358,6 +358,17 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Serializable {
     }
 
     /**
+     * Prepend a value to this tuple.
+     *
+     * @param <T0> type of the value to prepend
+     * @param t0 the value to prepend
+     * @return a new Tuple with the value prepended
+     */
+    public <T0> Tuple5<T0, T1, T2, T3, T4> prepend(T0 t0) {
+        return Tuple.of(t0, _1, _2, _3, _4);
+    }
+
+    /**
      * Append a value to this tuple.
      *
      * @param <T5> type of the value to append

--- a/src-gen/main/java/io/vavr/Tuple5.java
+++ b/src-gen/main/java/io/vavr/Tuple5.java
@@ -421,6 +421,17 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Serializable {
     }
 
     /**
+     * Prepend a value to this tuple.
+     *
+     * @param <T0> type of the value to prepend
+     * @param t0 the value to prepend
+     * @return a new Tuple with the value prepended
+     */
+    public <T0> Tuple6<T0, T1, T2, T3, T4, T5> prepend(T0 t0) {
+        return Tuple.of(t0, _1, _2, _3, _4, _5);
+    }
+
+    /**
      * Append a value to this tuple.
      *
      * @param <T6> type of the value to append

--- a/src-gen/main/java/io/vavr/Tuple6.java
+++ b/src-gen/main/java/io/vavr/Tuple6.java
@@ -484,6 +484,17 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Serializable
     }
 
     /**
+     * Prepend a value to this tuple.
+     *
+     * @param <T0> type of the value to prepend
+     * @param t0 the value to prepend
+     * @return a new Tuple with the value prepended
+     */
+    public <T0> Tuple7<T0, T1, T2, T3, T4, T5, T6> prepend(T0 t0) {
+        return Tuple.of(t0, _1, _2, _3, _4, _5, _6);
+    }
+
+    /**
      * Append a value to this tuple.
      *
      * @param <T7> type of the value to append

--- a/src-gen/main/java/io/vavr/Tuple7.java
+++ b/src-gen/main/java/io/vavr/Tuple7.java
@@ -547,6 +547,17 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Serializ
     }
 
     /**
+     * Prepend a value to this tuple.
+     *
+     * @param <T0> type of the value to prepend
+     * @param t0 the value to prepend
+     * @return a new Tuple with the value prepended
+     */
+    public <T0> Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> prepend(T0 t0) {
+        return Tuple.of(t0, _1, _2, _3, _4, _5, _6, _7);
+    }
+
+    /**
      * Append a value to this tuple.
      *
      * @param <T8> type of the value to append

--- a/src-gen/test/java/io/vavr/Tuple0Test.java
+++ b/src-gen/test/java/io/vavr/Tuple0Test.java
@@ -58,6 +58,13 @@ public class Tuple0Test {
     }
 
     @Test
+    public void shouldPrependValue() {
+        final Tuple1<Integer> actual = Tuple0.instance().prepend(1);
+        final Tuple1<Integer> expected = Tuple.of(1);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldAppendValue() {
         final Tuple1<Integer> actual = Tuple0.instance().append(1);
         final Tuple1<Integer> expected = Tuple.of(1);

--- a/src-gen/test/java/io/vavr/Tuple1Test.java
+++ b/src-gen/test/java/io/vavr/Tuple1Test.java
@@ -99,6 +99,13 @@ public class Tuple1Test {
     }
 
     @Test
+    public void shouldPrependValue() {
+        final Tuple2<Integer, Integer> actual = Tuple.of(1).prepend(2);
+        final Tuple2<Integer, Integer> expected = Tuple.of(2, 1);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldAppendValue() {
         final Tuple2<Integer, Integer> actual = Tuple.of(1).append(2);
         final Tuple2<Integer, Integer> expected = Tuple.of(1, 2);

--- a/src-gen/test/java/io/vavr/Tuple2Test.java
+++ b/src-gen/test/java/io/vavr/Tuple2Test.java
@@ -150,6 +150,13 @@ public class Tuple2Test {
     }
 
     @Test
+    public void shouldPrependValue() {
+        final Tuple3<Integer, Integer, Integer> actual = Tuple.of(1, 2).prepend(3);
+        final Tuple3<Integer, Integer, Integer> expected = Tuple.of(3, 1, 2);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldAppendValue() {
         final Tuple3<Integer, Integer, Integer> actual = Tuple.of(1, 2).append(3);
         final Tuple3<Integer, Integer, Integer> expected = Tuple.of(1, 2, 3);

--- a/src-gen/test/java/io/vavr/Tuple3Test.java
+++ b/src-gen/test/java/io/vavr/Tuple3Test.java
@@ -164,6 +164,13 @@ public class Tuple3Test {
     }
 
     @Test
+    public void shouldPrependValue() {
+        final Tuple4<Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3).prepend(4);
+        final Tuple4<Integer, Integer, Integer, Integer> expected = Tuple.of(4, 1, 2, 3);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldAppendValue() {
         final Tuple4<Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3).append(4);
         final Tuple4<Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4);

--- a/src-gen/test/java/io/vavr/Tuple4Test.java
+++ b/src-gen/test/java/io/vavr/Tuple4Test.java
@@ -196,6 +196,13 @@ public class Tuple4Test {
     }
 
     @Test
+    public void shouldPrependValue() {
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4).prepend(5);
+        final Tuple5<Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(5, 1, 2, 3, 4);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldAppendValue() {
         final Tuple5<Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4).append(5);
         final Tuple5<Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5);

--- a/src-gen/test/java/io/vavr/Tuple5Test.java
+++ b/src-gen/test/java/io/vavr/Tuple5Test.java
@@ -232,6 +232,13 @@ public class Tuple5Test {
     }
 
     @Test
+    public void shouldPrependValue() {
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5).prepend(6);
+        final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(6, 1, 2, 3, 4, 5);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldAppendValue() {
         final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5).append(6);
         final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6);

--- a/src-gen/test/java/io/vavr/Tuple6Test.java
+++ b/src-gen/test/java/io/vavr/Tuple6Test.java
@@ -272,6 +272,13 @@ public class Tuple6Test {
     }
 
     @Test
+    public void shouldPrependValue() {
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5, 6).prepend(7);
+        final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(7, 1, 2, 3, 4, 5, 6);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldAppendValue() {
         final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5, 6).append(7);
         final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7);

--- a/src-gen/test/java/io/vavr/Tuple7Test.java
+++ b/src-gen/test/java/io/vavr/Tuple7Test.java
@@ -316,6 +316,13 @@ public class Tuple7Test {
     }
 
     @Test
+    public void shouldPrependValue() {
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5, 6, 7).prepend(8);
+        final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(8, 1, 2, 3, 4, 5, 6, 7);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     public void shouldAppendValue() {
         final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> actual = Tuple.of(1, 2, 3, 4, 5, 6, 7).append(8);
         final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> expected = Tuple.of(1, 2, 3, 4, 5, 6, 7, 8);


### PR DESCRIPTION
Added the `prepend` in TupleN template.

After we can use:
```
<T> Tuple0.prepend(T t0) = Tuple1<T>
<T> Tuple2<A, B>.prepend(T t0) = Tuple3<T, A, B>
```
