### PR TITLE
Vector.of(T element) performance improvement

### DIFF
--- a/src/main/java/io/vavr/collection/Vector.java
+++ b/src/main/java/io/vavr/collection/Vector.java
@@ -102,7 +102,7 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
      * @return A new Vector instance containing the given element
      */
     public static <T> Vector<T> of(T element) {
-        return ofAll(Iterator.of(element));
+        return ofAll(BitMappedTrie.ofAll(new Object[]{element}));
     }
 
     /**


### PR DESCRIPTION
As discussed here https://github.com/vavr-io/vavr/issues/2656#issuecomment-841811218