### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on: [push]
 
 jobs:
   build-gradle-project:
+    strategy:
+      matrix:
+        java_version: [8, 11, 17]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout project sources
@@ -11,7 +14,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: ${{ matrix.java_version }}
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Build and test
+
+on: [push]
+
+jobs:
+  build-gradle-project:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout project sources
+      uses: actions/checkout@v2
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+    - name: Build and test
+      run: ./gradlew check --info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: Checkout project sources
       uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK ${{ matrix.java_version }}
       uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java_version }}
@@ -20,3 +20,5 @@ jobs:
       uses: gradle/gradle-build-action@v2
     - name: Build and test
       run: ./gradlew check --info
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3

--- a/src/main/java/io/vavr/control/Validation.java
+++ b/src/main/java/io/vavr/control/Validation.java
@@ -199,7 +199,7 @@ public abstract class Validation<E, T> implements Iterable<T>, Value<T>, Seriali
 
     /**
      * A wrapper to {@link #all(Traversable)}.
-     * <p/>
+     * <br>
      * Usage example :
      *
      * <pre>{@code


### PR DESCRIPTION
Closes #2684.

This migrates the CI from Travis to GitHub Actions.

In Travis, Java 16 was also tested: in this new CI workflow I only added the LTS versions: 8, 11, 17. I think this should generally be sufficient unless there is anything specific about Java 16 that is relevant for Vavr.

The automatic deploy to the Maven repository would still need to be added (not having access to this repository I cannot set up the required secrets for it).

I also had to fix a small error in Javadoc generation.