### PR TITLE
Replace synchronization by Lock in FutureImpl

### DIFF
--- a/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
+++ b/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
@@ -47,7 +47,7 @@ final class FutureImpl<T> implements Future<T> {
     /**
      * Used to synchronize state changes.
      */
-    private final Lock lock = new ReentrantLock();
+    private final Lock lock;
 
     /**
      * Indicates if this Future is cancelled
@@ -89,6 +89,7 @@ final class FutureImpl<T> implements Future<T> {
 
     // single constructor
     private FutureImpl(Executor executor, Option<Try<T>> value, Queue<Consumer<Try<T>>> actions, Queue<Thread> waiters, Computation<T> computation) {
+        this.lock = new ReentrantLock();
         this.executor = executor;
         lock.lock();
         try {

--- a/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
+++ b/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
@@ -25,7 +25,9 @@ import io.vavr.control.Try;
 
 import java.util.Objects;
 import java.util.concurrent.*;
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 /**
@@ -45,7 +47,7 @@ final class FutureImpl<T> implements Future<T> {
     /**
      * Used to synchronize state changes.
      */
-    private final Object lock = new Object();
+    private final Lock lock = new ReentrantLock();
 
     /**
      * Indicates if this Future is cancelled
@@ -88,7 +90,8 @@ final class FutureImpl<T> implements Future<T> {
     // single constructor
     private FutureImpl(Executor executor, Option<Try<T>> value, Queue<Consumer<Try<T>>> actions, Queue<Thread> waiters, Computation<T> computation) {
         this.executor = executor;
-        synchronized (lock) {
+        lock.lock();
+        try {
             this.cancelled = false;
             this.value = value;
             this.actions = actions;
@@ -98,6 +101,8 @@ final class FutureImpl<T> implements Future<T> {
             } catch (Throwable x) {
                 tryComplete(Try.failure(x));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -219,8 +224,11 @@ final class FutureImpl<T> implements Future<T> {
                 public boolean block() {
                     try {
                         if (!threadEnqueued) {
-                            synchronized (lock) {
+                            lock.lock();
+                            try {
                                 waiters = waiters.enqueue(waitingThread);
+                            } finally {
+                                lock.unlock();
                             }
                             threadEnqueued = true;
                         }
@@ -256,7 +264,8 @@ final class FutureImpl<T> implements Future<T> {
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         if (!isCompleted()) {
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (!isCompleted()) {
                     if (mayInterruptIfRunning && this.thread != null) {
                         this.thread.interrupt();
@@ -264,6 +273,8 @@ final class FutureImpl<T> implements Future<T> {
                     this.cancelled = tryComplete(Try.failure(new CancellationException()));
                     return this.cancelled;
                 }
+            } finally {
+                lock.unlock();
             }
         }
         return false;
@@ -272,7 +283,8 @@ final class FutureImpl<T> implements Future<T> {
     private void updateThread() {
         // cancellation may have been initiated by a different thread before this.thread is set by the worker thread
         if (!isCompleted()) {
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (!isCompleted()) {
                     this.thread = Thread.currentThread();
                     try {
@@ -281,6 +293,8 @@ final class FutureImpl<T> implements Future<T> {
                         // we are not allowed to set the uncaught exception handler of the worker thread ¯\_(ツ)_/¯
                     }
                 }
+            } finally {
+                lock.unlock();
             }
         }
     }
@@ -322,12 +336,15 @@ final class FutureImpl<T> implements Future<T> {
         if (isCompleted()) {
             perform(action);
         } else {
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (isCompleted()) {
                     perform(action);
                 } else {
                     actions = actions.enqueue((Consumer<Try<T>>) action);
                 }
+            } finally {
+                lock.unlock();
             }
         }
         return this;
@@ -362,7 +379,8 @@ final class FutureImpl<T> implements Future<T> {
             final Queue<Consumer<Try<T>>> actions;
             final Queue<Thread> waiters;
             // it is essential to make the completed state public *before* performing the actions
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (isCompleted()) {
                     actions = null;
                     waiters = null;
@@ -374,6 +392,8 @@ final class FutureImpl<T> implements Future<T> {
                     this.waiters = null;
                     this.thread = null;
                 }
+            } finally {
+                lock.unlock();
             }
             if (waiters != null) {
                 waiters.forEach(this::unlock);


### PR DESCRIPTION
I replaced _synchronized_ blocks with Lock for the sake of Virtual Threads support. More details: https://docs.oracle.com/en/java/javase/21/core/virtual-threads.html#GUID-04C03FFC-066D-4857-85B9-E5A27A875AF9

----
Similar to https://github.com/vavr-io/vavr/pull/2845