### PR TITLE
Rename type parameter T0 for `prepend` in TupleN

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -2171,12 +2171,12 @@ def generateMainClasses(): Unit = {
               /$javadoc
                * Prepend a value to this tuple.
                *
-               * @param <T0> type of the value to prepend
-               * @param t0 the value to prepend
+               * @param <T> type of the value to prepend
+               * @param t the value to prepend
                * @return a new Tuple with the value prepended
                */
-              public <T0> Tuple${i+1}<${(0 to i).gen(j => s"T$j")(", ")}> prepend(T0 t0) {
-                  return ${im.getType("io.vavr.Tuple")}.of(t0${(i > 0).gen(", ")}${(1 to i).gen(k => s"_$k")(", ")});
+              public <T> Tuple${i+1}<T${(i > 0).gen(", ")}${(1 to i).gen(j => s"T$j")(", ")}> prepend(T t) {
+                  return ${im.getType("io.vavr.Tuple")}.of(t${(i > 0).gen(", ")}${(1 to i).gen(k => s"_$k")(", ")});
               }
             """)}
 

--- a/src-gen/main/java/io/vavr/Tuple0.java
+++ b/src-gen/main/java/io/vavr/Tuple0.java
@@ -90,12 +90,12 @@ public final class Tuple0 implements Tuple, Serializable {
     /**
      * Prepend a value to this tuple.
      *
-     * @param <T0> type of the value to prepend
-     * @param t0 the value to prepend
+     * @param <T> type of the value to prepend
+     * @param t the value to prepend
      * @return a new Tuple with the value prepended
      */
-    public <T0> Tuple1<T0> prepend(T0 t0) {
-        return Tuple.of(t0);
+    public <T> Tuple1<T> prepend(T t) {
+        return Tuple.of(t);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple1.java
+++ b/src-gen/main/java/io/vavr/Tuple1.java
@@ -145,12 +145,12 @@ public final class Tuple1<T1> implements Tuple, Serializable {
     /**
      * Prepend a value to this tuple.
      *
-     * @param <T0> type of the value to prepend
-     * @param t0 the value to prepend
+     * @param <T> type of the value to prepend
+     * @param t the value to prepend
      * @return a new Tuple with the value prepended
      */
-    public <T0> Tuple2<T0, T1> prepend(T0 t0) {
-        return Tuple.of(t0, _1);
+    public <T> Tuple2<T, T1> prepend(T t) {
+        return Tuple.of(t, _1);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple2.java
+++ b/src-gen/main/java/io/vavr/Tuple2.java
@@ -257,12 +257,12 @@ public final class Tuple2<T1, T2> implements Tuple, Serializable {
     /**
      * Prepend a value to this tuple.
      *
-     * @param <T0> type of the value to prepend
-     * @param t0 the value to prepend
+     * @param <T> type of the value to prepend
+     * @param t the value to prepend
      * @return a new Tuple with the value prepended
      */
-    public <T0> Tuple3<T0, T1, T2> prepend(T0 t0) {
-        return Tuple.of(t0, _1, _2);
+    public <T> Tuple3<T, T1, T2> prepend(T t) {
+        return Tuple.of(t, _1, _2);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple3.java
+++ b/src-gen/main/java/io/vavr/Tuple3.java
@@ -297,12 +297,12 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Serializable {
     /**
      * Prepend a value to this tuple.
      *
-     * @param <T0> type of the value to prepend
-     * @param t0 the value to prepend
+     * @param <T> type of the value to prepend
+     * @param t the value to prepend
      * @return a new Tuple with the value prepended
      */
-    public <T0> Tuple4<T0, T1, T2, T3> prepend(T0 t0) {
-        return Tuple.of(t0, _1, _2, _3);
+    public <T> Tuple4<T, T1, T2, T3> prepend(T t) {
+        return Tuple.of(t, _1, _2, _3);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple4.java
+++ b/src-gen/main/java/io/vavr/Tuple4.java
@@ -360,12 +360,12 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Serializable {
     /**
      * Prepend a value to this tuple.
      *
-     * @param <T0> type of the value to prepend
-     * @param t0 the value to prepend
+     * @param <T> type of the value to prepend
+     * @param t the value to prepend
      * @return a new Tuple with the value prepended
      */
-    public <T0> Tuple5<T0, T1, T2, T3, T4> prepend(T0 t0) {
-        return Tuple.of(t0, _1, _2, _3, _4);
+    public <T> Tuple5<T, T1, T2, T3, T4> prepend(T t) {
+        return Tuple.of(t, _1, _2, _3, _4);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple5.java
+++ b/src-gen/main/java/io/vavr/Tuple5.java
@@ -423,12 +423,12 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Serializable {
     /**
      * Prepend a value to this tuple.
      *
-     * @param <T0> type of the value to prepend
-     * @param t0 the value to prepend
+     * @param <T> type of the value to prepend
+     * @param t the value to prepend
      * @return a new Tuple with the value prepended
      */
-    public <T0> Tuple6<T0, T1, T2, T3, T4, T5> prepend(T0 t0) {
-        return Tuple.of(t0, _1, _2, _3, _4, _5);
+    public <T> Tuple6<T, T1, T2, T3, T4, T5> prepend(T t) {
+        return Tuple.of(t, _1, _2, _3, _4, _5);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple6.java
+++ b/src-gen/main/java/io/vavr/Tuple6.java
@@ -486,12 +486,12 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Serializable
     /**
      * Prepend a value to this tuple.
      *
-     * @param <T0> type of the value to prepend
-     * @param t0 the value to prepend
+     * @param <T> type of the value to prepend
+     * @param t the value to prepend
      * @return a new Tuple with the value prepended
      */
-    public <T0> Tuple7<T0, T1, T2, T3, T4, T5, T6> prepend(T0 t0) {
-        return Tuple.of(t0, _1, _2, _3, _4, _5, _6);
+    public <T> Tuple7<T, T1, T2, T3, T4, T5, T6> prepend(T t) {
+        return Tuple.of(t, _1, _2, _3, _4, _5, _6);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple7.java
+++ b/src-gen/main/java/io/vavr/Tuple7.java
@@ -549,12 +549,12 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Serializ
     /**
      * Prepend a value to this tuple.
      *
-     * @param <T0> type of the value to prepend
-     * @param t0 the value to prepend
+     * @param <T> type of the value to prepend
+     * @param t the value to prepend
      * @return a new Tuple with the value prepended
      */
-    public <T0> Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> prepend(T0 t0) {
-        return Tuple.of(t0, _1, _2, _3, _4, _5, _6, _7);
+    public <T> Tuple8<T, T1, T2, T3, T4, T5, T6, T7> prepend(T t) {
+        return Tuple.of(t, _1, _2, _3, _4, _5, _6, _7);
     }
 
     /**


### PR DESCRIPTION
Following the [previous discussion](https://github.com/vavr-io/vavr/pull/2627#pullrequestreview-565344945), we thought that the type parameter `T0` should be renamed to `T`.

```
<T> Tuple0.prepend(T t): Tuple1<T>
<T> Tuple2<T1, T2>.prepend(T t): Tuple3<T, T1, T2>
```