### PR TITLE
Add missing test coverage for Peek methods

### DIFF
--- a/src/test/java/io/vavr/control/EitherTest.java
+++ b/src/test/java/io/vavr/control/EitherTest.java
@@ -30,6 +30,8 @@ import io.vavr.AbstractValueTest;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Vector;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.NoSuchElementException;
@@ -482,9 +484,33 @@ public class EitherTest extends AbstractValueTest {
     @Test
     public void shouldPeekLeftForLeft() {
         final int[] effect = { 0 };
-        final Either<Integer, ?> actual = Either.left(1).peekLeft(i -> effect[0] = i);
+        final Either<Integer, ?> actual = Either.left(1)
+                .peekLeft(i -> effect[0] = i);
         assertThat(actual).isEqualTo(Either.left(1));
         assertThat(effect[0]).isEqualTo(1);
+    }
+
+
+    @Nested
+    @DisplayName("peek(Runnable, Consumer)")
+    class PeekRunnableConsumer {
+        @Test
+        void shouldConsumePresentValueOnPeekWhenValueIsDefined() {
+            final int[] actual = new int[] { -1 };
+            final Either<Integer, ?> testee = Either.left(1)
+                    .peek(i -> actual[0] = 1, i -> actual[0] = 2);
+            assertThat(testee).isEqualTo(Either.left(1));
+            assertThat(actual[0]).isEqualTo(1);
+        }
+
+        @Test
+        void shouldRunRunnableWhenValueIsNotDefined() {
+            final int[] actual = new int[] { -1 };
+            final Either<?, Integer> testee = Either.right(1)
+                    .peek(i -> actual[0] = 1, i -> actual[0] = 2);
+            assertThat(testee).isEqualTo(Either.right(1));
+            assertThat(actual[0]).isEqualTo(2);
+        }
     }
 
     @Test

--- a/src/test/java/io/vavr/control/OptionTest.java
+++ b/src/test/java/io/vavr/control/OptionTest.java
@@ -29,6 +29,8 @@ package io.vavr.control;
 import io.vavr.*;
 import io.vavr.collection.Seq;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -509,22 +511,45 @@ public class OptionTest extends AbstractValueTest {
         assertThat(API.None().toValidation(() -> "bad")).isEqualTo(API.Invalid("bad"));
     }
 
-    // -- peek
+    @Nested
+    class Peek {
+        @Test
+        public void shouldConsumePresentValueOnPeekWhenValueIsDefined() {
+            final int[] actual = new int[] { -1 };
+            final Option<Integer> testee = Option.of(1).peek(i -> actual[0] = i);
+            assertThat(actual[0]).isEqualTo(1);
+            assertThat(testee).isEqualTo(Option.of(1));
+        }
 
-    @Test
-    public void shouldConsumePresentValueOnPeekWhenValueIsDefined() {
-        final int[] actual = new int[] { -1 };
-        final Option<Integer> testee = Option.of(1).peek(i -> actual[0] = i);
-        assertThat(actual[0]).isEqualTo(1);
-        assertThat(testee).isEqualTo(Option.of(1));
+        @Test
+        public void shouldNotConsumeAnythingOnPeekWhenValueIsNotDefined() {
+            final int[] actual = new int[] { -1 };
+            final Option<Integer> testee = Option.<Integer> none().peek(i -> actual[0] = i);
+            assertThat(actual[0]).isEqualTo(-1);
+            assertThat(testee).isEqualTo(Option.none());
+        }
     }
 
-    @Test
-    public void shouldNotConsumeAnythingOnPeekWhenValueIsNotDefined() {
-        final int[] actual = new int[] { -1 };
-        final Option<Integer> testee = Option.<Integer> none().peek(i -> actual[0] = i);
-        assertThat(actual[0]).isEqualTo(-1);
-        assertThat(testee).isEqualTo(Option.none());
+    @Nested
+    @DisplayName("peek(Runnable, Consumer)")
+    class PeekRunnableConsumer {
+        @Test
+        void shouldConsumePresentValueOnPeekWhenValueIsDefined() {
+            final int[] actual = new int[] { -1 };
+            final Option<Integer> testee = Option.of(1)
+                    .peek(() -> actual[0] = -2, i -> actual[0] = i);
+            assertThat(actual[0]).isEqualTo(1);
+            assertThat(testee).isEqualTo(Option.of(1));
+        }
+
+        @Test
+        void shouldRunRunnableWhenValueIsNotDefined() {
+            final int[] actual = new int[] { -1 };
+            final Option<Integer> testee = Option.<Integer> none()
+                    .peek(() -> actual[0] = -2, i -> actual[0] = i);
+            assertThat(actual[0]).isEqualTo(-2);
+            assertThat(testee).isEqualTo(Option.none());
+        }
     }
 
     // -- transform


### PR DESCRIPTION
- Add test coverage for `Option#peek(Runnable, Consumer)`
- Add test coverage for `Either#peek(Consumer, Consumer)`