### PR TITLE
Remove non-threadsafe tests capturing stdout/stderr

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -2622,7 +2622,6 @@ def generateTestClasses(): Unit = {
       val assertThat = im.getStatic("org.assertj.core.api.Assertions.assertThat")
       val nested = im.getType("org.junit.jupiter.api.Nested")
       val test = im.getType("org.junit.jupiter.api.Test")
-      val assertThrows = im.getStatic("org.junit.jupiter.api.Assertions.assertThrows")
 
       val API = im.getType("io.vavr.API")
       val AssertionsExtensions = im.getType("io.vavr.AssertionsExtensions")
@@ -2838,7 +2837,6 @@ def generateTestClasses(): Unit = {
       def genShortcutsTests(im: ImportManager, packageName: String, className: String): String = {
 
         val fail = im.getStatic("org.junit.jupiter.api.Assertions.fail")
-        val captureStdOut = im.getStatic("io.vavr.OutputTester.captureStdOut")
 
         xs"""
           @$test
@@ -2860,26 +2858,6 @@ def generateTestClasses(): Unit = {
               } catch(NotImplementedError err) {
                   assertThat(err.getMessage()).isEqualTo(msg);
               }
-          }
-
-          @$test
-          public void shouldCallprint_Object() {
-              assertThat($captureStdOut(()->print("ok"))).isEqualTo("ok");
-          }
-
-          @$test
-          public void shouldCallprintf() {
-              assertThat($captureStdOut(()->printf("%s", "ok"))).isEqualTo("ok");
-          }
-
-          @$test
-          public void shouldCallprintln_Object() {
-              assertThat($captureStdOut(()->println("ok"))).isEqualTo("ok\\n");
-          }
-
-          @$test
-          public void shouldCallprintln() {
-              assertThat($captureStdOut(()->println())).isEqualTo("\\n");
           }
         """
       }

--- a/vavr/src-gen/test/java/io/vavr/APITest.java
+++ b/vavr/src-gen/test/java/io/vavr/APITest.java
@@ -1448,8 +1448,6 @@ public class APITest {
 
     }
 
-    // -- Match patterns
-
     @Nested
     class MatchPatternTests {
 

--- a/vavr/src-gen/test/java/io/vavr/APITest.java
+++ b/vavr/src-gen/test/java/io/vavr/APITest.java
@@ -75,26 +75,6 @@ public class APITest {
             }
         }
 
-        @Test
-        public void shouldCallprint_Object() {
-            assertThat(captureStdOut(()->print("ok"))).isEqualTo("ok");
-        }
-
-        @Test
-        public void shouldCallprintf() {
-            assertThat(captureStdOut(()->printf("%s", "ok"))).isEqualTo("ok");
-        }
-
-        @Test
-        public void shouldCallprintln_Object() {
-            assertThat(captureStdOut(()->println("ok"))).isEqualTo("ok\n");
-        }
-
-        @Test
-        public void shouldCallprintln() {
-            assertThat(captureStdOut(()->println())).isEqualTo("\n");
-        }
-
     }
 
     //

--- a/vavr/src-gen/test/java/io/vavr/APITest.java
+++ b/vavr/src-gen/test/java/io/vavr/APITest.java
@@ -24,10 +24,8 @@ package io.vavr;
 \*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
 import static io.vavr.API.*;
-import static io.vavr.OutputTester.captureStdOut;
 import static io.vavr.Patterns.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import io.vavr.collection.List;

--- a/vavr/src/test/java/io/vavr/OutputTester.java
+++ b/vavr/src/test/java/io/vavr/OutputTester.java
@@ -153,15 +153,5 @@ public class OutputTester {
     public static void withFailingStdOut(Runnable runnable) {
         Output.OUT.failOnWrite(runnable);
     }
-
-    /**
-     * Execute the given runnable and capture everything that written
-     * to stdout. The written text is normalized to unix line feeds before its returned.
-     *
-     * @param runnable the runnable to be executed.
-     * @return the content written to stdout, normalized to unix line endings.
-     */
-    public static String captureStdOut(Runnable runnable) {
-        return Output.OUT.capture(runnable);
-    }
+    
 }

--- a/vavr/src/test/java/io/vavr/OutputTester.java
+++ b/vavr/src/test/java/io/vavr/OutputTester.java
@@ -18,10 +18,10 @@
  */
 package io.vavr;
 
-import java.io.*;
-import java.nio.charset.Charset;
-
-import static org.assertj.core.api.Assertions.fail;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
 
 /**
  * Small utility that allows to test code which write to standard error or standard out.
@@ -29,82 +29,6 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Sebastian Zarnekow
  */
 public class OutputTester {
-
-    /**
-     * Encapsulate the standard output and error stream accessors.
-     */
-    private enum Output {
-        OUT {
-            @Override
-            void set(PrintStream stream) {
-                System.setOut(stream);
-            }
-
-            @Override
-            PrintStream get() {
-                return System.out;
-            }
-        },
-        ERR {
-            @Override
-            void set(PrintStream stream) {
-                System.setErr(stream);
-            }
-
-            @Override
-            PrintStream get() {
-                return System.err;
-            }
-        };
-
-        /**
-         * Modifier for the output slot.
-         */
-        abstract void set(PrintStream stream);
-
-        /**
-         * Accessor for the output slot.
-         */
-        abstract PrintStream get();
-
-        /**
-         * Capture the output written to this standard stream and normalize to unix line endings.
-         */
-        String capture(Runnable action) {
-            synchronized (this) {
-                try {
-                    PrintStream orig = get();
-                    try (ByteArrayOutputStream out = new ByteArrayOutputStream(); PrintStream inmemory = new PrintStream(out) {
-                    }) {
-                        set(inmemory);
-                        action.run();
-                        return new String(out.toByteArray(), Charset.defaultCharset()).replace("\r\n", "\n");
-                    } finally {
-                        set(orig);
-                    }
-                } catch (IOException e) {
-                    fail("Unexpected IOException", e);
-                    return "UNREACHABLE";
-                }
-            }
-        }
-
-        /**
-         * Each attempt to write the this standard output will fail with an IOException
-         */
-        void failOnWrite(Runnable action) {
-            synchronized (this) {
-                final PrintStream original = get();
-                try (PrintStream failingPrintStream = failingPrintStream()) {
-                    set(failingPrintStream);
-                    action.run();
-                } finally {
-                    set(original);
-                }
-            }
-        }
-
-    }
 
     private static OutputStream failingOutputStream() {
         return new OutputStream() {
@@ -131,27 +55,6 @@ public class OutputTester {
      */
     public static PrintWriter failingPrintWriter() {
         return new PrintWriter(failingOutputStream());
-    }
-
-    /**
-     * Execute the given runnable in a context, where each attempt to
-     * write to stderr will fail with an {@link IOException}
-     *
-     * @param runnable the runnable to be executed.
-     */
-    public static void withFailingErrOut(Runnable runnable) {
-        Output.ERR.failOnWrite(runnable);
-    }
-
-    /**
-     * Execute the given runnable in a context, where each attempt to
-     * write to stdout will fail with an {@link IOException}
-     *
-     * @param runnable the runnable to be executed.
-     */
-
-    public static void withFailingStdOut(Runnable runnable) {
-        Output.OUT.failOnWrite(runnable);
     }
 
 }

--- a/vavr/src/test/java/io/vavr/OutputTester.java
+++ b/vavr/src/test/java/io/vavr/OutputTester.java
@@ -153,5 +153,5 @@ public class OutputTester {
     public static void withFailingStdOut(Runnable runnable) {
         Output.OUT.failOnWrite(runnable);
     }
-    
+
 }

--- a/vavr/src/test/java/io/vavr/OutputTester.java
+++ b/vavr/src/test/java/io/vavr/OutputTester.java
@@ -171,15 +171,4 @@ public class OutputTester {
     public static String captureStdOut(Runnable runnable) {
         return Output.OUT.capture(runnable);
     }
-
-    /**
-     * Execute the given runnable and capture everything that written
-     * to stderr. The written text is normalized to unix line feeds before its returned.
-     *
-     * @param runnable the runnable to be executed.
-     * @return the content written to stderr, normalized to unix line endings.
-     */
-    public static String captureErrOut(Runnable runnable) {
-        return Output.ERR.capture(runnable);
-    }
 }

--- a/vavr/src/test/java/io/vavr/OutputTester.java
+++ b/vavr/src/test/java/io/vavr/OutputTester.java
@@ -20,9 +20,7 @@ package io.vavr;
 
 import java.io.*;
 import java.nio.charset.Charset;
-import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /**
@@ -31,11 +29,6 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Sebastian Zarnekow
  */
 public class OutputTester {
-
-    @Test
-    public void shouldNormalizeToUnixLineSeparators() {
-        assertThat(captureStdOut(() -> System.out.print("\r\n"))).isEqualTo("\n");
-    }
 
     /**
      * Encapsulate the standard output and error stream accessors.

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -2118,25 +2118,11 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
     // -- stderr
 
     @TestTemplate
-    public void shouldWriteToStderr() {
-        assertThat(captureErrOut(() -> of(1, 2, 3).stderr())).isEqualTo("1\n" +
-          "2\n" +
-          "3\n");
-    }
-
-    @TestTemplate
     public void shouldHandleStderrIOException() {
         assertThrows(IllegalStateException.class, () -> withFailingErrOut(() -> of(0).stderr()));
     }
 
     // -- stdout
-
-    @TestTemplate
-    public void shouldWriteToStdout() {
-        assertThat(captureStdOut(() -> of(1, 2, 3).stdout())).isEqualTo("1\n" +
-          "2\n" +
-          "3\n");
-    }
 
     @TestTemplate
     public void shouldHandleStdoutIOException() {

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -46,8 +46,6 @@ import static io.vavr.API.$;
 import static io.vavr.API.Case;
 import static io.vavr.API.List;
 import static io.vavr.API.Map;
-import static io.vavr.OutputTester.captureErrOut;
-import static io.vavr.OutputTester.captureStdOut;
 import static io.vavr.OutputTester.failingPrintStream;
 import static io.vavr.OutputTester.failingPrintWriter;
 import static io.vavr.OutputTester.withFailingErrOut;

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -18,10 +18,7 @@
  */
 package io.vavr.collection;
 
-import io.vavr.AbstractValueTest;
-import io.vavr.PartialFunction;
-import io.vavr.Tuple;
-import io.vavr.Tuple2;
+import io.vavr.*;
 import io.vavr.control.Option;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -48,8 +45,6 @@ import static io.vavr.API.List;
 import static io.vavr.API.Map;
 import static io.vavr.OutputTester.failingPrintStream;
 import static io.vavr.OutputTester.failingPrintWriter;
-import static io.vavr.OutputTester.withFailingErrOut;
-import static io.vavr.OutputTester.withFailingStdOut;
 import static java.lang.System.lineSeparator;
 import static java.util.Arrays.asList;
 import static java.util.Comparator.comparingInt;
@@ -2113,18 +2108,11 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.IMMUTABLE)).isTrue();
     }
 
-    // -- stderr
-
-    @TestTemplate
-    public void shouldHandleStderrIOException() {
-        assertThrows(IllegalStateException.class, () -> withFailingErrOut(() -> of(0).stderr()));
-    }
-
-    // -- stdout
+    // -- out
 
     @TestTemplate
     public void shouldHandleStdoutIOException() {
-        assertThrows(IllegalStateException.class, () -> withFailingStdOut(() -> of(0).stdout()));
+        assertThrows(IllegalStateException.class, () -> of(0).out(OutputTester.failingPrintStream()));
     }
 
     // -- PrintStream

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -42,8 +42,6 @@ import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.api.StringAssert;
 import org.junit.jupiter.api.Test;
 
-import static io.vavr.OutputTester.captureErrOut;
-import static io.vavr.OutputTester.captureStdOut;
 import static io.vavr.OutputTester.withFailingErrOut;
 import static io.vavr.OutputTester.withFailingStdOut;
 import static java.util.Arrays.asList;

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -1771,25 +1771,11 @@ public class CharSeqTest {
     // -- stderr
 
     @Test
-    public void shouldWriteToStderr() {
-        assertThat(captureErrOut(() -> CharSeq.of('1', '2', '3').stderr())).isEqualTo("1\n" +
-          "2\n" +
-          "3\n");
-    }
-
-    @Test
     public void shouldHandleStderrIOException() {
         assertThrows(IllegalStateException.class, () -> withFailingErrOut(() -> CharSeq.of('0').stderr()));
     }
 
     // -- stdout
-
-    @Test
-    public void shouldWriteToStdout() {
-        assertThat(captureStdOut(() -> CharSeq.of('1', '2', '3').stdout())).isEqualTo("1\n" +
-          "2\n" +
-          "3\n");
-    }
 
     @Test
     public void shouldHandleStdoutIOException() {

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -18,6 +18,7 @@
  */
 package io.vavr.collection;
 
+import io.vavr.OutputTester;
 import io.vavr.Serializables;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
@@ -42,8 +43,6 @@ import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.api.StringAssert;
 import org.junit.jupiter.api.Test;
 
-import static io.vavr.OutputTester.withFailingErrOut;
-import static io.vavr.OutputTester.withFailingStdOut;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -1766,18 +1765,11 @@ public class CharSeqTest {
         assertThat(CharSeq.of('a', 'b', 'c').startsWith(CharSeq.of('b', 'd'), 1)).isFalse();
     }
 
-    // -- stderr
-
-    @Test
-    public void shouldHandleStderrIOException() {
-        assertThrows(IllegalStateException.class, () -> withFailingErrOut(() -> CharSeq.of('0').stderr()));
-    }
-
-    // -- stdout
+    // -- out
 
     @Test
     public void shouldHandleStdoutIOException() {
-        assertThrows(IllegalStateException.class, () -> withFailingStdOut(() -> CharSeq.of('0').stdout()));
+        assertThrows(IllegalStateException.class, () -> CharSeq.of('0').out(OutputTester.failingPrintStream()));
     }
 
     // -- sum


### PR DESCRIPTION
- [x] Remove tests that capture standard output (flaky in concurrent environments)
- [x] Remove unused test utility code 