### PR TITLE
Suppress Tuple elements serialization warning

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1953,6 +1953,7 @@ def generateMainClasses(): Unit = {
               /$javadoc
                * The ${j.ordinal} element of this tuple.
                */
+              @SuppressWarnings("serial") // Conditionally serializable
               public final T$j _$j;
             """)("\n\n")}
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple1.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple1.java
@@ -43,6 +43,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     /**
      * The 1st element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T1 _1;
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Tuple2.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple2.java
@@ -47,11 +47,13 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     /**
      * The 1st element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T2 _2;
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Tuple3.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple3.java
@@ -45,16 +45,19 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     /**
      * The 1st element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T3 _3;
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Tuple4.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple4.java
@@ -46,21 +46,25 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     /**
      * The 1st element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T3 _3;
 
     /**
      * The 4th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T4 _4;
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Tuple5.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple5.java
@@ -47,26 +47,31 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     /**
      * The 1st element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T3 _3;
 
     /**
      * The 4th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T4 _4;
 
     /**
      * The 5th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T5 _5;
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Tuple6.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple6.java
@@ -48,31 +48,37 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
     /**
      * The 1st element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T3 _3;
 
     /**
      * The 4th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T4 _4;
 
     /**
      * The 5th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T5 _5;
 
     /**
      * The 6th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T6 _6;
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Tuple7.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple7.java
@@ -49,36 +49,43 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
     /**
      * The 1st element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T3 _3;
 
     /**
      * The 4th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T4 _4;
 
     /**
      * The 5th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T5 _5;
 
     /**
      * The 6th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T6 _6;
 
     /**
      * The 7th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T7 _7;
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Tuple8.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple8.java
@@ -50,41 +50,49 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
     /**
      * The 1st element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T1 _1;
 
     /**
      * The 2nd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T2 _2;
 
     /**
      * The 3rd element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T3 _3;
 
     /**
      * The 4th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T4 _4;
 
     /**
      * The 5th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T5 _5;
 
     /**
      * The 6th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T6 _6;
 
     /**
      * The 7th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T7 _7;
 
     /**
      * The 8th element of this tuple.
      */
+    @SuppressWarnings("serial") // Conditionally serializable
     public final T8 _8;
 
     /**


### PR DESCRIPTION
`Tuple` serializability depends on the serializability of all its elements - we can't enforce `Tuple` elements to be serializable, therefor the only option is to silence the warning