### PR TITLE
Speed up testing using parallelization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
 tasks.withType(Test).configureEach {
     useJUnitPlatform()
-
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     maxHeapSize = '1G'
 }
 


### PR DESCRIPTION
- [x] Use parallel execution for test
    - Used basic implementation from [Gradle Docs](https://docs.gradle.org/current/userguide/performance.html#execute_tests_in_parallel) as a start
    - Tests seem already properly independent and hence parallelizable

CI effect: 
- before: `+/- 3m 30s` per action (total usage for 5 actions: `15m 31s`)
- after: `2m 58s` per action (total usage for 5 actions: `13m 36s`)

Local effect: On my device (Apple M1 Max, 64GB Memory) running `gradle clean test`:
- before: ` 1m 42s`
- after: `55s`