### PR TITLE
more robust slideby classifier function handling

### DIFF
--- a/src/main/java/io/vavr/collection/Iterator.java
+++ b/src/main/java/io/vavr/collection/Iterator.java
@@ -1909,6 +1909,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
                     if (next == null && source.hasNext()) {
                         final Object key = classifier.apply(source.touch());
                         final java.util.List<T> acc = new ArrayList<>();
+                        acc.add(source.next());
                         while (source.hasNext() && key.equals(classifier.apply(source.touch()))) {
                             acc.add(source.next());
                         }

--- a/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -26,6 +26,7 @@ import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
@@ -1917,6 +1918,17 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
     @Test
     public void shouldSlideNilByClassifier() {
         assertThat(empty().slideBy(Function.identity())).isEmpty();
+    }
+
+    @Test(timeout=1000)
+    public void shouldTerminateSlideByClassifier() {
+        AtomicInteger ai = new AtomicInteger(0);
+        List<List<String>> expected = List.of(List.of("a", "-"), List.of( "-"), List.of("d") );
+        List<List<String>> actual = List.of("a", "-", "-", "d")
+                .slideBy(x -> x.equals("-") ? ai.getAndIncrement() : ai.get())
+                .toList();
+        assertThat(actual).containsAll(expected);
+        assertThat(expected).containsAll(actual);
     }
 
     @Test


### PR DESCRIPTION
When the classifier function is pure everything works fine, but with
state, `slideBy` might end up in an infinite loop. The reason: `slideBy`
calls the classifier two times on the same item. If the second call
returns a different value, `slideBy` will not advance anymore and
iterate indefinitely on the same item.