### PR TITLE
Enforce package depth with ArchUnit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ plugins {
 ext.ammoniteScalaVersion = '3.5'
 ext.ammoniteVersion = '3.0.0'
 ext.ammoniteVersionQualifier = '2-6342755f'
+ext.archUnitVersion = '1.3.0'
 ext.assertjVersion = '3.27.0'
 ext.junitVersion = '5.11.4'
 
@@ -60,6 +61,7 @@ repositories {
 dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "com.tngtech.archunit:archunit-junit5:$archUnitVersion"
 }
 
 tasks.withType(Test).configureEach {

--- a/src/test/java/linter/PackageDepthTest.java
+++ b/src/test/java/linter/PackageDepthTest.java
@@ -17,7 +17,7 @@ public class PackageDepthTest {
         classes()
                 .should(havePackageDepthLessThanOrEqualTo(1 + 2))
                 .check(new ClassFileImporter()
-                        .withImportOption(new ImportOption.DoNotIncludeTests())
+                        .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
                         .importPackages("io.vavr"));
     }
 

--- a/src/test/java/linter/PackageDepthTest.java
+++ b/src/test/java/linter/PackageDepthTest.java
@@ -1,0 +1,39 @@
+package linter;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+public class PackageDepthTest {
+    @Test
+    void maxTwo() {
+        classes()
+                .should(havePackageDepthLessThanOrEqualTo(1 + 2))
+                .check(new ClassFileImporter()
+                        .withImportOption(new ImportOption.DoNotIncludeTests())
+                        .importPackages("io.vavr"));
+    }
+
+    private static ArchCondition<JavaClass> havePackageDepthLessThanOrEqualTo(int maxDepth) {
+        return new ArchCondition<JavaClass>("have a package depth of " + maxDepth + " or less") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                int depth = item.getPackageName().split("\\.").length;
+                if (depth > maxDepth) {
+                    String message = String.format(
+                            "Class %s has a package depth of %d, which exceeds the allowed maximum of %d",
+                            item.getName(), depth, maxDepth
+                    );
+                    events.add(SimpleConditionEvent.violated(item, message));
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Enforce package depth using ArchUnit test

CONTRIBUTING.md mentions:
> The maximum package depth is two

Violation results in a unit test failure:
> Architecture Violation [Priority: MEDIUM] - Rule 'classes should have a package depth of 3 or less' was violated (1 times):
Class io.vavr.too.deep.SomeClass has a package depth of 4, which exceeds the allowed maximum of 3

Small step in fixing issue #2924
