### PR TITLE
Qualify all yield() calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,12 +73,12 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.deploy.version>3.0.0-M1</maven.deploy.version>
         <maven.gpg.version>1.6</maven.gpg.version>
-        <maven.jacoco.version>0.8.2</maven.jacoco.version>
+        <maven.jacoco.version>0.8.12</maven.jacoco.version>
         <maven.jar.version>3.1.1</maven.jar.version>
         <maven.javadoc.version>3.0.1</maven.javadoc.version>
         <maven.release.version>2.5.3</maven.release.version>
         <maven.versions.version>2.7</maven.versions.version>
-        <maven.surefire.version>3.0.0-M3</maven.surefire.version>
+        <maven.surefire.version>3.3.1</maven.surefire.version>
         <maven.source.version>3.0.1</maven.source.version>
         <maven.exec.version>1.5.0</maven.exec.version>
         <scala.maven.version>3.4.4</scala.maven.version>

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -838,7 +838,7 @@ def generateMainClasses(): Unit = {
                      * @return an {@code Iterator} of mapped results
                      */
                     public $rtype<T1> yield() {
-                        return yield(Function.identity());
+                        return this.yield(Function.identity());
                     }
                   """)}
               }

--- a/vavr/src-gen/main/java/io/vavr/API.java
+++ b/vavr/src-gen/main/java/io/vavr/API.java
@@ -3260,7 +3260,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           */
          public Iterator<T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 
@@ -3559,7 +3559,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           */
          public Option<T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 
@@ -3858,7 +3858,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           */
          public Future<T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 
@@ -4157,7 +4157,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           */
          public Try<T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 
@@ -4456,7 +4456,7 @@ public final class API {
           * @return an {@code Iterator} of mapped results
           */
          public List<T1> yield() {
-             return yield(Function.identity());
+             return this.yield(Function.identity());
          }
      }
 


### PR DESCRIPTION
Unqualified calls to `yield()` method are not supported since Java 14. 

`yield` is now an integral part of the switch expression: [https://openjdk.org/jeps/361](link)