### PR TITLE
Added distinctByKeepLast for Sequences

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -747,6 +747,18 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    public Array<T> distinctByKeepLast(Comparator<? super T> comparator) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        return ofAll(iterator().distinctByKeepLast(comparator));
+    }
+
+    @Override
+    public <U> Array<T> distinctByKeepLast(Function<? super T, ? extends U> keyExtractor) {
+        Objects.requireNonNull(keyExtractor, "keyExtractor is null");
+        return ofAll(iterator().distinctByKeepLast(keyExtractor));
+    }
+
+    @Override
     public Array<T> drop(int n) {
         if (n <= 0) {
             return this;

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -472,6 +472,18 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
+    public CharSeq distinctByKeepLast(Comparator<? super Character> comparator) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        return ofAll(iterator().distinctByKeepLast(comparator));
+    }
+
+    @Override
+    public <U> CharSeq distinctByKeepLast(Function<? super Character, ? extends U> keyExtractor) {
+        Objects.requireNonNull(keyExtractor, "keyExtractor is null");
+        return ofAll(iterator().distinctByKeepLast(keyExtractor));
+    }
+
+    @Override
     public CharSeq drop(int n) {
         if (n <= 0) {
             return this;

--- a/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
@@ -106,6 +106,12 @@ public interface IndexedSeq<T> extends Seq<T> {
     <U> IndexedSeq<T> distinctBy(Function<? super T, ? extends U> keyExtractor);
 
     @Override
+    IndexedSeq<T> distinctByKeepLast(Comparator<? super T> comparator);
+
+    @Override
+    <U> IndexedSeq<T> distinctByKeepLast(Function<? super T, ? extends U> keyExtractor);
+
+    @Override
     IndexedSeq<T> drop(int n);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Iterator.java
+++ b/vavr/src/main/java/io/vavr/collection/Iterator.java
@@ -1373,6 +1373,30 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
         }
     }
 
+    default Iterator<T> distinctByKeepLast(Comparator<? super T> comparator) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        if (!hasNext()) {
+            return empty();
+        } else {
+            return Collections.reverseIterator(new DistinctIterator<>(
+                    Collections.reverseIterator(this),
+                    TreeSet.empty(comparator),
+                    Function.identity()));
+        }
+    }
+
+    default <U> Iterator<T> distinctByKeepLast(Function<? super T, ? extends U> keyExtractor) {
+        Objects.requireNonNull(keyExtractor, "keyExtractor is null");
+        if (!hasNext()) {
+            return empty();
+        } else {
+            return Collections.reverseIterator(new DistinctIterator<>(
+                    Collections.reverseIterator(this),
+                    io.vavr.collection.HashSet.empty(),
+                    keyExtractor));
+        }
+    }
+
     /**
      * Removes up to n elements from this iterator.
      *

--- a/vavr/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/LinearSeq.java
@@ -106,6 +106,12 @@ public interface LinearSeq<T> extends Seq<T> {
     <U> LinearSeq<T> distinctBy(Function<? super T, ? extends U> keyExtractor);
 
     @Override
+    LinearSeq<T> distinctByKeepLast(Comparator<? super T> comparator);
+
+    @Override
+    <U> LinearSeq<T> distinctByKeepLast(Function<? super T, ? extends U> keyExtractor);
+
+    @Override
     LinearSeq<T> drop(int n);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -818,6 +818,18 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
+    default List<T> distinctByKeepLast(Comparator<? super T> comparator) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        return ofAll(iterator().distinctByKeepLast(comparator));
+    }
+
+    @Override
+    default <U> List<T> distinctByKeepLast(Function<? super T, ? extends U> keyExtractor) {
+        Objects.requireNonNull(keyExtractor, "keyExtractor is null");
+        return ofAll(iterator().distinctByKeepLast(keyExtractor));
+    }
+
+    @Override
     default List<T> drop(int n) {
         if (n <= 0) {
             return this;

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -738,6 +738,18 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
+    public Queue<T> distinctByKeepLast(Comparator<? super T> comparator) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        return ofAll(toList().distinctByKeepLast(comparator));
+    }
+
+    @Override
+    public <U> Queue<T> distinctByKeepLast(Function<? super T, ? extends U> keyExtractor) {
+        Objects.requireNonNull(keyExtractor, "keyExtractor is null");
+        return ofAll(toList().distinctByKeepLast(keyExtractor));
+    }
+
+    @Override
     public Queue<T> drop(int n) {
         if (n <= 0) {
             return this;

--- a/vavr/src/main/java/io/vavr/collection/Seq.java
+++ b/vavr/src/main/java/io/vavr/collection/Seq.java
@@ -1126,6 +1126,31 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
     @Override
     <U> Seq<T> distinctBy(Function<? super T, ? extends U> keyExtractor);
 
+    /**
+     * Returns a sequential collection where duplicate elements, as determined by the comparator,
+     * are removed. If duplicates are encountered, the last occurrence of the element is
+     * retained in the resulting sequence.
+     *
+     * @param comparator the comparator used to determine equality of elements for the purpose
+     *                   of identifying duplicates. The comparator defines if two elements are
+     *                   considered equal.
+     * @return a new sequence where duplicates are removed, retaining the last occurrence of
+     *         each element as per the comparator provided.
+     */
+    Seq<T> distinctByKeepLast(Comparator<? super T> comparator);
+
+    /**
+     * Returns a sequential Stream-like sequence where the elements are distinct based on a key
+     * derived from the provided keyExtractor function. When duplicate elements are found,
+     * the last encountered element is kept in the sequence.
+     *
+     * @param <U> the type of key extracted from elements of this sequence
+     * @param keyExtractor the function to extract the key used for determining uniqueness
+     * @return a sequence consisting of distinct elements, keeping the last occurrence of each
+     *         duplicate based on the extracted key
+     */
+    <U> Seq<T> distinctByKeepLast(Function<? super T, ? extends U> keyExtractor);
+
     @Override
     Seq<T> drop(int n);
 

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -993,6 +993,18 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
+    default Stream<T> distinctByKeepLast(Comparator<? super T> comparator) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        return ofAll(iterator().distinctByKeepLast(comparator));
+    }
+
+    @Override
+    default <U> Stream<T> distinctByKeepLast(Function<? super T, ? extends U> keyExtractor) {
+        Objects.requireNonNull(keyExtractor, "keyExtractor is null");
+        return ofAll(iterator().distinctByKeepLast(keyExtractor));
+    }
+
+    @Override
     default Stream<T> drop(int n) {
         Stream<T> stream = this;
         while (n-- > 0 && !stream.isEmpty()) {

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -686,6 +686,18 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    public Vector<T> distinctByKeepLast(Comparator<? super T> comparator) {
+        Objects.requireNonNull(comparator, "comparator is null");
+        return ofAll(iterator().distinctByKeepLast(comparator));
+    }
+
+    @Override
+    public <U> Vector<T> distinctByKeepLast(Function<? super T, ? extends U> keyExtractor) {
+        Objects.requireNonNull(keyExtractor, "keyExtractor is null");
+        return ofAll(iterator().distinctByKeepLast(keyExtractor));
+    }
+
+    @Override
     public Vector<T> drop(int n) {
         return wrap(trie.drop(n));
     }

--- a/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSeqTest.java
@@ -24,12 +24,15 @@ import io.vavr.control.Option;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Spliterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collector;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 
+import static java.util.Comparator.comparingInt;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -2284,6 +2287,57 @@ public abstract class AbstractSeqTest extends AbstractTraversableRangeTest {
     public void shouldTestIndexedSeqEndsWithNonIndexedSeq() {
         assertThat(of(1, 3, 4).endsWith(Stream.of(3, 4))).isTrue();
         assertThat(of(1, 2, 3, 4).endsWith(Stream.of(2, 3, 5))).isFalse();
+    }
+
+    // -- distinctByKeepLast(Comparator)
+
+    @TestTemplate
+    public void shouldComputeDistinctByKeepLastOfEmptySeqUsingComparator() {
+        final Comparator<Integer> comparator = comparingInt(i -> i);
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(this.<Integer>empty().distinctByKeepLast(comparator)).isEqualTo(empty());
+        } else {
+            assertThat(this.<Integer>empty().distinctByKeepLast(comparator)).isSameAs(empty());
+        }
+    }
+
+    @TestTemplate
+    public void shouldComputeDistinctByKeepLastOfNonEmptySeqUsingComparator() {
+        final Comparator<String> comparator = comparingInt(s -> (s.charAt(1)));
+        final Seq<String> distinct = of("1a", "2a", "3b", "4b", "3a", "5c")
+                .distinctByKeepLast(comparator);
+        assertThat(distinct).isEqualTo(of("4b", "3a", "5c"));
+    }
+
+    @TestTemplate
+    public void shouldReturnSameInstanceWhenDistinctByKeepLastComparatorEmptySeq() {
+        final Seq<?> empty = empty();
+        assertThat(empty.distinctByKeepLast(Comparators.naturalComparator())).isSameAs(empty);
+    }
+
+    // -- distinctByKeepLast(Function)
+
+    @TestTemplate
+    public void shouldComputeDistinctByKeepLastOfEmptySeqUsingKeyExtractor() {
+        if (useIsEqualToInsteadOfIsSameAs()) {
+            assertThat(empty().distinctByKeepLast(Function.identity())).isEqualTo(empty());
+        } else {
+            assertThat(empty().distinctByKeepLast(Function.identity())).isSameAs(empty());
+        }
+    }
+
+    @TestTemplate
+    public void shouldComputeDistinctByKeepLastOfNonEmptySeqUsingKeyExtractor() {
+        final Function<String, Character> function = c -> c.charAt(1);
+        final Seq<String> distinct = of("1a", "2a", "3b", "4b", "3a", "5c")
+                .distinctByKeepLast(function);
+        assertThat(distinct).isEqualTo(of("4b", "3a", "5c"));
+    }
+
+    @TestTemplate
+    public void shouldReturnSameInstanceWhenDistinctByKeepLastFunctionEmptySeq() {
+        final Seq<?> empty = empty();
+        assertThat(empty.distinctByKeepLast(Function.identity())).isSameAs(empty);
     }
 
     private interface SomeInterface {

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -664,6 +664,34 @@ public class CharSeqTest {
           .isEqualTo(CharSeq.of('1', '2', '3', '4', '5'));
     }
 
+    // -- distinctByKeepLast(Comparator)
+
+    @Test
+    public void shouldComputeDistinctByKeepLastOfEmptyTraversableUsingComparator() {
+        final Comparator<Character> comparator = Comparator.comparingInt(i -> i);
+        assertThat(CharSeq.empty().distinctByKeepLast(comparator)).isSameAs(CharSeq.empty());
+    }
+
+    @Test
+    public void shouldComputeDistinctByKeepLastOfNonEmptyTraversableUsingComparator() {
+        final Comparator<Character> comparator = (s1, s2) -> (s1 - s2);
+        assertThat(CharSeq.of('1', '2', '3', '3', '4', '5').distinctByKeepLast(comparator))
+                .isEqualTo(CharSeq.of('1', '2', '3', '4', '5'));
+    }
+
+    // -- distinctByKeepLast(Function)
+
+    @Test
+    public void shouldComputeDistinctByKeepLastOfEmptyTraversableUsingKeyExtractor() {
+        assertThat(CharSeq.empty().distinctByKeepLast(Function.identity())).isSameAs(CharSeq.empty());
+    }
+
+    @Test
+    public void shouldComputeDistinctByKeepLastOfNonEmptyTraversableUsingKeyExtractor() {
+        assertThat(CharSeq.of('1', '2', '3', '2', '4', '5').distinctByKeepLast(c -> c))
+                .isEqualTo(CharSeq.of('1', '3', '2', '4', '5'));
+    }
+
     // -- drop
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/IteratorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/IteratorTest.java
@@ -604,6 +604,8 @@ public class IteratorTest extends AbstractTraversableTest {
         multipleHasNext(() -> Iterator.of(1, 2, 1, 2, 1, 2).distinct());
         multipleHasNext(() -> Iterator.of(1, 2, 1, 2, 1, 2).distinctBy(e -> e % 2));
         multipleHasNext(() -> Iterator.of(1, 2, 1, 2, 1, 2).distinctBy(Comparator.comparingInt(e -> e % 2)));
+        multipleHasNext(() -> Iterator.of(1, 2, 1, 2, 1, 2).distinctByKeepLast(e -> e % 2));
+        multipleHasNext(() -> Iterator.of(1, 2, 1, 2, 1, 2).distinctByKeepLast(Comparator.comparingInt(e -> e % 2)));
         multipleHasNext(() -> Iterator.of(1, 2, 3, 4).drop(1));
         multipleHasNext(() -> Iterator.of(1, 2, 3, 4).dropRight(1));
         multipleHasNext(() -> Iterator.of(1, 2, 3, 4).dropUntil(e -> e == 3));


### PR DESCRIPTION
### About
This PR addresses a feature request mentioned [here](https://github.com/vavr-io/vavr/issues/2712).

The intent behind this change is to introduce a method(`distinctByKeepLast`) to sequences that can distinguish and retain the last seen value based on a specified key.

```
List.of("1a", "2a", "3a", "2b", "4a").distinctByKeepLast(s -> s.substring(1)); 
//Should return ["2b", "4a"]
```

--- 
closes: https://github.com/vavr-io/vavr/issues/2712