### PR TITLE
Faster LinkedHashMap tail()

### DIFF
--- a/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -917,7 +917,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         if (isEmpty()) {
             throw new UnsupportedOperationException("tail of empty LinkedHashMap");
         } else {
-            return LinkedHashMap.ofEntries(list.tail());
+            return wrap(list.tail(), map.remove(list.head()._1()));
         }
     }
 


### PR DESCRIPTION
Change: LinkedHashMap tail() no longer copies the entire datastructure.

Motivation: We have a use case which looks somewhat like the following.

1. It's effectively a Queue use case (fifo).
2. Iteration order needs to be stable.
3. Elements in the queue frequently need to be verified as present in the queue.
4. Occasionally, removals must occur, which are usually from the head of the queue although occasionally randomly.

We started with a Queue and eventually found performance issues from too much linear scanning. This was not obviously going to be a bottleneck since our queues are usually of very small size, but ended up so. The next type we considered was a LinkedHashSet, using the `head` and `tail` methods to implement a dequeue-like operation and the set operations being sufficient for the other operations. Unfortunately, it seems that `tail` at present copies the entire queue despite not seemingly needing to.

We moved to our own hand-crafted HashSet+Queue structure, but this PR seems like it'd generally be beneficial for users of Vavr! It affects LinkedHashMap, and because LinkedHashSet contains a LinkedHashMap, LinkedHashSet, too.