### PR TITLE
Actual faster LinkedHashSet tail

### DIFF
--- a/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -831,7 +831,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
         if (map.isEmpty()) {
             throw new UnsupportedOperationException("tail of empty set");
         }
-        return remove(head());
+        return wrap(map.tail());
     }
 
     @Override


### PR DESCRIPTION
My profuse apologies - in the last PR I somehow realised and then forgot that LinkedHashSet tail doesn't actually use LinkedHashMap tail. This remedies that. Sorry for the thrash!