### PR TITLE
update depricated gradle features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,8 +85,8 @@ task generateSources() {
             ant.get(src: ammoniteReleaseUrl, dest: ammoniteJar)
         }
         javaexec {
-            main = "-jar"
-            args = [ammoniteJar, "generator/Generator.sc"]
+            classpath = project.files(ammoniteJar)
+            args = ["generator/Generator.sc"]
         }
     }
 }
@@ -100,7 +100,7 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.named('jacocoTestReport') {
     reports {
-        xml.enabled = true
+        xml.required = true
     }
 }
 


### PR DESCRIPTION
This prevents the following gradle warning:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.3.1/userguide/command_line_interface.html#sec:command_line_warnings
```