### PR TITLE
Fix Java Serialization warnings for Tuple

### DIFF
--- a/generator/Generator.sc
+++ b/generator/Generator.sc
@@ -1963,7 +1963,7 @@ def generateMainClasses(): Unit = {
               /$javadoc
                * The ${j.ordinal} element of this tuple.
                */
-              public final T$j _$j;
+              transient public T$j _$j;
             """)("\n\n")}
 
             ${if (i == 0) xs"""
@@ -2237,6 +2237,24 @@ def generateMainClasses(): Unit = {
             public int hashCode() {
                 return ${if (i == 0) "1" else if (i == 1) "Objects.hashCode(_1)" else if (i == 2) "Objects.hashCode(_1) ^ Objects.hashCode(_2)" else s"""Objects.hash(${(1 to i).gen(j => s"_$j")(", ")})"""};
             }
+
+            ${(i > 0).gen(xs"""
+            private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+                s.defaultWriteObject();
+                ${(1 to i).gen(j => xs"""
+                  s.writeObject(_$j);
+                   """)("\n")}
+            }
+
+            @SuppressWarnings("unchecked")
+            private void readObject(java.io.ObjectInputStream s)
+                        throws java.io.IOException, ClassNotFoundException {
+                s.defaultReadObject();
+                ${(1 to i).gen(j => xs"""
+                  _$j = (T$j) s.readObject();
+                   """)("\n")}
+            }
+            """)}
 
             @Override
             public String toString() {

--- a/src-gen/main/java/io/vavr/Tuple1.java
+++ b/src-gen/main/java/io/vavr/Tuple1.java
@@ -49,7 +49,7 @@ public final class Tuple1<T1> implements Tuple, Serializable {
     /**
      * The 1st element of this tuple.
      */
-    public final T1 _1;
+    transient public T1 _1;
 
     /**
      * Constructs a tuple of one element.
@@ -301,6 +301,18 @@ public final class Tuple1<T1> implements Tuple, Serializable {
     @Override
     public int hashCode() {
         return Objects.hashCode(_1);
+    }
+
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        s.writeObject(_1);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readObject(java.io.ObjectInputStream s)
+                throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        _1 = (T1) s.readObject();
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple2.java
+++ b/src-gen/main/java/io/vavr/Tuple2.java
@@ -53,12 +53,12 @@ public final class Tuple2<T1, T2> implements Tuple, Serializable {
     /**
      * The 1st element of this tuple.
      */
-    public final T1 _1;
+    transient public T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
-    public final T2 _2;
+    transient public T2 _2;
 
     /**
      * Constructs a tuple of two elements.
@@ -395,6 +395,20 @@ public final class Tuple2<T1, T2> implements Tuple, Serializable {
     @Override
     public int hashCode() {
         return Objects.hashCode(_1) ^ Objects.hashCode(_2);
+    }
+
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        s.writeObject(_1);
+        s.writeObject(_2);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readObject(java.io.ObjectInputStream s)
+                throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        _1 = (T1) s.readObject();
+        _2 = (T2) s.readObject();
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple3.java
+++ b/src-gen/main/java/io/vavr/Tuple3.java
@@ -51,17 +51,17 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Serializable {
     /**
      * The 1st element of this tuple.
      */
-    public final T1 _1;
+    transient public T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
-    public final T2 _2;
+    transient public T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
-    public final T3 _3;
+    transient public T3 _3;
 
     /**
      * Constructs a tuple of three elements.
@@ -418,6 +418,22 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(_1, _2, _3);
+    }
+
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        s.writeObject(_1);
+        s.writeObject(_2);
+        s.writeObject(_3);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readObject(java.io.ObjectInputStream s)
+                throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        _1 = (T1) s.readObject();
+        _2 = (T2) s.readObject();
+        _3 = (T3) s.readObject();
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple4.java
+++ b/src-gen/main/java/io/vavr/Tuple4.java
@@ -52,22 +52,22 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Serializable {
     /**
      * The 1st element of this tuple.
      */
-    public final T1 _1;
+    transient public T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
-    public final T2 _2;
+    transient public T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
-    public final T3 _3;
+    transient public T3 _3;
 
     /**
      * The 4th element of this tuple.
      */
-    public final T4 _4;
+    transient public T4 _4;
 
     /**
      * Constructs a tuple of 4 elements.
@@ -465,6 +465,24 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(_1, _2, _3, _4);
+    }
+
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        s.writeObject(_1);
+        s.writeObject(_2);
+        s.writeObject(_3);
+        s.writeObject(_4);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readObject(java.io.ObjectInputStream s)
+                throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        _1 = (T1) s.readObject();
+        _2 = (T2) s.readObject();
+        _3 = (T3) s.readObject();
+        _4 = (T4) s.readObject();
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple5.java
+++ b/src-gen/main/java/io/vavr/Tuple5.java
@@ -53,27 +53,27 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Serializable {
     /**
      * The 1st element of this tuple.
      */
-    public final T1 _1;
+    transient public T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
-    public final T2 _2;
+    transient public T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
-    public final T3 _3;
+    transient public T3 _3;
 
     /**
      * The 4th element of this tuple.
      */
-    public final T4 _4;
+    transient public T4 _4;
 
     /**
      * The 5th element of this tuple.
      */
-    public final T5 _5;
+    transient public T5 _5;
 
     /**
      * Constructs a tuple of 5 elements.
@@ -513,6 +513,26 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(_1, _2, _3, _4, _5);
+    }
+
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        s.writeObject(_1);
+        s.writeObject(_2);
+        s.writeObject(_3);
+        s.writeObject(_4);
+        s.writeObject(_5);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readObject(java.io.ObjectInputStream s)
+                throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        _1 = (T1) s.readObject();
+        _2 = (T2) s.readObject();
+        _3 = (T3) s.readObject();
+        _4 = (T4) s.readObject();
+        _5 = (T5) s.readObject();
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple6.java
+++ b/src-gen/main/java/io/vavr/Tuple6.java
@@ -54,32 +54,32 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Serializable
     /**
      * The 1st element of this tuple.
      */
-    public final T1 _1;
+    transient public T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
-    public final T2 _2;
+    transient public T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
-    public final T3 _3;
+    transient public T3 _3;
 
     /**
      * The 4th element of this tuple.
      */
-    public final T4 _4;
+    transient public T4 _4;
 
     /**
      * The 5th element of this tuple.
      */
-    public final T5 _5;
+    transient public T5 _5;
 
     /**
      * The 6th element of this tuple.
      */
-    public final T6 _6;
+    transient public T6 _6;
 
     /**
      * Constructs a tuple of 6 elements.
@@ -562,6 +562,28 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Serializable
     @Override
     public int hashCode() {
         return Objects.hash(_1, _2, _3, _4, _5, _6);
+    }
+
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        s.writeObject(_1);
+        s.writeObject(_2);
+        s.writeObject(_3);
+        s.writeObject(_4);
+        s.writeObject(_5);
+        s.writeObject(_6);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readObject(java.io.ObjectInputStream s)
+                throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        _1 = (T1) s.readObject();
+        _2 = (T2) s.readObject();
+        _3 = (T3) s.readObject();
+        _4 = (T4) s.readObject();
+        _5 = (T5) s.readObject();
+        _6 = (T6) s.readObject();
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple7.java
+++ b/src-gen/main/java/io/vavr/Tuple7.java
@@ -55,37 +55,37 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Serializ
     /**
      * The 1st element of this tuple.
      */
-    public final T1 _1;
+    transient public T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
-    public final T2 _2;
+    transient public T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
-    public final T3 _3;
+    transient public T3 _3;
 
     /**
      * The 4th element of this tuple.
      */
-    public final T4 _4;
+    transient public T4 _4;
 
     /**
      * The 5th element of this tuple.
      */
-    public final T5 _5;
+    transient public T5 _5;
 
     /**
      * The 6th element of this tuple.
      */
-    public final T6 _6;
+    transient public T6 _6;
 
     /**
      * The 7th element of this tuple.
      */
-    public final T7 _7;
+    transient public T7 _7;
 
     /**
      * Constructs a tuple of 7 elements.
@@ -612,6 +612,30 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Serializ
     @Override
     public int hashCode() {
         return Objects.hash(_1, _2, _3, _4, _5, _6, _7);
+    }
+
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        s.writeObject(_1);
+        s.writeObject(_2);
+        s.writeObject(_3);
+        s.writeObject(_4);
+        s.writeObject(_5);
+        s.writeObject(_6);
+        s.writeObject(_7);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readObject(java.io.ObjectInputStream s)
+                throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        _1 = (T1) s.readObject();
+        _2 = (T2) s.readObject();
+        _3 = (T3) s.readObject();
+        _4 = (T4) s.readObject();
+        _5 = (T5) s.readObject();
+        _6 = (T6) s.readObject();
+        _7 = (T7) s.readObject();
     }
 
     @Override

--- a/src-gen/main/java/io/vavr/Tuple8.java
+++ b/src-gen/main/java/io/vavr/Tuple8.java
@@ -56,42 +56,42 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Seri
     /**
      * The 1st element of this tuple.
      */
-    public final T1 _1;
+    transient public T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
-    public final T2 _2;
+    transient public T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
-    public final T3 _3;
+    transient public T3 _3;
 
     /**
      * The 4th element of this tuple.
      */
-    public final T4 _4;
+    transient public T4 _4;
 
     /**
      * The 5th element of this tuple.
      */
-    public final T5 _5;
+    transient public T5 _5;
 
     /**
      * The 6th element of this tuple.
      */
-    public final T6 _6;
+    transient public T6 _6;
 
     /**
      * The 7th element of this tuple.
      */
-    public final T7 _7;
+    transient public T7 _7;
 
     /**
      * The 8th element of this tuple.
      */
-    public final T8 _8;
+    transient public T8 _8;
 
     /**
      * Constructs a tuple of 8 elements.
@@ -641,6 +641,32 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Seri
     @Override
     public int hashCode() {
         return Objects.hash(_1, _2, _3, _4, _5, _6, _7, _8);
+    }
+
+    private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+        s.defaultWriteObject();
+        s.writeObject(_1);
+        s.writeObject(_2);
+        s.writeObject(_3);
+        s.writeObject(_4);
+        s.writeObject(_5);
+        s.writeObject(_6);
+        s.writeObject(_7);
+        s.writeObject(_8);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readObject(java.io.ObjectInputStream s)
+                throws java.io.IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        _1 = (T1) s.readObject();
+        _2 = (T2) s.readObject();
+        _3 = (T3) s.readObject();
+        _4 = (T4) s.readObject();
+        _5 = (T5) s.readObject();
+        _6 = (T6) s.readObject();
+        _7 = (T7) s.readObject();
+        _8 = (T8) s.readObject();
     }
 
     @Override


### PR DESCRIPTION
Fix Java Serialization warnings for Tuple.
Maven build throws warnings related to Java Serialization when built with JDK21
>  non-transient instance field of a serializable class declared with a non-serializable type

https://github.com/vavr-io/vavr/issues/2811
