### PR TITLE
Rename type parameter Tn for `append` in TupleN

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -2184,12 +2184,12 @@ def generateMainClasses(): Unit = {
               /$javadoc
                * Append a value to this tuple.
                *
-               * @param <T${i+1}> type of the value to append
-               * @param t${i+1} the value to append
+               * @param <T> type of the value to append
+               * @param t the value to append
                * @return a new Tuple with the value appended
                */
-              public <T${i+1}> Tuple${i+1}<${(1 to i+1).gen(j => s"T$j")(", ")}> append(T${i+1} t${i+1}) {
-                  return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}${(i > 0).gen(", ")}t${i+1});
+              public <T> Tuple${i+1}<${(1 to i).gen(j => s"T$j")(", ")}${(i > 0).gen(", ")}T> append(T t) {
+                  return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(", ")}${(i > 0).gen(", ")}t);
               }
             """)}
 

--- a/src-gen/main/java/io/vavr/Tuple0.java
+++ b/src-gen/main/java/io/vavr/Tuple0.java
@@ -101,12 +101,12 @@ public final class Tuple0 implements Tuple, Serializable {
     /**
      * Append a value to this tuple.
      *
-     * @param <T1> type of the value to append
-     * @param t1 the value to append
+     * @param <T> type of the value to append
+     * @param t the value to append
      * @return a new Tuple with the value appended
      */
-    public <T1> Tuple1<T1> append(T1 t1) {
-        return Tuple.of(t1);
+    public <T> Tuple1<T> append(T t) {
+        return Tuple.of(t);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple1.java
+++ b/src-gen/main/java/io/vavr/Tuple1.java
@@ -156,12 +156,12 @@ public final class Tuple1<T1> implements Tuple, Serializable {
     /**
      * Append a value to this tuple.
      *
-     * @param <T2> type of the value to append
-     * @param t2 the value to append
+     * @param <T> type of the value to append
+     * @param t the value to append
      * @return a new Tuple with the value appended
      */
-    public <T2> Tuple2<T1, T2> append(T2 t2) {
-        return Tuple.of(_1, t2);
+    public <T> Tuple2<T1, T> append(T t) {
+        return Tuple.of(_1, t);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple2.java
+++ b/src-gen/main/java/io/vavr/Tuple2.java
@@ -268,12 +268,12 @@ public final class Tuple2<T1, T2> implements Tuple, Serializable {
     /**
      * Append a value to this tuple.
      *
-     * @param <T3> type of the value to append
-     * @param t3 the value to append
+     * @param <T> type of the value to append
+     * @param t the value to append
      * @return a new Tuple with the value appended
      */
-    public <T3> Tuple3<T1, T2, T3> append(T3 t3) {
-        return Tuple.of(_1, _2, t3);
+    public <T> Tuple3<T1, T2, T> append(T t) {
+        return Tuple.of(_1, _2, t);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple3.java
+++ b/src-gen/main/java/io/vavr/Tuple3.java
@@ -308,12 +308,12 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Serializable {
     /**
      * Append a value to this tuple.
      *
-     * @param <T4> type of the value to append
-     * @param t4 the value to append
+     * @param <T> type of the value to append
+     * @param t the value to append
      * @return a new Tuple with the value appended
      */
-    public <T4> Tuple4<T1, T2, T3, T4> append(T4 t4) {
-        return Tuple.of(_1, _2, _3, t4);
+    public <T> Tuple4<T1, T2, T3, T> append(T t) {
+        return Tuple.of(_1, _2, _3, t);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple4.java
+++ b/src-gen/main/java/io/vavr/Tuple4.java
@@ -371,12 +371,12 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Serializable {
     /**
      * Append a value to this tuple.
      *
-     * @param <T5> type of the value to append
-     * @param t5 the value to append
+     * @param <T> type of the value to append
+     * @param t the value to append
      * @return a new Tuple with the value appended
      */
-    public <T5> Tuple5<T1, T2, T3, T4, T5> append(T5 t5) {
-        return Tuple.of(_1, _2, _3, _4, t5);
+    public <T> Tuple5<T1, T2, T3, T4, T> append(T t) {
+        return Tuple.of(_1, _2, _3, _4, t);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple5.java
+++ b/src-gen/main/java/io/vavr/Tuple5.java
@@ -434,12 +434,12 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Serializable {
     /**
      * Append a value to this tuple.
      *
-     * @param <T6> type of the value to append
-     * @param t6 the value to append
+     * @param <T> type of the value to append
+     * @param t the value to append
      * @return a new Tuple with the value appended
      */
-    public <T6> Tuple6<T1, T2, T3, T4, T5, T6> append(T6 t6) {
-        return Tuple.of(_1, _2, _3, _4, _5, t6);
+    public <T> Tuple6<T1, T2, T3, T4, T5, T> append(T t) {
+        return Tuple.of(_1, _2, _3, _4, _5, t);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple6.java
+++ b/src-gen/main/java/io/vavr/Tuple6.java
@@ -497,12 +497,12 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Serializable
     /**
      * Append a value to this tuple.
      *
-     * @param <T7> type of the value to append
-     * @param t7 the value to append
+     * @param <T> type of the value to append
+     * @param t the value to append
      * @return a new Tuple with the value appended
      */
-    public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> append(T7 t7) {
-        return Tuple.of(_1, _2, _3, _4, _5, _6, t7);
+    public <T> Tuple7<T1, T2, T3, T4, T5, T6, T> append(T t) {
+        return Tuple.of(_1, _2, _3, _4, _5, _6, t);
     }
 
     /**

--- a/src-gen/main/java/io/vavr/Tuple7.java
+++ b/src-gen/main/java/io/vavr/Tuple7.java
@@ -560,12 +560,12 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Serializ
     /**
      * Append a value to this tuple.
      *
-     * @param <T8> type of the value to append
-     * @param t8 the value to append
+     * @param <T> type of the value to append
+     * @param t the value to append
      * @return a new Tuple with the value appended
      */
-    public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> append(T8 t8) {
-        return Tuple.of(_1, _2, _3, _4, _5, _6, _7, t8);
+    public <T> Tuple8<T1, T2, T3, T4, T5, T6, T7, T> append(T t) {
+        return Tuple.of(_1, _2, _3, _4, _5, _6, _7, t);
     }
 
     /**


### PR DESCRIPTION
Following the [previous discussion](https://github.com/vavr-io/vavr/pull/2627#pullrequestreview-565344945), we thought that the type parameter `Tn` should be renamed to `T`.

```
<T> Tuple0.append(T t): Tuple1<T>
<T> Tuple2<T1, T2>.append(T t): Tuple3<T1, T2, T>
```