### PR TITLE
Reintroduce `Try.mapFailure(Function<Throwable, Throwable>)`

### DIFF
--- a/src/main/java/io/vavr/control/Try.java
+++ b/src/main/java/io/vavr/control/Try.java
@@ -734,6 +734,21 @@ public abstract class Try<T> implements Iterable<T>, io.vavr.Value<T>, Serializa
     }
 
     /**
+     * Maps the cause to a new exception if this is a {@code Failure} or returns this instance if this is a {@code Success}.
+     *
+     * @param mapper A function that maps the cause of a failure to another exception.
+     * @return A new {@code Try} if this is a {@code Failure}, otherwise this.
+     * @throws NullPointerException if {@code mapper} is null.
+     */
+    public final Try<T> mapFailure(Function<? super Throwable, ? extends Throwable> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+
+        return isFailure()
+            ? failure(mapper.apply(getCause()))
+            : this;
+    }
+
+    /**
      * Runs the given checked function if this is a {@link Try.Success},
      * passing the result of the current expression to it.
      * If this expression is a {@link Try.Failure} then it'll return a new

--- a/src/test/java/io/vavr/control/TryTest.java
+++ b/src/test/java/io/vavr/control/TryTest.java
@@ -28,6 +28,7 @@ package io.vavr.control;
 
 import static io.vavr.API.*;
 import static io.vavr.Predicates.instanceOf;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -1156,7 +1157,7 @@ public class TryTest extends AbstractValueTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldMapFailureWhenSuccess() {
+    public void shouldMapFailuresCaseWhenSuccess() {
         final Try<Integer> testee = Success(1);
         final Try<Integer> actual = testee.mapFailure(
                 Case($(instanceOf(RuntimeException.class)), (Function<RuntimeException, Error>) Error::new)
@@ -1166,7 +1167,7 @@ public class TryTest extends AbstractValueTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldMapFailureWhenFailureAndMatches() {
+    public void shouldMapFailureCasesWhenFailureAndMatches() {
         final Try<Integer> testee = Failure(new IOException());
         final Try<Integer> actual = testee.mapFailure(
                 Case($(instanceOf(IOException.class)), (Function<IOException, Error>) Error::new)
@@ -1176,12 +1177,33 @@ public class TryTest extends AbstractValueTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldMapFailureWhenFailureButDoesNotMatch() {
+    public void shouldMapFailureCasesWhenFailureButDoesNotMatch() {
         final Try<Integer> testee = Failure(new IOException());
         final Try<Integer> actual = testee.mapFailure(
                 Case($(instanceOf(RuntimeException.class)), (Function<RuntimeException, Error>) Error::new)
         );
         assertThat(actual).isSameAs(testee);
+    }
+
+    @Test
+    public void shouldMapFailureWhenSuccess() {
+        final Try<Integer> testee = Success(1);
+        final Try<Integer> actual = testee.mapFailure(Error::new);
+        assertThat(actual).isSameAs(testee);
+    }
+
+    @Test
+    public void shouldMapFailureWhenFailure() {
+        final Try<Object> actual = failure().mapFailure(Error::new);
+        assertThat(actual.getCause()).isInstanceOf(Error.class);
+    }
+
+    @Test
+    public void mapFailureShouldThrowWithNullMapper() {
+        assertThatNullPointerException()
+            .isThrownBy(() ->
+                success().mapFailure((Function<? super Throwable, ? extends Throwable>) null)
+            ).withMessage("mapper is null");
     }
 
     // -- andThen


### PR DESCRIPTION
Between 1.0.0-alpha-2 and 1.0.0-alpha-3, the method was removed. This commit adds back the method.

See:
- https://github.com/vavr-io/vavr/commit/459d188
- https://github.com/vavr-io/vavr/compare/459d188...vavr-1.0.0-alpha-3#diff-62c83e39394d03a2ace34c80b861281bd8cd75bf80cb0b9ac8506cf7c433314cL576-R639
- https://github.com/vavr-io/vavr/issues/1521#issuecomment-1891092473

# Revisions

# Revision 1

https://github.com/vavr-io/vavr/compare/26181f14b9629ceb729a73795d3854363c7dce0e...edf8f10d1e3cef469af61e5f78532232001d4ec0

## 2024-09-06 Update: Rebase on top of latest `origin/master`

https://github.com/vavr-io/vavr/compare/edf8f10d1e3cef469af61e5f78532232001d4ec0..a92240bed247dcf6e29a1cc83995a64732d2aeec

