### PR TITLE
Add support for threaded use of Try.withResources() for up to 3 arguments

### DIFF
--- a/src/test/java/io/vavr/control/TryTest.java
+++ b/src/test/java/io/vavr/control/TryTest.java
@@ -627,6 +627,50 @@ public class TryTest extends AbstractValueTest {
         assertThat(closeable8.isClosed).isTrue();
     }
 
+    @Test
+    public void shouldCreateSuccessTryWithThreadedResources2() {
+        final Closeable<Integer> closeable1 = Closeable.of(1);
+        final Closeable<Integer> closeable2 = Closeable.of(2);
+        final Try<String> actual = Try.withResources(() -> closeable1, i1 -> closeable2).of(i2 -> "" + i2.value);
+        assertThat(actual).isEqualTo(Success("2"));
+        assertThat(closeable1.isClosed).isTrue();
+        assertThat(closeable2.isClosed).isTrue();
+    }
+
+    @Test
+    public void shouldCreateFailureTryWithThreadedResources2() {
+        final Closeable<Integer> closeable1 = Closeable.of(1);
+        final Closeable<Integer> closeable2 = Closeable.of(2);
+        final Try<?> actual = Try.withResources(() -> closeable1, i1 -> closeable2).of(i2 -> { throw new Error(); });
+        assertThat(actual.isFailure()).isTrue();
+        assertThat(closeable1.isClosed).isTrue();
+        assertThat(closeable2.isClosed).isTrue();
+    }
+
+    @Test
+    public void shouldCreateSuccessTryWithChainedResources3() {
+        final Closeable<Integer> closeable1 = Closeable.of(1);
+        final Closeable<Integer> closeable2 = Closeable.of(2);
+        final Closeable<Integer> closeable3 = Closeable.of(3);
+        final Try<String> actual = Try.withResources(() -> closeable1, i1 -> closeable2, i2 -> closeable3).of(i3 -> "" + i3.value);
+        assertThat(actual).isEqualTo(Success("3"));
+        assertThat(closeable1.isClosed).isTrue();
+        assertThat(closeable2.isClosed).isTrue();
+        assertThat(closeable3.isClosed).isTrue();
+    }
+
+    @Test
+    public void shouldCreateFailureTryWithThreadedResources3() {
+        final Closeable<Integer> closeable1 = Closeable.of(1);
+        final Closeable<Integer> closeable2 = Closeable.of(2);
+        final Closeable<Integer> closeable3 = Closeable.of(3);
+        final Try<?> actual = Try.withResources(() -> closeable1, i1 -> closeable2, i2 -> closeable3).of(i3 -> { throw new Error(); });
+        assertThat(actual.isFailure()).isTrue();
+        assertThat(closeable1.isClosed).isTrue();
+        assertThat(closeable2.isClosed).isTrue();
+        assertThat(closeable3.isClosed).isTrue();
+    }
+
     // -- Failure.Cause
 
     @Test


### PR DESCRIPTION
It would be useful to be able to thread your Autocloseable resources when using Try.withResources() in common scenarios/use cases such as database related resource management (Connection, PreparedStatement, ResultSet).

For example :-

`Try.withResources(dataSource::getConnection, conn -> conn.prepareStatement("SELECT id, name from books"),  PreparedStatement::executeQuery).of(rs -> /* extract what you need from ResultSet */)`

Is equivalent but preferable to :-

`Try.of(() -> try(Connection conn = dataSource.getConnection(); PreparedStatement stmt = conn.prepareStatement("SELECT id, name from books"); ResultSet rs = stmt.executeQuery())).flatMap(rs -> /* extract what you need from ResultSet */);`
 