### PR TITLE
Fix Array#update(int, T) complexity

### DIFF
--- a/src/main/java/io/vavr/collection/package-info.java
+++ b/src/main/java/io/vavr/collection/package-info.java
@@ -16,7 +16,7 @@
  * </tr>
  * </thead>
  * <tbody>
- * <tr><td>{@linkplain io.vavr.collection.Array}</td><td><small>const</small></td><td><small>linear</small></td><td><small>const</small></td><td><small>const</small></td><td><small>linear</small></td><td><small>linear</small></td></tr>
+ * <tr><td>{@linkplain io.vavr.collection.Array}</td><td><small>const</small></td><td><small>linear</small></td><td><small>const</small></td><td><small>linear</small></td><td><small>linear</small></td><td><small>linear</small></td></tr>
  * <tr><td>{@linkplain io.vavr.collection.CharSeq}</td><td><small>const</small></td><td><small>linear</small></td><td><small>const</small></td><td><small>linear</small></td><td><small>linear</small></td><td><small>linear</small></td></tr>
  * <tr><td><em>{@linkplain io.vavr.collection.Iterator}</em></td><td><small>const</small></td><td><small>const</small></td><td>&mdash;</td><td>&mdash;</td><td>&mdash;</td><td>&mdash;</td></tr>
  * <tr><td>{@linkplain io.vavr.collection.List}</td><td><small>const</small></td><td><small>const</small></td><td><small>linear</small></td><td><small>linear</small></td><td><small>const</small></td><td><small>linear</small></td></tr>


### PR DESCRIPTION
io.vavr.collection.Array#update(int, T) [contains](https://github.com/vavr-io/vavr/blob/2fe989583fee00842e3fc4a5f806b7f2d99a6eba/src/main/java/io/vavr/collection/Array.java#L1507) java.util.Arrays#copyOf(T[], int) call. So it can't be of constant complexity.