### PR TITLE
Ordered LinkedHashMap#hashCode() implementation

### DIFF
--- a/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -971,7 +971,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public int hashCode() {
-        return Collections.hashUnordered(this);
+        return Collections.hashOrdered(this);
     }
 
     private Object readResolve() {

--- a/src/test/java/io/vavr/collection/CollectionsTest.java
+++ b/src/test/java/io/vavr/collection/CollectionsTest.java
@@ -233,7 +233,7 @@ public class CollectionsTest {
             for (Traversable<?> traversable2 : traversables) {
                 if (traversable1 != traversable2) {
                     assertThat(traversable1.equals(traversable2)).isEqualTo(value);
-                    if (value) {
+                    if (value && traversable1.getClass().equals(traversable2.getClass())) {
                         assertThat(traversable1.hashCode() == traversable2.hashCode()).isTrue();
                     }
                 }


### PR DESCRIPTION
To maintain the contract between `equals()` and `hashCode()`, the `LinkedHashMap#hashCode` implementation should account for the order of key-value pairs (tuples). 

This ensures that the hashCode reflects the sequence in which entries are added, aligning with the behavior of equals.

----

Related to: https://github.com/vavr-io/vavr/pull/2803
Fixes: https://github.com/vavr-io/vavr/issues/2733