### PR TITLE
Remove outdated comment

### DIFF
--- a/vavr/src/test/java/io/vavr/IterableTest.java
+++ b/vavr/src/test/java/io/vavr/IterableTest.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-// Specific tests. For general tests, see AbstractIterableTest.
 public class IterableTest {
 
     // -- eq


### PR DESCRIPTION
* Remove comment mentioning another class (`AbstractIterableTest`) that does not exist