### PR TITLE
Add mapTry to Option

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
+}
+
 rootProject.name = 'vavr'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,1 @@
-plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
-}
-
 rootProject.name = 'vavr'

--- a/src/main/java/io/vavr/control/Option.java
+++ b/src/main/java/io/vavr/control/Option.java
@@ -663,6 +663,16 @@ public abstract class Option<T> implements Iterable<T>, io.vavr.Value<T>, Serial
         return isEmpty() ? none() : some(mapper.apply(get()));
     }
 
+
+    /**
+     * Converts this to a {@link Try}, then runs the given checked function if this is a {@link Try.Success},
+     * passing the result of the current expression to it.
+     *
+     * @param <U>    The new component type
+     * @param mapper A checked function
+     * @return a {@code Try}
+     * @throws NullPointerException if {@code mapper} is null
+     */
     public final <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
         return toTry().mapTry(mapper);
     }

--- a/src/main/java/io/vavr/control/Option.java
+++ b/src/main/java/io/vavr/control/Option.java
@@ -26,6 +26,7 @@
  */
 package io.vavr.control;
 
+import io.vavr.CheckedFunction1;
 import io.vavr.PartialFunction;
 import io.vavr.collection.Iterator;
 import io.vavr.collection.Seq;
@@ -660,6 +661,10 @@ public abstract class Option<T> implements Iterable<T>, io.vavr.Value<T>, Serial
     public final <U> Option<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? none() : some(mapper.apply(get()));
+    }
+
+    public final <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
+        return toTry().mapTry(mapper);
     }
 
     /**

--- a/src/test/java/io/vavr/control/OptionTest.java
+++ b/src/test/java/io/vavr/control/OptionTest.java
@@ -28,9 +28,12 @@ package io.vavr.control;
 
 import io.vavr.*;
 import io.vavr.collection.Seq;
+import io.vavr.concurrent.FutureTest;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -399,6 +402,30 @@ public class OptionTest extends AbstractValueTest {
     @Test
     public void shouldMapNone() {
         assertThat(Option.<Integer> none().map(String::valueOf)).isEqualTo(Option.none());
+    }
+    
+    @Nested
+    class MapTry {
+        @Test
+        public void shouldMapTrySome() {
+            assertThat(Option.of(1).mapTry(String::valueOf)).isEqualTo(Try.success("1"));
+        }
+
+        @Test
+        public void shouldMapTryNone() {
+            Try<String> result = Option.none().mapTry(String::valueOf);
+            assertThat(result.isFailure()).isTrue();
+            assertThat(result.getCause().getClass()).isEqualTo(NoSuchElementException.class);
+            assertThat(result.getCause().getMessage()).isEqualTo("No value present");
+        }
+
+        @Test
+        public void shouldMapTryCheckedException() {
+            Try<Integer> result = Option.of("a").mapTry(Integer::new);
+            assertThat(result.isFailure()).isTrue();
+            assertThat(result.getCause().getClass()).isEqualTo(NumberFormatException.class);
+            assertThat(result.getCause().getMessage()).isEqualTo("For input string: \"a\"");
+        }
     }
 
     // -- flatMap

--- a/src/test/java/io/vavr/control/OptionTest.java
+++ b/src/test/java/io/vavr/control/OptionTest.java
@@ -403,7 +403,7 @@ public class OptionTest extends AbstractValueTest {
     public void shouldMapNone() {
         assertThat(Option.<Integer> none().map(String::valueOf)).isEqualTo(Option.none());
     }
-    
+
     @Nested
     class MapTry {
         @Test


### PR DESCRIPTION
* Add `mapTry` method to Option, which is a shortcut for `.toTry().mapTry`
  * I propose this because when mapping an optional using a checked method, I find it intuitive that the type changes to a Try, and `mapTry` methods exist on other types already
  * I initially added it onto `Value` but this ran into an issue where a method with same name but return value already exists on subtype`Future`

Unrelated but maybe helpful (I can remove it if desired)
* Add toolchain resolver
   * After forking the project I could not load it in IntelliJ, Gradle complained that it could not resolve the toolchain. Added a resolver as per the [Gradle Docs](https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories)
* Add Nested test class for `mapTry` tests instead of a comment
   * This achieves organizational separation just like the comment, but now `JUnit` also understands it and can e.g. run only these tests in isolation.