### PR TITLE
Tweak junit execution for parallel testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,12 +304,6 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
                         <parallel>all</parallel>
                         <threadCount>4</threadCount>
                         <reuseForks>true</reuseForks>
-                        <properties>
-                            <configurationParameters>
-                                junit.jupiter.execution.parallel.enabled = true
-                                junit.jupiter.execution.parallel.mode.default = concurrent
-                            </configurationParameters>
-                        </properties>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,12 @@ We use these goals frequently to keep the dependencies and plugins up-to-date:
                         <parallel>all</parallel>
                         <threadCount>4</threadCount>
                         <reuseForks>true</reuseForks>
+                        <properties>
+                            <configurationParameters>
+                                junit.jupiter.execution.parallel.enabled = true
+                                junit.jupiter.execution.parallel.mode.default = concurrent
+                            </configurationParameters>
+                        </properties>
                     </configuration>
                 </plugin>
             </plugins>

--- a/vavr/src/test/resources/junit-platform.properties
+++ b/vavr/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent

--- a/vavr/src/test/resources/junit-platform.properties
+++ b/vavr/src/test/resources/junit-platform.properties
@@ -1,3 +1,2 @@
-
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
- [x] Set junit parameters in maven test
  - [x] Local IntelliJ test run: 33s -> 15s 
  - [x] Local `maven test` run: 58s -> 30s
  - [x] CI run
    - [x] JDK8:  [02:10m](https://github.com/vavr-io/vavr/actions/runs/13807668590/job/38621833526#step:4:4018) -> [02:00m](https://github.com/vavr-io/vavr/actions/runs/13809442865/job/38627485133?pr=3001#step:4:4021) 
    - [x] JDK11: [01:46m](https://github.com/vavr-io/vavr/actions/runs/13807668590/job/38621834088#step:4:5217) -> [01:21m](https://github.com/vavr-io/vavr/actions/runs/13809442865/job/38627485605?pr=3001#step:4:5196)
    - [x] JDK23: [01:35m](https://github.com/vavr-io/vavr/actions/runs/13807668590/job/38621835881#step:4:5207) -> [01.10m](https://github.com/vavr-io/vavr/actions/runs/13809442865/job/38627487693?pr=3001#step:4:5168)

Local data gathered on MacBook Pro M1 Max, 64GB RAM

