### PR TITLE
Fix CheckedRunnableTest#shouldApplyAnUncheckedFunctionThatThrows

### DIFF
--- a/src/test/java/io/vavr/CheckedRunnableTest.java
+++ b/src/test/java/io/vavr/CheckedRunnableTest.java
@@ -64,12 +64,13 @@ public class CheckedRunnableTest {
 
     @Test
     public void shouldApplyAnUncheckedFunctionThatThrows() {
+        boolean thrown = false;
         final Runnable runnable = CheckedRunnable.of(() -> { throw new Error(); }).unchecked();
         try {
             runnable.run();
-            Assertions.fail("Did expect an exception.");
         } catch(Error x) {
-            // ok!
+            thrown = true;
         }
+        assertThat(thrown).isTrue();
     }
 }

--- a/src/test/java/io/vavr/CheckedRunnableTest.java
+++ b/src/test/java/io/vavr/CheckedRunnableTest.java
@@ -64,13 +64,7 @@ public class CheckedRunnableTest {
 
     @Test
     public void shouldApplyAnUncheckedFunctionThatThrows() {
-        boolean thrown = false;
         final Runnable runnable = CheckedRunnable.of(() -> { throw new Error(); }).unchecked();
-        try {
-            runnable.run();
-        } catch(Error x) {
-            thrown = true;
-        }
-        assertThat(thrown).isTrue();
+        Assertions.assertThrows(Error.class, () -> runnable.run());
     }
 }


### PR DESCRIPTION
* `shouldApplyAnUncheckedFunctionThatThrows` always passed,  when removing the `throw new Error()` because the failed asserting was immediately caught.

```java
        final Runnable runnable = CheckedRunnable.of(() -> { /*throw new Error();*/ }).unchecked(); // Test would still pass
```

Fixed by using `assertThrows` from JUnit