### PR TITLE
Propose Either.toTry(L => Throwable)

### DIFF
--- a/src/main/java/io/vavr/control/Either.java
+++ b/src/main/java/io/vavr/control/Either.java
@@ -794,6 +794,22 @@ public abstract class Either<L, R> implements Iterable<R>, io.vavr.Value<R>, Ser
         return isRight() ? Validation.valid(get()) : Validation.invalid(getLeft());
     }
 
+    /**
+     * Transforms this {@code Either} into a {@link Try} instance.
+     * <p>
+     * Map this {@code left} value to a {@link Throwable} using the {@code leftMapper}
+     * or return a {@link Try#success(Object) Success} of this {@code right} value.
+     * </p>
+     *
+     * @param leftMapper A function that maps the left value of this {@code Either} to a {@link Throwable} instance
+     * @return A {@link Try} instance that represents the result of the transformation
+     * @throws NullPointerException if {@code leftMapper} is {@code null}
+     */
+    public final Try<R> toTry(Function<? super L, ? extends Throwable> leftMapper) {
+        Objects.requireNonNull(leftMapper, "leftMapper is null");
+        return mapLeft(leftMapper).fold(Try::failure,Try::success);
+    }
+
     // -- Left/Right projections
 
     /**

--- a/src/test/java/io/vavr/control/EitherTest.java
+++ b/src/test/java/io/vavr/control/EitherTest.java
@@ -571,6 +571,22 @@ public class EitherTest extends AbstractValueTest {
         assertThat(validation.getError()).isEqualTo("vavr");
     }
 
+    // -- toTry
+
+    @Test
+    public void shouldConvertToSuccessTry() {
+        final Try<Integer> actual = Either.right(42).toTry(left -> new IllegalStateException(Objects.toString(left)));
+        assertThat(actual.isSuccess()).isTrue();
+        assertThat(actual.get()).isEqualTo(42);
+    }
+
+    @Test
+    public void shouldConvertToFailureTry() {
+        final Try<?> actual = Either.left("vavr").toTry(left->new IllegalStateException(left));
+        assertThat(actual.isFailure()).isTrue();
+        assertThat(actual.getCause().getMessage()).isEqualTo("vavr");
+    }
+
     // hashCode
 
     @Test


### PR DESCRIPTION
Add a method to convert an `Either` to a `Try`.

Example of the same approach in Scala : [`def toTry(implicit ev: <:<[A, Throwable]): Try[B]`](https://www.scala-lang.org/api/current/scala/util/Either.html#toTry(implicitev:A%3C:%3CThrowable):scala.util.Try[B])
