### PR TITLE
minor: make private class final with default constructor

### DIFF
--- a/src/test/java/io/vavr/collection/BitSetTest.java
+++ b/src/test/java/io/vavr/collection/BitSetTest.java
@@ -589,7 +589,7 @@ public class BitSetTest extends AbstractSortedSetTest {
 
     // -- classes
 
-    private static class Mapper<T> implements Serializable {
+    private static final class Mapper<T> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 

--- a/src/test/java/io/vavr/collection/HashArrayMappedTrieTest.java
+++ b/src/test/java/io/vavr/collection/HashArrayMappedTrieTest.java
@@ -190,7 +190,7 @@ public class HashArrayMappedTrieTest {
         }
     }
 
-    private class Comparator<K, V> {
+    private final class Comparator<K, V> {
         private final java.util.Map<K, V> classic = new java.util.HashMap<>();
         private Map<K, V> hamt = HashMap.empty();
 

--- a/src/test/java/io/vavr/collection/euler/Euler17Test.java
+++ b/src/test/java/io/vavr/collection/euler/Euler17Test.java
@@ -120,7 +120,7 @@ public class Euler17Test {
     /**
      * Solution using Vavr Pattern Matching.
      */
-    private static class SolutionA implements SolutionProblem17 {
+    private static final class SolutionA implements SolutionProblem17 {
         @Override
         public int letterCount(int num) {
             return Match(num).of( /*@formatter:off*/
@@ -142,7 +142,7 @@ public class Euler17Test {
     /**
      * A more general solution using functionality of the Vavr Collections.
      */
-    private static class SolutionB implements SolutionProblem17 {
+    private static final class SolutionB implements SolutionProblem17 {
         @Override
         public int letterCount(int number) {
             return asText(number).length();


### PR DESCRIPTION
minor: make private class final with default constructor

This is part of https://github.com/checkstyle/checkstyle/pull/12737

According to the https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.8.9 The default constructor has the same access modifier as the class.
and according to the check https://checkstyle.org/config_design.html#FinalClass a class that has only private constructors and has no descendant classes is declared as final.