### PR TITLE
Add Option#mapTry()

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -18,6 +18,7 @@
  */
 package io.vavr.control;
 
+import io.vavr.CheckedFunction1;
 import io.vavr.PartialFunction;
 import io.vavr.Tuple;
 import io.vavr.Value;
@@ -389,6 +390,10 @@ public interface Option<T> extends Value<T>, Serializable {
     default <U> Option<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return isEmpty() ? none() : some(mapper.apply(get()));
+    }
+
+    public final <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
+        return toTry().mapTry(mapper);
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -402,7 +402,7 @@ public interface Option<T> extends Value<T>, Serializable {
      * @return a {@code Try}
      * @throws NullPointerException if {@code mapper} is null
      */
-    public final <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
+    default <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
         return toTry().mapTry(mapper);
     }
 

--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -392,6 +392,16 @@ public interface Option<T> extends Value<T>, Serializable {
         return isEmpty() ? none() : some(mapper.apply(get()));
     }
 
+
+    /**
+     * Converts this to a {@link Try}, then runs the given checked function if this is a {@link Try.Success},
+     * passing the result of the current expression to it.
+     *
+     * @param <U>    The new component type
+     * @param mapper A checked function
+     * @return a {@code Try}
+     * @throws NullPointerException if {@code mapper} is null
+     */
     public final <U> Try<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
         return toTry().mapTry(mapper);
     }

--- a/vavr/src/test/java/io/vavr/control/OptionTest.java
+++ b/vavr/src/test/java/io/vavr/control/OptionTest.java
@@ -25,8 +25,10 @@ import io.vavr.Function1;
 import io.vavr.PartialFunction;
 import io.vavr.Serializables;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -359,6 +361,30 @@ public class OptionTest extends AbstractValueTest {
     @Test
     public void shouldMapNone() {
         assertThat(Option.<Integer> none().map(String::valueOf)).isEqualTo(Option.none());
+    }
+    
+    @Nested
+    class MapTry {
+        @Test
+        public void shouldMapTrySome() {
+            assertThat(Option.of(1).mapTry(String::valueOf)).isEqualTo(Try.success("1"));
+        }
+
+        @Test
+        public void shouldMapTryNone() {
+            Try<String> result = Option.none().mapTry(String::valueOf);
+            assertThat(result.isFailure()).isTrue();
+            assertThat(result.getCause().getClass()).isEqualTo(NoSuchElementException.class);
+            assertThat(result.getCause().getMessage()).isEqualTo("No value present");
+        }
+
+        @Test
+        public void shouldMapTryCheckedException() {
+            Try<Integer> result = Option.of("a").mapTry(Integer::new);
+            assertThat(result.isFailure()).isTrue();
+            assertThat(result.getCause().getClass()).isEqualTo(NumberFormatException.class);
+            assertThat(result.getCause().getMessage()).isEqualTo("For input string: \"a\"");
+        }
     }
 
     // -- flatMap

--- a/vavr/src/test/java/io/vavr/control/OptionTest.java
+++ b/vavr/src/test/java/io/vavr/control/OptionTest.java
@@ -362,7 +362,7 @@ public class OptionTest extends AbstractValueTest {
     public void shouldMapNone() {
         assertThat(Option.<Integer> none().map(String::valueOf)).isEqualTo(Option.none());
     }
-    
+
     @Nested
     class MapTry {
         @Test

--- a/vavr/src/test/java/io/vavr/control/OptionTest.java
+++ b/vavr/src/test/java/io/vavr/control/OptionTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -380,10 +379,15 @@ public class OptionTest extends AbstractValueTest {
 
         @Test
         public void shouldMapTryCheckedException() {
-            Try<Integer> result = Option.of("a").mapTry(Integer::new);
+            Try<Integer> result = Option.of("a")
+                    .mapTry(this::checkedFunction);
             assertThat(result.isFailure()).isTrue();
-            assertThat(result.getCause().getClass()).isEqualTo(NumberFormatException.class);
-            assertThat(result.getCause().getMessage()).isEqualTo("For input string: \"a\"");
+            assertThat(result.getCause().getClass()).isEqualTo(Exception.class);
+            assertThat(result.getCause().getMessage()).isEqualTo("message");
+        }
+
+        private Integer checkedFunction(String string) throws Exception {
+            throw new Exception("message");
         }
     }
 


### PR DESCRIPTION
Add `mapTry` method to Option, which is a shortcut for `.toTry().mapTry`:
  * when mapping an optional using a checked method, I find it intuitive that the type changes to a Try, and `mapTry` methods exist on other types already
  * I initially added it onto `Value` but this ran into an issue where a method with same name but return value already exists on subtype`Future`
  
----

Rebase of #2950 