### PR TITLE
Add peekError on Validation

### DIFF
--- a/src/main/java/io/vavr/control/Validation.java
+++ b/src/main/java/io/vavr/control/Validation.java
@@ -807,6 +807,15 @@ public abstract class Validation<E, T> implements Iterable<T>, Value<T>, Seriali
         return this;
     }
 
+    public final Validation<E, T> peekError(Consumer<? super E> action) {
+        Objects.requireNonNull(action, "action is null");
+
+        if (isInvalid()) {
+            action.accept(getError());
+        }
+        return this;
+    }
+
     /**
      * A {@code Validation}'s value is computed synchronously.
      *

--- a/src/test/java/io/vavr/control/ValidationTest.java
+++ b/src/test/java/io/vavr/control/ValidationTest.java
@@ -224,6 +224,26 @@ public class ValidationTest extends AbstractValueTest {
         assertThat(invalid.flatMap(v -> Validation.valid("ok"))).isSameAs(invalid);
     }
 
+    // -- peekError
+
+    @Test
+    public void shouldPeekErrorNil() {
+        assertThat(empty().peekError(t -> {})).isEqualTo(empty());
+    }
+
+    @Test
+    public void shouldPeekErrorForInvalid() {
+        final int[] effect = { 0 };
+        final Validation<Integer, ?> actual = Validation.invalid(1).peekError(i -> effect[0] = i);
+        assertThat(actual).isEqualTo(Validation.invalid(1));
+        assertThat(effect[0]).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldNotPeekErrorForValid() {
+        Validation.valid(1).peekError(i -> { throw new IllegalStateException(); });
+    }
+
     // -- orElse
 
     @Test


### PR DESCRIPTION
This pull request adds `peekError` on `Validation` class (similar to peekLeft on Either)