### PR TITLE
Replace synchronized by lock in functions generator

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1752,8 +1752,10 @@ def generateMainClasses(): Unit = {
 	                        """}
                       """ else if (i == 1) xs"""
                         final ${im.getType("java.util.Map")}<$generics, R> cache = new ${im.getType("java.util.HashMap")}<>();
+                        final ${im.getType("java.util.concurrent.locks.ReentrantLock")} lock = new ${im.getType("java.util.concurrent.locks.ReentrantLock")}();
                         return ($className$fullGenerics & Memoized) ($params) -> {
-                            synchronized (cache) {
+                            lock.lock();
+                            try {
                                 if (cache.containsKey($params)) {
                                     return cache.get($params);
                                 } else {
@@ -1761,13 +1763,17 @@ def generateMainClasses(): Unit = {
                                     cache.put($params, value);
                                     return value;
                                 }
+                            } finally {
+                                lock.unlock();
                             }
                         };
                       """ else xs"""
                         final ${im.getType("java.util.Map")}<Tuple$i<$generics>, R> cache = new ${im.getType("java.util.HashMap")}<>();
+                        final ${im.getType("java.util.concurrent.locks.ReentrantLock")} lock = new ${im.getType("java.util.concurrent.locks.ReentrantLock")}();
                         return ($className$fullGenerics & Memoized) ($params) -> {
                             final Tuple$i$genericsTuple key = Tuple.of($params);
-                            synchronized (cache) {
+                            lock.lock();
+                            try {
                                 if (cache.containsKey(key)) {
                                     return cache.get(key);
                                 } else {
@@ -1775,6 +1781,8 @@ def generateMainClasses(): Unit = {
                                     cache.put(key, value);
                                     return value;
                                 }
+                            } finally {
+                                lock.unlock();
                             }
                         };
                       """}

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -207,8 +208,10 @@ public interface CheckedFunction1<T1, R> extends Serializable {
             return this;
         } else {
             final Map<T1, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (CheckedFunction1<T1, R> & Memoized) (t1) -> {
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(t1)) {
                         return cache.get(t1);
                     } else {
@@ -216,6 +219,8 @@ public interface CheckedFunction1<T1, R> extends Serializable {
                         cache.put(t1, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -215,9 +216,11 @@ public interface CheckedFunction2<T1, T2, R> extends Serializable {
             return this;
         } else {
             final Map<Tuple2<T1, T2>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (CheckedFunction2<T1, T2, R> & Memoized) (t1, t2) -> {
                 final Tuple2<T1, T2> key = Tuple.of(t1, t2);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -225,6 +228,8 @@ public interface CheckedFunction2<T1, T2, R> extends Serializable {
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -232,9 +233,11 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Serializable {
             return this;
         } else {
             final Map<Tuple3<T1, T2, T3>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (CheckedFunction3<T1, T2, T3, R> & Memoized) (t1, t2, t3) -> {
                 final Tuple3<T1, T2, T3> key = Tuple.of(t1, t2, t3);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -242,6 +245,8 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Serializable {
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -251,9 +252,11 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Serializable {
             return this;
         } else {
             final Map<Tuple4<T1, T2, T3, T4>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (CheckedFunction4<T1, T2, T3, T4, R> & Memoized) (t1, t2, t3, t4) -> {
                 final Tuple4<T1, T2, T3, T4> key = Tuple.of(t1, t2, t3, t4);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -261,6 +264,8 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Serializable {
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -271,9 +272,11 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Serializable {
             return this;
         } else {
             final Map<Tuple5<T1, T2, T3, T4, T5>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (CheckedFunction5<T1, T2, T3, T4, T5, R> & Memoized) (t1, t2, t3, t4, t5) -> {
                 final Tuple5<T1, T2, T3, T4, T5> key = Tuple.of(t1, t2, t3, t4, t5);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -281,6 +284,8 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Serializable {
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -292,9 +293,11 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Serializabl
             return this;
         } else {
             final Map<Tuple6<T1, T2, T3, T4, T5, T6>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (CheckedFunction6<T1, T2, T3, T4, T5, T6, R> & Memoized) (t1, t2, t3, t4, t5, t6) -> {
                 final Tuple6<T1, T2, T3, T4, T5, T6> key = Tuple.of(t1, t2, t3, t4, t5, t6);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -302,6 +305,8 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Serializabl
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -314,9 +315,11 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Seriali
             return this;
         } else {
             final Map<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7) -> {
                 final Tuple7<T1, T2, T3, T4, T5, T6, T7> key = Tuple.of(t1, t2, t3, t4, t5, t6, t7);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -324,6 +327,8 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Seriali
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -337,9 +338,11 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Ser
             return this;
         } else {
             final Map<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7, t8) -> {
                 final Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> key = Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -347,6 +350,8 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Ser
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -206,8 +207,10 @@ public interface Function1<T1, R> extends Serializable, Function<T1, R> {
             return this;
         } else {
             final Map<T1, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (Function1<T1, R> & Memoized) (t1) -> {
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(t1)) {
                         return cache.get(t1);
                     } else {
@@ -215,6 +218,8 @@ public interface Function1<T1, R> extends Serializable, Function<T1, R> {
                         cache.put(t1, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/Function3.java
+++ b/vavr/src-gen/main/java/io/vavr/Function3.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -230,9 +231,11 @@ public interface Function3<T1, T2, T3, R> extends Serializable {
             return this;
         } else {
             final Map<Tuple3<T1, T2, T3>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (Function3<T1, T2, T3, R> & Memoized) (t1, t2, t3) -> {
                 final Tuple3<T1, T2, T3> key = Tuple.of(t1, t2, t3);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -240,6 +243,8 @@ public interface Function3<T1, T2, T3, R> extends Serializable {
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/Function4.java
+++ b/vavr/src-gen/main/java/io/vavr/Function4.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -249,9 +250,11 @@ public interface Function4<T1, T2, T3, T4, R> extends Serializable {
             return this;
         } else {
             final Map<Tuple4<T1, T2, T3, T4>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (Function4<T1, T2, T3, T4, R> & Memoized) (t1, t2, t3, t4) -> {
                 final Tuple4<T1, T2, T3, T4> key = Tuple.of(t1, t2, t3, t4);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -259,6 +262,8 @@ public interface Function4<T1, T2, T3, T4, R> extends Serializable {
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/Function5.java
+++ b/vavr/src-gen/main/java/io/vavr/Function5.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -269,9 +270,11 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Serializable {
             return this;
         } else {
             final Map<Tuple5<T1, T2, T3, T4, T5>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (Function5<T1, T2, T3, T4, T5, R> & Memoized) (t1, t2, t3, t4, t5) -> {
                 final Tuple5<T1, T2, T3, T4, T5> key = Tuple.of(t1, t2, t3, t4, t5);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -279,6 +282,8 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Serializable {
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/Function6.java
+++ b/vavr/src-gen/main/java/io/vavr/Function6.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -290,9 +291,11 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Serializable {
             return this;
         } else {
             final Map<Tuple6<T1, T2, T3, T4, T5, T6>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (Function6<T1, T2, T3, T4, T5, T6, R> & Memoized) (t1, t2, t3, t4, t5, t6) -> {
                 final Tuple6<T1, T2, T3, T4, T5, T6> key = Tuple.of(t1, t2, t3, t4, t5, t6);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -300,6 +303,8 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Serializable {
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/Function7.java
+++ b/vavr/src-gen/main/java/io/vavr/Function7.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -312,9 +313,11 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Serializable {
             return this;
         } else {
             final Map<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (Function7<T1, T2, T3, T4, T5, T6, T7, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7) -> {
                 final Tuple7<T1, T2, T3, T4, T5, T6, T7> key = Tuple.of(t1, t2, t3, t4, t5, t6, t7);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -322,6 +325,8 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Serializable {
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }

--- a/vavr/src-gen/main/java/io/vavr/Function8.java
+++ b/vavr/src-gen/main/java/io/vavr/Function8.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 /**
@@ -335,9 +336,11 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Serializab
             return this;
         } else {
             final Map<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
             return (Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7, t8) -> {
                 final Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> key = Tuple.of(t1, t2, t3, t4, t5, t6, t7, t8);
-                synchronized (cache) {
+                lock.lock();
+                try {
                     if (cache.containsKey(key)) {
                         return cache.get(key);
                     } else {
@@ -345,6 +348,8 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Serializab
                         cache.put(key, value);
                         return value;
                     }
+                } finally {
+                    lock.unlock();
                 }
             };
         }


### PR DESCRIPTION
Similar to https://github.com/vavr-io/vavr/pull/2845 

I replaced synchronized blocks by `Lock` because of virtual threads. More details: https://docs.oracle.com/en/java/javase/21/core/virtual-threads.html#GUID-04C03FFC-066D-4857-85B9-E5A27A875AF9