### PR TITLE
Propose Validation.all() to combine multiple validations on the same value.

### DIFF
--- a/src/main/java/io/vavr/control/Validation.java
+++ b/src/main/java/io/vavr/control/Validation.java
@@ -19,9 +19,11 @@
 package io.vavr.control;
 
 import io.vavr.*;
+import io.vavr.collection.Array;
 import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
+import io.vavr.collection.Traversable;
 
 import java.io.Serializable;
 import java.util.NoSuchElementException;
@@ -185,6 +187,52 @@ public abstract class Validation<E, T> implements Iterable<T>, Value<T>, Seriali
             }
         }
         return errors.isEmpty() ? valid(list.reverse()) : invalid(errors.reverse());
+    }
+
+    /**
+     * A wrapper to {@link #all(Traversable)}.
+     * <p/>
+     * Usage example :
+     *
+     * <pre>{@code
+     *  Validation<String, Path> isDirectory(Path path){
+     *      [...]
+     *  }
+     *
+     *  Validation<String, Path> isWritable(Path path){
+     *      [...]
+     *  }
+     *
+     *  Validation<Seq<String>, Path> checkWritableDirectory = Validation.all(
+     *                 isDirectory(path),
+     *                 isWritable(path)
+     *  );
+     * }</pre>
+     *
+     * @see #all(Traversable)
+     */
+    @SuppressWarnings("varargs")
+    @SafeVarargs
+    public static <E, T> Validation<Seq<E>, T> all(final Validation <? extends E, ? extends T>... values) {
+        Objects.requireNonNull(values, "values is null");
+        return all(Array.of(values));
+    }
+
+    /**
+     * Combine many {@code Validation} of the same type into a single {@code Validation} with a list of invalid values.
+     *
+     *
+     * @param <E>    value type in the case of invalid
+     * @param <T>    value type in the case of valid
+     * @param values An iterable of Validation instances.
+     * @return A valid Validation of the last value if all Validation instances are valid
+     * or an invalid Validation containing an accumulated List of errors.
+     * @throws NullPointerException if values is null
+     */
+    public static <E, T> Validation<Seq<E>, T> all(Traversable<? extends Validation <? extends E, ? extends T>> values) {
+        Objects.requireNonNull(values, "values is null");
+        Iterable<Validation<List<? extends E>, ? extends T>> mapped = values.map(v -> v.mapError(List::of));
+        return sequence(mapped).map(Traversable::last);
     }
 
     /**

--- a/src/test/java/io/vavr/control/ValidationTest.java
+++ b/src/test/java/io/vavr/control/ValidationTest.java
@@ -20,8 +20,9 @@ package io.vavr.control;
 
 import io.vavr.AbstractValueTest;
 import io.vavr.collection.CharSeq;
-import io.vavr.collection.Seq;
 import io.vavr.collection.List;
+import io.vavr.collection.Seq;
+import io.vavr.collection.Traversable;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -151,6 +152,58 @@ public class ValidationTest extends AbstractValueTest {
                 Validation.invalid(List.of("error3", "error4"))
         ));
         assertThat(actual).isEqualTo(Validation.invalid(List.of("error1", "error2", "error3", "error4")));
+    }
+
+    // -- Validation.all
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowWhenAllCombiningNull() {
+        Validation.all((Traversable<? extends Validation<?, ?>>) null);
+    }
+
+    @Test
+    public void shouldCreateValidWhenAllCombiningValids() {
+        final Validation<Seq<String>, Integer> actual = Validation.all(List.of(
+                Validation.valid(1),
+                Validation.valid(2)
+        ));
+        assertThat(actual).isEqualTo(Validation.valid(List.of(1, 2).last()));
+    }
+
+    @Test
+    public void shouldCreateInvalidWhenAllCombiningInvalid() {
+        final Validation<Seq<String>, Integer> actual = Validation.all(List.of(
+                Validation.valid(1),
+                Validation.invalid("error1"),
+                Validation.valid(2),
+                Validation.invalid("error2")
+        ));
+        assertThat(actual).isEqualTo(Validation.invalid(List.of("error1", "error2")));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowWhenAllCombiningVargNull() {
+        Validation.all((Validation<?, ?>) null);
+    }
+
+    @Test
+    public void shouldCreateValidWhenAllCombiningVargValids() {
+        final Validation<Seq<String>, Integer> actual = Validation.all(
+                Validation.valid(1),
+                Validation.valid(2)
+        );
+        assertThat(actual).isEqualTo(Validation.valid(List.of(1, 2).last()));
+    }
+
+    @Test
+    public void shouldCreateInvalidWhenAllCombiningVargInvalid() {
+        Validation<Seq<String>, Integer> actual = Validation.all(
+                Validation.valid(1),
+                Validation.invalid("error2"),
+                Validation.valid(3),
+                Validation.invalid("error4")
+        );
+        assertThat(actual).isEqualTo(Validation.invalid(List.of("error2", "error4")));
     }
 
     // -- Validation.traverse


### PR DESCRIPTION

Hello all,

I'm submitting this pull request to add a method to combine multiple validation of the same type into a single validation.

I've added the tests and it's working as expected. I've also updated the relevant documentation to reflect the changes.
Please let me know if there's anything that needs to be changed or improved upon. I'm happy to make any necessary updates before merging.
Thank you for your time!

### Example:
We have a Path and we want to validate that it’s an absolute path on a writable directory.
We already have simple validations like :
```java
Validation<String,Path> isAbsolute(Path)
Validation<String,Path> isDirectory(Path)
Validation<String,Path> isWritable(Path)
```
We can then combine those like this :
```java
var pathValidation=Validation.all(
	isAbsolute(path),
	isDirectory(path),
	isWritable(path)
);
```	