### PR TITLE
Option.none(Class) with type

### DIFF
--- a/src/main/java/io/vavr/control/Option.java
+++ b/src/main/java/io/vavr/control/Option.java
@@ -176,6 +176,25 @@ public abstract class Option<T> implements Iterable<T>, io.vavr.Value<T>, Serial
     }
 
     /**
+     * Returns the single instance of {@code None}
+     *
+     * <pre>{@code
+     * // = None
+     * Option<String> none = Option.none();
+     * }</pre>
+     *
+     * @param <T> component type
+     * @param type the class of the component type
+     * @return the single instance of {@code None}
+     */
+    @SuppressWarnings("unused")
+    public static <T> Option<T> none(Class<T> type) {
+        @SuppressWarnings("unchecked")
+        final None<T> none = (None<T>) None.INSTANCE;
+        return none;
+    }
+    
+    /**
      * Narrows a widened {@code Option<? extends T>} to {@code Option<T>}
      * by performing a type-safe cast. This is eligible because immutable/read-only
      * collections are covariant.

--- a/src/test/java/io/vavr/control/OptionTest.java
+++ b/src/test/java/io/vavr/control/OptionTest.java
@@ -711,4 +711,11 @@ public class OptionTest extends AbstractValueTest {
         assertThat(right.get()).isEqualTo(1);
         assertThat(left.getLeft()).isEqualTo("Empty");
     }
+
+    @Test
+    public void testOptionNoneWithType() {
+        Supplier<Option<String>> noneWithStringTypeSupplier = () -> Option.none(String.class);
+        Object option = noneWithStringTypeSupplier.get();
+        assertThat(option).isEqualTo(Option.none());
+    }
 }


### PR DESCRIPTION
The reason for this addition is because there is no convenient way of generating Lists (or infinite Streams) of Option.none() with a given type.

The current workaround:

```
String nullString = null;
// Calling Option.none() without arguments won"t compile
Stream<Option<String>>  optionStringStream = Stream.iterate(() -> Option.none(nullString));
```

Can now be simplified to:

```
Stream<Option<String>>  optionStringStream = Stream.iterate(() -> Option.none(String.class));
```