### PR TITLE
add copyright information to jar

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,17 @@
+____  ______________  ________________________  __________
+\   \/   /      \   \/   /   __/   /      \   \/   /      \
+ \______/___/\___\______/___/_____/___/\___\______/___/\___\
+
+Copyright 2023 Vavr, https://vavr.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,10 @@ tasks.named('check') {
 }
 
 tasks.named('jar') {
+    from('.') {
+        include 'COPYRIGHT'
+    }
+
     manifest {
         attributes('Automatic-Module-Name': 'io.vavr')
     }


### PR DESCRIPTION
### Add copyright information to Jar.

For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the copyright and licence information from our dependencies. This scanner can extract all informaton from the Jar File. Therefore it would be great to have the copyright information included in the Jar File as COPYRIGHT File. 