### PR TITLE
Replace synchronized method/block with reentrant lock  (#2842)

### DIFF
--- a/vavr/src/main/java/io/vavr/Lazy.java
+++ b/vavr/src/main/java/io/vavr/Lazy.java
@@ -30,6 +30,7 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -60,6 +61,7 @@ import java.util.function.Supplier;
 public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
 
     private static final long serialVersionUID = 1L;
+    private final ReentrantLock lock = new ReentrantLock();
 
     // read http://javarevisited.blogspot.de/2014/05/double-checked-locking-on-singleton-in-java.html
     private transient volatile Supplier<? extends T> supplier;
@@ -155,11 +157,16 @@ public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
         return (supplier == null) ? value : computeValue();
     }
     
-    private synchronized T computeValue() {
-        final Supplier<? extends T> s = supplier;
-        if (s != null) {
-            value = s.get();
-            supplier = null;
+    private T computeValue() {
+        lock.lock();
+        try {
+            final Supplier<? extends T> s = supplier;
+            if (s != null) {
+                value = s.get();
+                supplier = null;
+            }
+        } finally {
+            lock.unlock();
         }
         return value;
     }


### PR DESCRIPTION
Virtual threads suffer when performing a blocking operation inside a `synchronized` method/block, and it is recommended that the `synchronized` method/block be replaced with a `ReentrantLock`.

More details: https://docs.oracle.com/en/java/javase/21/core/virtual-threads.html#GUID-04C03FFC-066D-4857-85B9-E5A27A875AF9

----

related: https://github.com/vavr-io/vavr/issues/2760