### PR TITLE
create MatchV2

### DIFF
--- a/vavr/src/main/java/io/vavr/MatchV2.java
+++ b/vavr/src/main/java/io/vavr/MatchV2.java
@@ -1,0 +1,289 @@
+package io.vavr;
+
+import io.vavr.control.Option;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * Optional-like structural pattern matching for Java。
+ * <pre>
+ * <code>
+ *      MatchV2.of(matchString, "def")
+ *          .caseNull("is null")
+ *          .caseValue("null", "null")
+ *          .caseValue(String::isEmpty, "is empty")
+ *          .caseValue(StringUtils::isBlank, ()->"is blank");
+ * </code>
+ * </pre>
+ *
+ * @param <T> The type of the match value of an MatchV2.
+ * @param <R> The type of the return/def value of an MatchV2.
+ * @author tanglt
+ */
+public class MatchV2<T,R> {
+
+
+    /**
+     * match value
+     */
+    private final T matchValue;
+
+    /**
+     * return value
+     */
+    private final R returnValue;
+
+    /**
+     * matches the condition is true
+     */
+    private final boolean hit;
+
+    /**
+     * default return value
+     */
+    private final R defValue;
+
+    private MatchV2(final T matchValue, final R defValue) {
+        this.matchValue = matchValue;
+        this.returnValue = null;
+        this.defValue = defValue;
+        this.hit = false;
+    }
+
+
+    private MatchV2(final T matchValue, final R returnValue, final R defValue, boolean hit) {
+        this.matchValue = matchValue;
+        this.returnValue = returnValue;
+        this.defValue = defValue;
+        this.hit = hit;
+    }
+
+    /**
+     * 一个空的{@code Match}
+     */
+//    private static final MatchV2<?,?> EMPTY = new MatchV2<>(null,null);
+
+    /**
+     * 返回一个空的{@code Match}
+     *
+     * @return Match
+     */
+//    public static <T,R> MatchV2<T,R> empty() {
+//        @SuppressWarnings("unchecked")
+//        final MatchV2<T,R> t = (MatchV2<T,R>) EMPTY;
+//        return t;
+//    }
+
+
+    /**
+     * Creates a new {@code MatchV2} of a match value.
+     *
+     * @param matchValue A match value
+     * @param defValue A default value
+     * @param <T>   type of the value
+     * @return {@code MatchV2}
+     */
+    public static <T,R> MatchV2<T,R> of(final T matchValue, final R defValue) {
+        return new MatchV2<>(matchValue,defValue);
+    }
+
+    /**
+     * Creates a new {@code MatchV2} of a match value. not set default
+     *
+     * @param matchValue A match value
+     * @param <T>   type of the value
+     * @return {@code MatchV2}
+     */
+    public static <T,R> MatchV2<T,R> of(final T matchValue) {
+        return new MatchV2<>(matchValue,null);
+    }
+
+    /**
+     * Maps the value to a new {@code MatchV2}.Two match statements can be concatenated.
+     * where if the first match condition is met, the second match becomes invalid.
+     * Otherwise, the second match takes effect.
+     *
+     * @param mapper A mapper
+     * @param <M>    a new matchValue type
+     * @return a new {@code Option}
+     */
+    public <M> MatchV2<M,R> flatMap(final BiFunction<? super T, ? super R, ? extends MatchV2<M,R>> mapper) {
+        Objects.requireNonNull(mapper);
+        MatchV2<M, R> mrMatchV2 = mapper.apply(this.matchValue ,isPresent()?this.returnValue:this.defValue);
+        if (isPresent()) {
+            return new MatchV2<>(mrMatchV2.matchValue,this.returnValue, mrMatchV2.defValue,true);
+        } else {
+            return mrMatchV2;
+        }
+    }
+
+    /**
+     * Maps the matchValue to a new {@code MatchV2}.
+     * @param matchMapper A mapper
+     * @param <U>    a new matchValue type
+     * @return a new {@code MatchV2}
+     */
+    public <U> MatchV2<U,R> mapMatch(final Function<? super T, ? extends U> matchMapper) {
+        Objects.requireNonNull(matchMapper);
+        return new MatchV2<>(matchMapper.apply(this.matchValue),this.returnValue,this.defValue,this.hit);
+    }
+
+    /**
+     * Maps the returnValue to a new {@code MatchV2}.
+     * @param returnMapper A mapper
+     * @param <F>    a new returnValue type
+     * @return a new {@code MatchV2}
+     */
+    public <F> MatchV2<T,F> map(final Function<? super R, ? extends F> returnMapper) {
+        Objects.requireNonNull(returnMapper);
+        if(isPresent()){
+            F returnValue = returnMapper.apply(this.returnValue);
+            return new MatchV2<>(this.matchValue,returnValue,returnValue,this.hit);
+        }else {
+            F defValue = returnMapper.apply(this.defValue);
+            return new MatchV2<>(this.matchValue,null,defValue,this.hit);
+        }
+    }
+
+    /**
+     * Evaluate the condition and specify the return value.
+     * @param caseValue A case value
+     * @param returnValue  a return value
+     * @return a new {@code MatchV2}
+     */
+    public MatchV2<T,R> caseValue(final T caseValue, final R returnValue) {
+        Objects.requireNonNull(caseValue);
+        if(isPresent()||!Objects.equals(this.matchValue,caseValue)){
+            return this;
+        }
+        return new MatchV2<>(this.matchValue,returnValue,this.defValue,true);
+    }
+
+    /**
+     * Evaluate the condition and specify the return value.
+     * @param predicate A Predicate Function
+     * @param returnValue  a return value
+     * @return a new {@code MatchV2}
+     */
+    public MatchV2<T,R> caseValue(final Predicate<? super T> predicate, final R returnValue) {
+        Objects.requireNonNull(predicate);
+        if(isPresent()||!predicate.test(this.matchValue)){
+            return this;
+        }
+        return new MatchV2<>(this.matchValue,returnValue,this.defValue,true);
+    }
+
+    /**
+     * Evaluate the condition and specify the return value.
+     * @param predicate A Predicate Function
+     * @param supplier  a return supplier
+     * @return a new {@code MatchV2}
+     */
+    public MatchV2<T,R> caseValue(final Predicate<? super T> predicate, final Supplier<R> supplier) {
+        Objects.requireNonNull(predicate);
+        Objects.requireNonNull(supplier);
+        if(isPresent()||!predicate.test(this.matchValue)){
+            return this;
+        }
+        return new MatchV2<>(this.matchValue,supplier.get(),this.defValue,true);
+    }
+
+    /**
+     * Check null and specify the return value.
+     * @param returnValue  a return value
+     * @return a new {@code MatchV2}
+     */
+    public MatchV2<T,R> caseNull(final R returnValue) {
+        if(isPresent()||!Objects.isNull(this.matchValue)){
+            return this;
+        }
+        return new MatchV2<>(null,returnValue,this.defValue,true);
+    }
+
+    /**
+     * Check null and specify the return value.
+     * @param supplier  a return supplier
+     * @return a new {@code MatchV2}
+     */
+    public MatchV2<T,R> caseNull(final Supplier<R> supplier) {
+        Objects.requireNonNull(supplier);
+        if(isPresent()||!Objects.isNull(this.matchValue)){
+            return this;
+        }
+        return new MatchV2<>(null,supplier.get(),this.defValue,true);
+    }
+
+    /**
+     * get matches the condition value or default value.
+     * @return <R>  the value that matches the condition or default value
+     */
+    public R get() {
+        return isPresent() ? this.returnValue : this.defValue;
+    }
+
+
+    /**
+     * Get the value that meets the condition. If there is none, use the other value.
+     * @param other  a other value
+     * @return <R>  the value that matches the condition or default value
+     */
+    public R orElse(final R other) {
+        return isPresent() ? this.returnValue : other;
+    }
+
+    /**
+     * Get the value that meets the condition. If there is none, use the other value.
+     * @param supplier  a supplier Function
+     * @return <R>  the value that matches the condition or default value
+     */
+    public R orElseGet(final Supplier<? extends R> supplier) {
+        return isPresent() ? this.returnValue : supplier.get();
+    }
+
+    /**
+     * Get the value that meets the condition. If there is none,  raise an exception.
+     * @param exceptionSupplier  a  Throwable supplier Function
+     * @return <R>  the value that matches the condition or default value
+     */
+    public <X extends Throwable> R orElseThrow(final Supplier<? extends X> exceptionSupplier) throws X{
+        if (isPresent()) {
+            return this.returnValue;
+        }
+        throw exceptionSupplier.get();
+    }
+
+    /**
+     * Check if the matching condition is satisfied.
+     * @return boolean
+     */
+    public boolean isPresent() {
+        return this.hit;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        return o == this || ( o instanceof Option.Some && Objects.equals(o.toString(),this.toString()));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.toString());
+    }
+
+    @Override
+    public String toString() {
+        return "matchValue("
+                +this.matchValue+
+                "),returnValue("
+                +this.returnValue+
+                "),hit("
+                +this.hit+
+                "),defValue("
+                +this.defValue+")";
+    }
+}

--- a/vavr/src/test/java/io/vavr/MatchV2Test.java
+++ b/vavr/src/test/java/io/vavr/MatchV2Test.java
@@ -1,0 +1,121 @@
+package io.vavr;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
+
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ *
+ * @author tanglt
+ * @version jdk 8
+ */
+public class MatchV2Test {
+
+    @Test
+    public void of() {
+        String a = null;
+        MatchV2<String, String> matchV2A = stringMatch(a);
+        String caseValue = matchV2A.get();
+        assertThat(caseValue).isEqualTo("is null");
+
+        a = "null";
+        matchV2A = stringMatch(a);
+        caseValue = matchV2A.get();
+        assertThat(caseValue).isEqualTo("null");
+
+        a = "";
+        matchV2A = stringMatch(a);
+        caseValue = matchV2A.get();
+        assertThat(caseValue).isEqualTo("is empty");
+
+        a = " ";
+        matchV2A = stringMatch(a);
+        caseValue = matchV2A.get();
+        assertThat(caseValue).isEqualTo("is blank");
+
+        a = "a";
+        matchV2A = stringMatch(a);
+        caseValue = matchV2A.get();
+        assertThat(caseValue).isEqualTo("def");
+
+
+        /**
+         *   String a = "";
+         *   Integer b = 0;
+         *    if...
+         *
+         *    else if(Objects.equals(b,0)){
+         *        caseValue = 0;
+         *    }
+         */
+
+        Integer b = 0;
+        MatchV2<Integer, String> matchV2B = matchV2A.flatMap((m, r) -> MatchV2.of(b, r));
+        caseValue = matchV2B.caseValue(0, "0").get();
+        assertThat(caseValue).isEqualTo("0");
+
+        MatchV2<String, String> matchV2C = matchV2B.mapMatch(String::valueOf);
+        caseValue = matchV2C.caseValue("0","String 0").get();
+        assertThat(caseValue).isEqualTo("String 0");
+
+        Long caseValueB = matchV2B.caseValue(0, "0").map(Long::valueOf).get();
+        assertThat((long)caseValueB).isEqualTo(0l);
+
+        a = "";
+        matchV2A = stringMatch(a);
+
+        Integer b2 = 0;
+        matchV2B = matchV2A.flatMap((m, r) -> MatchV2.of(b2, r));
+        caseValue = matchV2B.caseValue(0, "0").get();
+        assertThat(caseValue).isEqualTo("is empty");
+
+
+        /**
+         *
+         *    if...
+         *    else {
+         *      caseValue = "is def2";
+         *    }
+         */
+
+        a = "def";
+        matchV2A = stringMatch(a);
+        caseValue = matchV2A.orElse("def2");
+        assertThat(caseValue).isEqualTo("def2");
+
+        a = "def";
+        matchV2A = stringMatch(a);
+        caseValue = matchV2A.orElseGet(()->"def2");
+        assertThat(caseValue).isEqualTo("def2");
+
+        assertThatThrownBy(()->stringMatch("def").orElseThrow(NoSuchElementException::new)).isInstanceOf(NoSuchElementException.class);
+
+    }
+
+    private MatchV2<String, String> stringMatch(String matchString){
+
+        /**
+         *    String caseValue = "def";
+         *    if(Objects.isNull(matchString)){
+         *      caseValue = "null";
+         *    } else if(Objects.equals(matchString,"null")){
+         *      caseValue = "is null";
+         *    } else if(StringUtils.isBlank(matchString)){
+         *      caseValue = "is empty";
+         *    } else if(StringUtils.isBlank(matchString)){
+         *      caseValue = ()->"is blank";
+         *    }
+         */
+
+        return MatchV2.of(matchString, "def")
+                .caseNull("is null")
+                .caseValue("null", "null")
+                .caseValue(String::isEmpty, "is empty")
+                .caseValue(StringUtils::isBlank, ()->"is blank");
+    }
+}


### PR DESCRIPTION
My English is poor so I use translation software. Therefore, my expressions may not be accurate. In my project, I need to handle some situations where if statements are used to obtain a final value. I used the API.Match, but I don't like its syntax. So, I created my own Match class in my project. It is inspired by Optional. I prefer this syntax, and I think adding flatMap makes it more flexible. You can observe the following code:
```
String matchString = "1";
String value = MatchV2.of(matchString, "def")
    .caseNull("is null")
    .caseValue("null", "null")
    .flatMap((m, r) -> MatchV2.of(Integer.valueOf(m), r))
    .caseValue(0, "zero")
    .orElse("none");
```
is equal to
```
String matchString = "1";
String value="def";
if(Objects.isNull(matchString)){
    value="is null";
}else if(Objects.equals(matchString,"null")){
    value="null";
}else if(Objects.equals(Integer.valueOf(matchString),"0")){
    value="zero";
} else{
    value = "none"
}
```
I am not sure if Vavr considers this MatchV2 as a replacement for the API's Match, or as a class similar to Either. Or perhaps you are not considering adding this MatchV2 at all. I have limited understanding of Vavr's code standards and structure. If you are considering adding this class, could you please advise on how to optimize it? Alternatively, you could create a similar pattern matching implementation.
Please let me know your thoughts. Thank you!