### PR TITLE
Add method in validation on success

### DIFF
--- a/src/main/java/io/vavr/control/Validation.java
+++ b/src/main/java/io/vavr/control/Validation.java
@@ -558,6 +558,24 @@ public abstract class Validation<E, T> implements Iterable<T>, Value<T>, Seriali
         return isValid() ? this : (Validation<E, T>) supplier.get();
     }
 
+     /**
+     * Returns result of evaluating supplier if it is valid, otherwise return this.
+     *
+     * <pre>{@code
+     * // following code return an alternative Supplier validation("vavr") when there is an error in first validation
+     * Validation<? super Exception, ?> errorInValidation = Validation.invalid(Error.class);
+     * Validation<? super Exception, ?> validation = errorInValidation.onSuccess(() -> Validation.valid("vavr"));
+     * }</pre>
+     *
+     * @param supplier An alternative {@code Validation} supplier
+     * @return this {@code Validation} if it is invalid, otherwise return the result of evaluating supplier.
+     */
+    @SuppressWarnings("unchecked")
+    public final Validation<E, T> onSuccess(Supplier<? extends Validation<? extends E, ? extends T>> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
+        return isValid() ? (Validation<E, T>) supplier.get() : this;
+    }
+    
     @Override
     public final boolean isEmpty() {
         return isInvalid();

--- a/src/test/java/io/vavr/control/ValidationTest.java
+++ b/src/test/java/io/vavr/control/ValidationTest.java
@@ -742,4 +742,18 @@ public class ValidationTest extends AbstractValueTest {
     public void shouldHandleTransformOnLeft() {
         assertThat(Validation.invalid(0).<String> transform(self -> self.isEmpty() ? "ok" : "failed")).isEqualTo("ok");
     }
+    
+        // -- onSuccess
+
+    @Test
+    public void shouldReturnSupplierOnOnSuccessIfValid() {
+        Validation<Seq<String>, String> validValidation = valid();
+        assertThat(validValidation.onSuccess(this::valid)).isEqualTo(validValidation);
+    }
+
+    @Test
+    public void shouldReturnErrorOnOnSuccessIfInValid() {
+        Validation<Seq<String>, String> inValidValidation = invalid();
+        assertThat(inValidValidation.onSuccess(this::invalid)).isEqualTo(inValidValidation);
+    }
 }


### PR DESCRIPTION
Added onSuccess method in validation.

Purpose is to continue to next validation if current validation is successful. If a validation fails then skip the subsequent validations in the chain

ex:

 return rangeValidation(range)
                .onSuccess(() -> dateValidation(date))
                .onSuccess(() -> emailValidation(email));
