### PR TITLE
#2690 sontatype 401 fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,8 +182,8 @@ signing {
 nexusPublishing {
     repositories {
         sonatype {
-            username.set(providers.systemProperty("ossrhUsername").forUseAtConfigurationTime())
-            password.set(providers.systemProperty("ossrhPassword").forUseAtConfigurationTime())
+            username.set(ossrhUsername)
+            password.set(ossrhPassword)
         }
     }
 }


### PR DESCRIPTION
very trivial fix - actually in gradle 7.0 username and password from USER gradle.properties were not correctly read.
I have no idea why.

This small change seems to work - at least solves the error visible in #2690 

Edited:
Just small note - if you have 
`systemProp.org.gradle.project.ossrhUsername=xxx `
in your `HOME/.gradle/gradle.properties`
it will interfere with line
`ossrhUsername=xyz` 

That confused me - I had the first line (used in other project).
Probably the second form (as documented in `vavr` build file ) is a proper one - I am not a gradle specialist.
