### PR TITLE
Fix CheckedRunnableTest#shouldApplyAnUncheckedFunctionThatThrows

### DIFF
--- a/vavr/src/test/java/io/vavr/CheckedRunnableTest.java
+++ b/vavr/src/test/java/io/vavr/CheckedRunnableTest.java
@@ -50,18 +50,13 @@ public class CheckedRunnableTest {
         try {
             runnable.run();
         } catch(Throwable x) {
-            Assertions.fail("Did not excepect an exception but received: " + x.getMessage());
+            Assertions.fail("Did not expect an exception but received: " + x.getMessage());
         }
     }
 
     @Test
     public void shouldApplyAnUncheckedFunctionThatThrows() {
         final Runnable runnable = CheckedRunnable.of(() -> { throw new Error(); }).unchecked();
-        try {
-            runnable.run();
-            Assertions.fail("Did excepect an exception.");
-        } catch(Error x) {
-            // ok!
-        }
+        Assertions.assertThrows(Error.class, () -> runnable.run());
     }
 }


### PR DESCRIPTION
* `shouldApplyAnUncheckedFunctionThatThrows` always passed,  when removing the `throw new Error()` because the failed asserting was immediately caught.

```java
        final Runnable runnable = CheckedRunnable.of(() -> { /*throw new Error();*/ }).unchecked(); // Test would still pass
```

Fixed by using `assertThrows` from JUnit

----

backport of: https://github.com/vavr-io/vavr/pull/2954