### PR TITLE
Replace deterministic random values with actual randomness in tests

### DIFF
--- a/vavr/src/test/java/io/vavr/AbstractValueTest.java
+++ b/vavr/src/test/java/io/vavr/AbstractValueTest.java
@@ -64,18 +64,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @ExtendWith(AbstractMultimapTest.TestTemplateProvider.class)
 public abstract class AbstractValueTest {
 
-    protected Random getRandom(int seed) {
-        if (seed >= 0) {
-            return new Random(seed);
-        } else {
-            final Random random = new Random();
-            seed = random.nextInt();
-            System.out.println("using seed: " + seed);
-            random.setSeed(seed);
-            return random;
-        }
-    }
-
     protected <T> IterableAssert<T> assertThat(Iterable<T> actual) {
         return new IterableAssert<T>(actual) {
         };

--- a/vavr/src/test/java/io/vavr/AbstractValueTest.java
+++ b/vavr/src/test/java/io/vavr/AbstractValueTest.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.Random;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.assertj.core.api.BooleanAssert;

--- a/vavr/src/test/java/io/vavr/collection/BitSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/BitSetTest.java
@@ -462,7 +462,7 @@ public class BitSetTest extends AbstractSortedSetTest {
     @Test
     public void shouldBehaveExactlyLikeAnotherBitSet() {
         for (int i = 0; i < 10; i++) {
-            final Random random = getRandom(123456789);
+            final Random random = new Random();
 
             final java.util.BitSet mutableBitSet = new java.util.BitSet();
             BitSet<Integer> functionalBitSet = BitSet.empty();

--- a/vavr/src/test/java/io/vavr/collection/PriorityQueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/PriorityQueueTest.java
@@ -285,7 +285,7 @@ public class PriorityQueueTest extends AbstractTraversableTest {
     @Test
     public void shouldBehaveExactlyLikeAnotherPriorityQueue() {
         for (int i = 0; i < 10; i++) {
-            final Random random = getRandom(987654321);
+            final Random random = new Random();
 
             final java.util.PriorityQueue<Integer> mutablePriorityQueue = new java.util.PriorityQueue<>();
             PriorityQueue<Integer> functionalPriorityQueue = PriorityQueue.empty();


### PR DESCRIPTION
- [x] Use random numbers instead of fixed sequence in loop

Two tests used identical fixed random instance inside a loop, causing the extact same sequence of numbers being generated:

```java
        for (int i = 0; i < 10; i++) {
            final Random random = getRandom(123456789);
                // <rest of code>
        }
```

Unless I am missing the purpose, this means that each loop is identical and thus redundant.
Generating the same sequence of numbers via a Random does not seem to be the intented design here.

If my assumptions are correct, this fixes both issues by using an unseeded random instance, creating a test run with actual randomness.

If each loop iteration should be different but deterministic values are desired, a different fix could be to move the random instance out of the loop:

```java
        final Random random = getRandom(123456789);
        for (int i = 0; i < 10; i++) {
                // <rest of code>
        }
```