### PR TITLE
Propose Try.toEither(Throwable => L)

### DIFF
--- a/src/main/java/io/vavr/control/Try.java
+++ b/src/main/java/io/vavr/control/Try.java
@@ -1133,6 +1133,21 @@ public abstract class Try<T> implements Iterable<T>, io.vavr.Value<T>, Serializa
     }
 
     /**
+     * Converts this {@code Try} to an {@link Either}, converting the Throwable (if present)
+     * to a left value using the passed {@link Function}
+     *
+     * @param throwableMapper A transformation from throwable to the left type of the new {@code Either}
+     * @return A new {@code Either}
+     */
+    public final <L> Either<L, T> toEither(Function<? super Throwable, ? extends L> throwableMapper) {
+        if (isFailure()) {
+            return Either.left(throwableMapper.apply(getCause()));
+        } else {
+            return Either.right(get());
+        }
+    }
+
+    /**
      * Converts this {@code Try} to a {@link Validation}.
      *
      * @return A new {@code Validation}

--- a/src/test/java/io/vavr/control/TryTest.java
+++ b/src/test/java/io/vavr/control/TryTest.java
@@ -969,6 +969,15 @@ public class TryTest extends AbstractValueTest {
         assertThat(failure().toEither(() -> "test").isLeft()).isTrue();
     }
 
+    @Test
+    public void shouldConvertFailureToEitherLeftMapper() {
+        final Try<Object> failure = Try.failure(new RuntimeException("a certain value"));
+        final Either<Boolean, Object> either = failure.toEither(t ->
+                t.getMessage().equals("a certain value")
+        );
+        assertThat(either).isEqualTo(Either.left(true));
+    }
+
 
     // -- toValidation
 


### PR DESCRIPTION
### Thank You
Thank you for all of the work on Vavr! It has quickly become my favorite Java library, and usually the first thing I add to every new project ❤️  Aside from the benefit to my own code, it has also been a great tool to help teach others about FP and get them curious about it.

### Proposal / What is this?
I come across cases where I want to convert a `Try` to an `Either` while mapping the `Failure` value onto a `Left` value.
One example would be safely handling code which isn't mine, then mapping the `Throwable` onto an error type.

I do this normally either with `fold(throwableMapper, identity())` or `.toEither().mapLeft(throwableMapper)`, but find that `.toEither(throwableMapper)` would be a nice shortcut to replace either case.
I have also a few colleagues who would appreciate the addition from a readability standpoint I think, so I thought I'd suggest it.

### Implementation
By my own style, I'd normally just write this as a wrapper around a `fold` call. However, as a first contribution, I am trying to stick as close as possible to the style I already see in the code here.

By that reasoning, the code style, namings, and Javadoc are all created based on examples I find existing within the file.

Since the `toEither(Supplier)` implementation assumes the `Supplier` is pure/will not throw an exception and does not handle such a case, I have followed the same assumption here as well.