### PR TITLE
fix: hashcode should be calculated based on order

### DIFF
--- a/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -971,7 +971,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public int hashCode() {
-        return Collections.hashUnordered(this);
+        return Collections.hashOrdered(this);
     }
 
     private Object readResolve() {

--- a/src/test/java/io/vavr/collection/LinkedHashMapTest.java
+++ b/src/test/java/io/vavr/collection/LinkedHashMapTest.java
@@ -295,4 +295,9 @@ public class LinkedHashMapTest extends AbstractMapTest {
         assertThat(LinkedHashMap.of(1, 2, 3, 4).isSequential()).isTrue();
     }
 
+    @Test
+    public void shouldHashcodeOrdered() {
+        assertThat(LinkedHashMap.of("a", 1, "b", 2).hashCode()).isNotEqualTo(LinkedHashMap.of("a", 2, "b", 1).hashCode());
+    }
+
 }


### PR DESCRIPTION
What concerns me is that changing hashCode in such a big way can affect other parts of vavr, like equals. However, it seemed to not make any difference to comparing the same two (different) hash maps I made a test for, which is also the example from #2733 