### PR TITLE
Faster LinkedHashSet head()

### DIFF
--- a/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -631,12 +631,12 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
         if (map.isEmpty()) {
             throw new NoSuchElementException("head of empty set");
         }
-        return iterator().next();
+        return map.head()._1();
     }
 
     @Override
     public Option<T> headOption() {
-        return iterator().headOption();
+        return map.headOption().map(Tuple2::_1);
     }
 
     @Override


### PR DESCRIPTION
While writing up #2727 I noticed that `LinkedHashSet.head()` is implemented by `iterator().head()`. This is inefficient because `queue.iterator().next()` makes a call to `.head()`, but also to `.tail()` so as to prepare for the next `head()` call. Given the structure of the underlying `Queue`, the `head()` call is worst case `O(1)` but the tail call is worst case `O(n)`. The present worst case will be achieved if there have never been overwrites or removals from the set, which is probably a fairly common case.