### PR TITLE
Don't reference ThreadDeath directly due to its future removal

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -1696,7 +1696,7 @@ interface TryModule {
     static boolean isFatal(Throwable throwable) {
         return throwable instanceof InterruptedException
                 || throwable instanceof LinkageError
-                || throwable instanceof ThreadDeath
+                || ThreadDeathResolver.isThreadDeath(throwable)
                 || throwable instanceof VirtualMachineError;
     }
 
@@ -1706,4 +1706,21 @@ interface TryModule {
         throw (T) t;
     }
 
+    static class ThreadDeathResolver {
+        static final Class<?> THREAD_DEATH_CLASS = resolve();
+
+        static boolean isThreadDeath(Throwable throwable) {
+            return THREAD_DEATH_CLASS != null && THREAD_DEATH_CLASS.isInstance(throwable);
+        }
+
+        private static Class<?> resolve() {
+            try {
+                return Class.forName("java.lang.ThreadDeath");
+            } catch (ClassNotFoundException e) {
+                return null;
+            }
+        }
+    }
 }
+
+


### PR DESCRIPTION
`ThreadDeath` is deprecated for removal, so we can no longer reference it directly.