### PR TITLE
Fix for 'unknown property ossrhUsername'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,8 +182,8 @@ signing {
 nexusPublishing {
     repositories {
         sonatype {
-            username.set(ossrhUsername)
-            password.set(ossrhPassword)
+            username.set(providers.systemProperty("ossrhUsername").orElse("").forUseAtConfigurationTime())
+            password.set(providers.systemProperty("ossrhPassword").orElse("").forUseAtConfigurationTime())        
         }
     }
 }


### PR DESCRIPTION
This is to address a build failure observed with the latest code:
```
% ./gradlew build
Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* Where:
Build file '/**********************************/vavr/build.gradle' line: 185

* What went wrong:
A problem occurred evaluating root project 'vavr'.
> Could not get unknown property 'ossrhUsername' for object of type io.github.gradlenexus.publishplugin.NexusRepository.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 6s
```
