### PR TITLE
Fix maven build failure with JDK23

### DIFF
--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -64,6 +64,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessors>
+                        <annotationProcessor>
+                            io.vavr.match.PatternsProcessor
+                        </annotationProcessor>
+                    </annotationProcessors>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fix maven build failure with JDK23.
Attached failure logs: 
[build_logs.txt](https://github.com/user-attachments/files/17265414/build_logs.txt)
