### PR TITLE
Enforce method order with ArchUnit

### DIFF
--- a/src/test/java/linter/ClassSectionTest.java
+++ b/src/test/java/linter/ClassSectionTest.java
@@ -1,0 +1,70 @@
+package linter;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+public class ClassSectionTest {
+    @Test
+    public void methodsAreAlphabeticallyOrderedInSections() {
+        classes()
+                .should(haveOrderedMethodSections()).check(new ClassFileImporter()
+                        .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                        .importPackages("io.vavr"));
+    }
+
+    private ArchCondition<JavaClass> haveOrderedMethodSections() {
+        return new ArchCondition<JavaClass>("have methods alphabetically ordered in sections") {
+            @Override
+            public void check(JavaClass javaClass, ConditionEvents events) {
+                Map<String, List<JavaMethod>> sections = methodSections(javaClass.getMethods());
+
+                for (Map.Entry<String, List<JavaMethod>> section : sections.entrySet()) {
+                    List<JavaMethod> methods = section.getValue();
+
+                    List<String> methodNames = methods.stream()
+                            .map(JavaMethod::getName)
+                            .sorted()
+                            .collect(Collectors.toList());
+
+                    List<String> methodOrder = methods.stream()
+                            .sorted(Comparator.comparing(m -> m.getSourceCodeLocation().getLineNumber()))
+                            .map(JavaMethod::getName)
+                            .collect(Collectors.toList());
+
+                    if (!methodOrder.equals(methodNames)) {
+                        String message = String.format("Methods in section '%s' of class '%s' are not alphabetically ordered: %s",
+                                section.getKey(), javaClass.getName(), methodNames);
+                        events.add(SimpleConditionEvent.violated(javaClass, message));
+                    }
+                }
+            }
+        };
+    }
+
+    private Map<String, List<JavaMethod>> methodSections(Set<JavaMethod> methods) {
+        Map<String, List<JavaMethod>> sections = new HashMap<>();
+        sections.put("static API", new ArrayList<>());
+        sections.put("non-static API", new ArrayList<>());
+
+        for (JavaMethod method : methods) {
+            if (method.getModifiers().contains(JavaModifier.STATIC)) {
+                sections.get("static API").add(method);
+            } else {
+                sections.get("non-static API").add(method);
+            }
+        }
+        return sections;
+    }
+}

--- a/src/test/java/linter/ClassSectionTest.java
+++ b/src/test/java/linter/ClassSectionTest.java
@@ -3,6 +3,7 @@ package linter;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.JavaParameter;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchCondition;
@@ -67,12 +68,22 @@ public class ClassSectionTest {
         for (JavaMethod method : methods) {
             if (method.getModifiers().contains(JavaModifier.STATIC)) {
                 sections.get(STATIC_API).add(method);
-            } else if (method.isAnnotatedWith(Override.class)) {
+            } else if (isOverridden(method)) {
                 sections.get(ADJUSTED_RETURN_TYPES).add(method);
-            } else {
+            }
+            else {
                 sections.get(NON_STATIC_API).add(method);
             }
         }
         return sections;
+    }
+
+    private boolean isOverridden(JavaMethod method) {
+        return method.getOwner().getAllRawInterfaces().stream()
+                .anyMatch(c -> c.tryGetMethod(method.getName(), getTypeNames(method.getParameters())).isPresent());
+    }
+
+    private String[] getTypeNames(List<JavaParameter> parameters) {
+        return parameters.stream().map(p -> p.getRawType().getName()).toArray(String[]::new);
     }
 }

--- a/src/test/java/linter/ClassSectionTest.java
+++ b/src/test/java/linter/ClassSectionTest.java
@@ -45,7 +45,7 @@ public class ClassSectionTest {
 
                     if (!methodOrder.equals(methodNames)) {
                         String message = String.format("Methods in section '%s' of class '%s' are not alphabetically ordered: %s",
-                                section.getKey(), javaClass.getName(), methodNames);
+                                section.getKey(), javaClass.getName(), methodOrder);
                         events.add(SimpleConditionEvent.violated(javaClass, message));
                     }
                 }

--- a/src/test/java/linter/ClassSectionTest.java
+++ b/src/test/java/linter/ClassSectionTest.java
@@ -16,6 +16,11 @@ import java.util.stream.Collectors;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
 public class ClassSectionTest {
+
+    public static final String STATIC_API = "static API";
+    public static final String ADJUSTED_RETURN_TYPES = "adjusted return types";
+    public static final String NON_STATIC_API = "non-static API";
+
     @Test
     public void methodsAreAlphabeticallyOrderedInSections() {
         classes()
@@ -55,14 +60,17 @@ public class ClassSectionTest {
 
     private Map<String, List<JavaMethod>> methodSections(Set<JavaMethod> methods) {
         Map<String, List<JavaMethod>> sections = new HashMap<>();
-        sections.put("static API", new ArrayList<>());
-        sections.put("non-static API", new ArrayList<>());
+        sections.put(STATIC_API, new ArrayList<>());
+        sections.put(ADJUSTED_RETURN_TYPES, new ArrayList<>());
+        sections.put(NON_STATIC_API, new ArrayList<>());
 
         for (JavaMethod method : methods) {
             if (method.getModifiers().contains(JavaModifier.STATIC)) {
-                sections.get("static API").add(method);
+                sections.get(STATIC_API).add(method);
+            } else if (method.isAnnotatedWith(Override.class)) {
+                sections.get(ADJUSTED_RETURN_TYPES).add(method);
             } else {
-                sections.get("non-static API").add(method);
+                sections.get(NON_STATIC_API).add(method);
             }
         }
         return sections;

--- a/src/test/java/linter/ClassSectionTest.java
+++ b/src/test/java/linter/ClassSectionTest.java
@@ -25,7 +25,8 @@ public class ClassSectionTest {
     @Test
     public void methodsAreAlphabeticallyOrderedInSections() {
         classes()
-                .should(haveOrderedMethodSections()).check(new ClassFileImporter()
+                .should(haveOrderedMethodSections())
+                .check(new ClassFileImporter()
                         .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
                         .importPackages("io.vavr"));
     }
@@ -70,20 +71,25 @@ public class ClassSectionTest {
                 sections.get(STATIC_API).add(method);
             } else if (isOverridden(method)) {
                 sections.get(ADJUSTED_RETURN_TYPES).add(method);
-            }
-            else {
+            } else {
                 sections.get(NON_STATIC_API).add(method);
             }
         }
         return sections;
     }
 
+    /* Source: https://github.com/TNG/ArchUnit/issues/359#issuecomment-975456116 */
     private boolean isOverridden(JavaMethod method) {
-        return method.getOwner().getAllRawInterfaces().stream()
+        return method.getOwner()
+                .getAllRawInterfaces()
+                .stream()
                 .anyMatch(c -> c.tryGetMethod(method.getName(), getTypeNames(method.getParameters())).isPresent());
     }
 
+    /* Source: https://github.com/TNG/ArchUnit/issues/359#issuecomment-975456116 */
     private String[] getTypeNames(List<JavaParameter> parameters) {
-        return parameters.stream().map(p -> p.getRawType().getName()).toArray(String[]::new);
+        return parameters.stream()
+                .map(p -> p.getRawType().getName())
+                .toArray(String[]::new);
     }
 }


### PR DESCRIPTION
* Enforce alphabetical method order within method kinds:
  * static methods
  * non-static methods
  * adjusted return types

Notes:
* To interpret "adjusted return types" I currently used "All overridden methods", perhaps this is not fully accurate.
* ArchUnit does not yet have a built-in override predicate so I copied code from https://github.com/TNG/ArchUnit/issues/359#issuecomment-975456116
* Build will fail due to 264 detected violations
* Not yet done: Validating that entire sections are ordered (static methods > non-static methods > adjusted return types)

Example test output:
>Architecture Violation [Priority: MEDIUM] - Rule 'classes should have methods alphabetically ordered in sections' was violated (264 times):
Methods in section 'adjusted return types' of class 'io.vavr.Function1$1' are not alphabetically ordered: [isDefinedAt, apply]

Part of implementing #2924 