### PR TITLE
Add `compose1`, ..., `composeN` methods to `FunctionN`

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1668,6 +1668,22 @@ def generateMainClasses(): Unit = {
                 """
               })("\n\n")}
 
+              ${(1 until i).gen(j => {
+                val partialApplicationArgs = (1 to j-1).gen(k => s"T$k t$k")(", ")
+                val resultFunctionGenerics = (j+1 to i).gen(k => s"T$k")(", ")
+                val resultFunctionArgs = (j+1 to i).gen(k => s"T$k t$k")(", ")
+                val fixedApplyArgs = (1 to j-1).gen(k => s"t$k")(", ")
+                val variableApplyArgs = (j+1 to i).gen(k => s"t$k")(", ")
+                xs"""
+                  /$javadoc
+                   * Compose $j
+                   */
+                  default $className<$fixedApplyArgs, S, $resultFunctionGenerics, R> compose$j(Function1<S, T$j> f) {
+                      return ($partialApplicationArgs, s, $resultFunctionArgs) -> apply($fixedApplyArgs, f.apply(s), $variableApplyArgs);
+                  }
+                """
+              })("\n\n")}
+
               ${(i == 0 && !checked).gen(
                 xs"""
                   /$javadoc

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1679,7 +1679,7 @@ def generateMainClasses(): Unit = {
                    * Compose $j
                    */
                   default $className<$fixedApplyArgs, S, $resultFunctionGenerics, R> compose$j(Function1<S, T$j> f) {
-                      return ($partialApplicationArgs, s, $resultFunctionArgs) -> apply($fixedApplyArgs, f.apply(s), $variableApplyArgs);
+                      return ($partialApplicationArgs, S s, $resultFunctionArgs) -> apply($fixedApplyArgs, f.apply(s), $variableApplyArgs);
                   }
                 """
               })("\n\n")}

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1677,11 +1677,10 @@ def generateMainClasses(): Unit = {
                 val variableApplyArgs = (j+1 to i).gen(k => s"t$k")(", ")
                 xs"""
                   /$javadoc
-                   * Compose $j
-                   * Returns a composed function that first applies the {@linkplain Function} {@code $fName} the
-                   * given argument and then applies this Function1 to the result.
+                   * Returns a composed function that first applies the {@linkplain Function} {@code $fName} to the
+                   * ${j.ordinal} argument and then applies this $className to the result.
                    *
-                   * @param <V> argument type of before
+                   * @param <S> argument type of before
                    * @param $fName the function applied before this
                    * @return a function composed of before and this
                    * @throws NullPointerException if before is null

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1669,9 +1669,8 @@ def generateMainClasses(): Unit = {
               })("\n\n")}
 
               ${(1 to i).gen(j => {
-                val partialApplicationArgs = (1 to j-1).gen(k => s"T$k t$k")(", ")
-                val preGenerics = (1 to j-1).gen(k => s"T$k")(", ")
-                val resultFunctionGenerics = (j+1 to i).gen(k => s"T$k")(", ")
+                val applicationArgs = (1 to i).gen(k => if (k == j) "S s" else s"T$k t$k")(", ")
+                val generics = (1 to i).gen(k => if (k == j) "S" else s"T$k")(", ")
                 val resultFunctionArgs = (j+1 to i).gen(k => s"T$k t$k")(", ")
                 val fixedApplyArgs = (1 to j-1).gen(k => s"t$k")(", ")
                 val variableApplyArgs = (j+1 to i).gen(k => s"t$k")(", ")
@@ -1679,8 +1678,8 @@ def generateMainClasses(): Unit = {
                   /$javadoc
                    * Compose $j
                    */
-                  default $className<$preGenerics, S, $resultFunctionGenerics, R> compose$j(Function1<S, T$j> f) {
-                      return ($partialApplicationArgs, S s, $resultFunctionArgs) -> apply($fixedApplyArgs, f.apply(s), $variableApplyArgs);
+                  default <S> $className<$generics, R> compose$j(Function1<S, T$j> f) {
+                      return ($applicationArgs) -> apply($fixedApplyArgs, f.apply(s), $variableApplyArgs);
                   }
                 """
               })("\n\n")}

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1670,6 +1670,7 @@ def generateMainClasses(): Unit = {
 
               ${(1 to i).gen(j => {
                 val partialApplicationArgs = (1 to j-1).gen(k => s"T$k t$k")(", ")
+                val preGenerics = (1 to j-1).gen(k => s"T$k")(", ")
                 val resultFunctionGenerics = (j+1 to i).gen(k => s"T$k")(", ")
                 val resultFunctionArgs = (j+1 to i).gen(k => s"T$k t$k")(", ")
                 val fixedApplyArgs = (1 to j-1).gen(k => s"t$k")(", ")
@@ -1678,7 +1679,7 @@ def generateMainClasses(): Unit = {
                   /$javadoc
                    * Compose $j
                    */
-                  default $className<$fixedApplyArgs, S, $resultFunctionGenerics, R> compose$j(Function1<S, T$j> f) {
+                  default $className<$preGenerics, S, $resultFunctionGenerics, R> compose$j(Function1<S, T$j> f) {
                       return ($partialApplicationArgs, S s, $resultFunctionArgs) -> apply($fixedApplyArgs, f.apply(s), $variableApplyArgs);
                   }
                 """

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1669,16 +1669,25 @@ def generateMainClasses(): Unit = {
               })("\n\n")}
 
               ${(1 to i).gen(j => {
+                val fName = "f"
                 val applicationArgs = (1 to i).gen(k => if (k == j) "S s" else s"T$k t$k")(", ")
                 val generics = (1 to i).gen(k => if (k == j) "S" else s"T$k")(", ")
                 val resultFunctionArgs = (j+1 to i).gen(k => s"T$k t$k")(", ")
-                val applyArgs = (1 to i).gen(k => if (k ==j) "f.apply(s)" else s"t$k")(", ")
+                val applyArgs = (1 to i).gen(k => if (k ==j) s"$fName.apply(s)" else s"t$k")(", ")
                 val variableApplyArgs = (j+1 to i).gen(k => s"t$k")(", ")
                 xs"""
                   /$javadoc
                    * Compose $j
+                   * Returns a composed function that first applies the {@linkplain Function} {@code $fName} the
+                   * given argument and then applies this Function1 to the result.
+                   *
+                   * @param <V> argument type of before
+                   * @param $fName the function applied before this
+                   * @return a function composed of before and this
+                   * @throws NullPointerException if before is null
                    */
-                  default <S> $className<$generics, R> compose$j(Function1<S, T$j> f) {
+                  default <S> $className<$generics, R> compose$j(Function1<S, T$j> $fName) {
+                      Objects.requireNonNull($fName, "$fName is null");
                       return ($applicationArgs) -> apply($applyArgs);
                   }
                 """

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1668,35 +1668,6 @@ def generateMainClasses(): Unit = {
                 """
               })("\n\n")}
 
-              ${(1 to i).gen(j => {
-                val fName = s"before$j"
-                val fGeneric = "S"
-                val applicationArgs = (1 to i).gen(k => if (k == j) s"$fGeneric ${fGeneric.toLowerCase}" else s"T$k t$k")(", ")
-                val generics = (1 to i).gen(k => if (k == j) "S" else s"T$k")(", ")
-                val resultFunctionArgs = (j+1 to i).gen(k => s"T$k t$k")(", ")
-                val applyArgs = (1 to i).gen(k => if (k ==j) s"$fName.apply(${fGeneric.toLowerCase})" else s"t$k")(", ")
-                val variableApplyArgs = (j+1 to i).gen(k => s"t$k")(", ")
-                val docAdd = i match
-                  case 1 => ""
-                  case 2 => " and the other argument"
-                  case _ => " and the other arguments"
-                xs"""
-                  /$javadoc
-                   * Returns a composed function that first applies the {@linkplain Function} {@code $fName} to the
-                   * ${j.ordinal} argument and then applies this $className to the result$docAdd.
-                   *
-                   * @param <$fGeneric> argument type of $fName
-                   * @param $fName the function applied before this
-                   * @return a function composed of $fName and this
-                   * @throws NullPointerException if $fName is null
-                   */
-                  default <S> $className<$generics, R> compose$j(Function1<? super $fGeneric, ? extends T$j> $fName) {
-                      Objects.requireNonNull($fName, "$fName is null");
-                      return ($applicationArgs) -> apply($applyArgs);
-                  }
-                """
-              })("\n\n")}
-
               ${(i == 0 && !checked).gen(
                 xs"""
                   /$javadoc
@@ -1921,6 +1892,35 @@ def generateMainClasses(): Unit = {
                     return v -> apply(before.apply(v));
                 }
               """)}
+
+              ${(1 to i).gen(j => {
+                val fName = s"before$j"
+                val fGeneric = "S"
+                val applicationArgs = (1 to i).gen(k => if (k == j) s"$fGeneric ${fGeneric.toLowerCase}" else s"T$k t$k")(", ")
+                val generics = (1 to i).gen(k => if (k == j) "S" else s"T$k")(", ")
+                val resultFunctionArgs = (j+1 to i).gen(k => s"T$k t$k")(", ")
+                val applyArgs = (1 to i).gen(k => if (k ==j) s"$fName.apply(${fGeneric.toLowerCase})" else s"t$k")(", ")
+                val variableApplyArgs = (j+1 to i).gen(k => s"t$k")(", ")
+                val docAdd = i match
+                  case 1 => ""
+                  case 2 => " and the other argument"
+                  case _ => " and the other arguments"
+                xs"""
+                  /$javadoc
+                   * Returns a composed function that first applies the {@linkplain Function} {@code $fName} to the
+                   * ${j.ordinal} argument and then applies this $className to the result$docAdd.
+                   *
+                   * @param <$fGeneric> argument type of $fName
+                   * @param $fName the function applied before this
+                   * @return a function composed of $fName and this
+                   * @throws NullPointerException if $fName is null
+                   */
+                  default <S> $className<$generics, R> compose$j(Function1<? super $fGeneric, ? extends T$j> $fName) {
+                      Objects.requireNonNull($fName, "$fName is null");
+                      return ($applicationArgs) -> apply($applyArgs);
+                  }
+                """
+              })("\n\n")}
           }
 
           ${checked.gen(xs"""

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1672,14 +1672,14 @@ def generateMainClasses(): Unit = {
                 val applicationArgs = (1 to i).gen(k => if (k == j) "S s" else s"T$k t$k")(", ")
                 val generics = (1 to i).gen(k => if (k == j) "S" else s"T$k")(", ")
                 val resultFunctionArgs = (j+1 to i).gen(k => s"T$k t$k")(", ")
-                val fixedApplyArgs = (1 to j-1).gen(k => s"t$k")(", ")
+                val applyArgs = (1 to i).gen(k => if (k ==j) "f.apply(s)" else s"t$k")(", ")
                 val variableApplyArgs = (j+1 to i).gen(k => s"t$k")(", ")
                 xs"""
                   /$javadoc
                    * Compose $j
                    */
                   default <S> $className<$generics, R> compose$j(Function1<S, T$j> f) {
-                      return ($applicationArgs) -> apply($fixedApplyArgs, f.apply(s), $variableApplyArgs);
+                      return ($applicationArgs) -> apply($applyArgs);
                   }
                 """
               })("\n\n")}

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1668,7 +1668,7 @@ def generateMainClasses(): Unit = {
                 """
               })("\n\n")}
 
-              ${(1 until i).gen(j => {
+              ${(1 to i).gen(j => {
                 val partialApplicationArgs = (1 to j-1).gen(k => s"T$k t$k")(", ")
                 val resultFunctionGenerics = (j+1 to i).gen(k => s"T$k")(", ")
                 val resultFunctionArgs = (j+1 to i).gen(k => s"T$k t$k")(", ")

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -3432,16 +3432,23 @@ def generateTestClasses(): Unit = {
               }
 
 
-              ${(1 to i).gen(i => xs"""
-                @$test
-                public void shouldComposeWithCompose$i() {
-                    final $name$i<$generics> f = ($functionArgs) -> null;
-                    final ${name}1<Object, Object> before = o -> null;
-                    final $name$i<$generics> composed = f.compose${i}(before);
-                    $assertThat(composed).isNotNull();
-                }
+              ${(1 to i).gen(j =>
+                val genArgs = (1 to i).gen(k => "String")(", ")
+                val params = (1 to i).gen(k => s"String s$k")(", ")
+                val values = (1 to i).gen(k => if (k == j) "\"xx\"" else s"\"s$k\"")(", ")
+                val expected = (1 to i).gen(k => if (k == j) "XX" else s"s$k")("")
+                val concat = (1 to i).gen(k => s"s$k")(" + ")
+                xs"""
+              @$test
+              public void shouldComposeWithCompose$j() ${checked.gen(" throws Throwable ")}{
+                  final $name$i<$genArgs, String> f = ($params) -> $concat;
+                  final Function1<String, String> toUpperCase = String::toUpperCase;
+                  assertThat(f.compose$j(toUpperCase).apply($values)).isEqualTo(\"$expected\");
+              }
 
-              """)}
+
+                """
+              )}
 
               ${(i == 0).gen(xs"""
               @$test

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -3452,13 +3452,13 @@ def generateTestClasses(): Unit = {
                 val expected = (1 to i).gen(k => if (k == j) "XX" else s"s$k")("")
                 val concat = (1 to i).gen(k => s"s$k")(" + ")
                 xs"""
+
               @$test
               public void shouldCompose$j() ${checked.gen(" throws Throwable ")}{
                   final $name$i<$genArgs, String> concat = ($params) -> $concat;
                   final Function1<String, String> toUpperCase = String::toUpperCase;
                   assertThat(concat.compose$j(toUpperCase).apply($values)).isEqualTo(\"$expected\");
               }
-
 
                 """
               )}

--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -3415,14 +3415,16 @@ def generateTestClasses(): Unit = {
                   $assertThat(composed).isNotNull();
               }
 
-              ${(i == 1).gen(xs"""
+
+              ${(1 to i).gen(i => xs"""
                 @$test
-                public void shouldComposeWithCompose() {
+                public void shouldComposeWithCompose$i() {
                     final $name$i<$generics> f = ($functionArgs) -> null;
                     final ${name}1<Object, Object> before = o -> null;
-                    final $name$i<$generics> composed = f.compose(before);
+                    final $name$i<$generics> composed = f.compose${i}(before);
                     $assertThat(composed).isNotNull();
                 }
+
               """)}
 
               ${(i == 0).gen(xs"""

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
@@ -160,6 +160,20 @@ public interface CheckedFunction1<T1, R> extends Serializable {
     R apply(T1 t1) throws Throwable;
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction1 to the result.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction1<S, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s) -> apply(before1.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
@@ -160,20 +160,6 @@ public interface CheckedFunction1<T1, R> extends Serializable {
     R apply(T1 t1) throws Throwable;
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this CheckedFunction1 to the result.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> CheckedFunction1<S, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s) -> apply(before1.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -311,6 +297,20 @@ public interface CheckedFunction1<T1, R> extends Serializable {
     default <V> CheckedFunction1<V, R> compose(CheckedFunction1<? super V, ? extends T1> before) {
         Objects.requireNonNull(before, "before is null");
         return v -> apply(before.apply(v));
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction1 to the result.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction1<S, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s) -> apply(before1.apply(s));
     }
 }
 

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
@@ -168,6 +168,34 @@ public interface CheckedFunction2<T1, T2, R> extends Serializable {
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction2 to the result and the other argument.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction2<S, T2, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2) -> apply(before1.apply(s), t2);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction2 to the result and the other argument.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction2<T1, S, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s) -> apply(t1, before2.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
@@ -168,34 +168,6 @@ public interface CheckedFunction2<T1, T2, R> extends Serializable {
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this CheckedFunction2 to the result and the other argument.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> CheckedFunction2<S, T2, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2) -> apply(before1.apply(s), t2);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this CheckedFunction2 to the result and the other argument.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> CheckedFunction2<T1, S, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s) -> apply(t1, before2.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -322,6 +294,33 @@ public interface CheckedFunction2<T1, T2, R> extends Serializable {
         return (t1, t2) -> after.apply(apply(t1, t2));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction2 to the result and the other argument.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction2<S, T2, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2) -> apply(before1.apply(s), t2);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction2 to the result and the other argument.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction2<T1, S, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s) -> apply(t1, before2.apply(s));
+    }
 }
 
 interface CheckedFunction2Module {

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
@@ -185,6 +185,48 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Serializable {
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction3<S, T2, T3, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3) -> apply(before1.apply(s), t2, t3);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction3<T1, S, T3, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3) -> apply(t1, before2.apply(s), t3);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction3<T1, T2, S, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s) -> apply(t1, t2, before3.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
@@ -185,48 +185,6 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Serializable {
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this CheckedFunction3 to the result and the other arguments.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> CheckedFunction3<S, T2, T3, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2, T3 t3) -> apply(before1.apply(s), t2, t3);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this CheckedFunction3 to the result and the other arguments.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> CheckedFunction3<T1, S, T3, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s, T3 t3) -> apply(t1, before2.apply(s), t3);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
-     * 3rd argument and then applies this CheckedFunction3 to the result and the other arguments.
-     *
-     * @param <S> argument type of before3
-     * @param before3 the function applied before this
-     * @return a function composed of before3 and this
-     * @throws NullPointerException if before3 is null
-     */
-    default <S> CheckedFunction3<T1, T2, S, R> compose3(Function1<? super S, ? extends T3> before3) {
-        Objects.requireNonNull(before3, "before3 is null");
-        return (T1 t1, T2 t2, S s) -> apply(t1, t2, before3.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -353,6 +311,47 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Serializable {
         return (t1, t2, t3) -> after.apply(apply(t1, t2, t3));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction3<S, T2, T3, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3) -> apply(before1.apply(s), t2, t3);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction3<T1, S, T3, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3) -> apply(t1, before2.apply(s), t3);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction3<T1, T2, S, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s) -> apply(t1, t2, before3.apply(s));
+    }
 }
 
 interface CheckedFunction3Module {

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
@@ -204,6 +204,62 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Serializable {
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction4<S, T2, T3, T4, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4) -> apply(before1.apply(s), t2, t3, t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction4<T1, S, T3, T4, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4) -> apply(t1, before2.apply(s), t3, t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction4<T1, T2, S, T4, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4) -> apply(t1, t2, before3.apply(s), t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this CheckedFunction4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> CheckedFunction4<T1, T2, T3, S, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s) -> apply(t1, t2, t3, before4.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
@@ -204,62 +204,6 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Serializable {
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this CheckedFunction4 to the result and the other arguments.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> CheckedFunction4<S, T2, T3, T4, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2, T3 t3, T4 t4) -> apply(before1.apply(s), t2, t3, t4);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this CheckedFunction4 to the result and the other arguments.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> CheckedFunction4<T1, S, T3, T4, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s, T3 t3, T4 t4) -> apply(t1, before2.apply(s), t3, t4);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
-     * 3rd argument and then applies this CheckedFunction4 to the result and the other arguments.
-     *
-     * @param <S> argument type of before3
-     * @param before3 the function applied before this
-     * @return a function composed of before3 and this
-     * @throws NullPointerException if before3 is null
-     */
-    default <S> CheckedFunction4<T1, T2, S, T4, R> compose3(Function1<? super S, ? extends T3> before3) {
-        Objects.requireNonNull(before3, "before3 is null");
-        return (T1 t1, T2 t2, S s, T4 t4) -> apply(t1, t2, before3.apply(s), t4);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
-     * 4th argument and then applies this CheckedFunction4 to the result and the other arguments.
-     *
-     * @param <S> argument type of before4
-     * @param before4 the function applied before this
-     * @return a function composed of before4 and this
-     * @throws NullPointerException if before4 is null
-     */
-    default <S> CheckedFunction4<T1, T2, T3, S, R> compose4(Function1<? super S, ? extends T4> before4) {
-        Objects.requireNonNull(before4, "before4 is null");
-        return (T1 t1, T2 t2, T3 t3, S s) -> apply(t1, t2, t3, before4.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -386,6 +330,61 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Serializable {
         return (t1, t2, t3, t4) -> after.apply(apply(t1, t2, t3, t4));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction4<S, T2, T3, T4, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4) -> apply(before1.apply(s), t2, t3, t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction4<T1, S, T3, T4, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4) -> apply(t1, before2.apply(s), t3, t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction4<T1, T2, S, T4, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4) -> apply(t1, t2, before3.apply(s), t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this CheckedFunction4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> CheckedFunction4<T1, T2, T3, S, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s) -> apply(t1, t2, t3, before4.apply(s));
+    }
 }
 
 interface CheckedFunction4Module {

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
@@ -224,76 +224,6 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Serializable {
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this CheckedFunction5 to the result and the other arguments.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> CheckedFunction5<S, T2, T3, T4, T5, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2, T3 t3, T4 t4, T5 t5) -> apply(before1.apply(s), t2, t3, t4, t5);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this CheckedFunction5 to the result and the other arguments.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> CheckedFunction5<T1, S, T3, T4, T5, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s, T3 t3, T4 t4, T5 t5) -> apply(t1, before2.apply(s), t3, t4, t5);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
-     * 3rd argument and then applies this CheckedFunction5 to the result and the other arguments.
-     *
-     * @param <S> argument type of before3
-     * @param before3 the function applied before this
-     * @return a function composed of before3 and this
-     * @throws NullPointerException if before3 is null
-     */
-    default <S> CheckedFunction5<T1, T2, S, T4, T5, R> compose3(Function1<? super S, ? extends T3> before3) {
-        Objects.requireNonNull(before3, "before3 is null");
-        return (T1 t1, T2 t2, S s, T4 t4, T5 t5) -> apply(t1, t2, before3.apply(s), t4, t5);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
-     * 4th argument and then applies this CheckedFunction5 to the result and the other arguments.
-     *
-     * @param <S> argument type of before4
-     * @param before4 the function applied before this
-     * @return a function composed of before4 and this
-     * @throws NullPointerException if before4 is null
-     */
-    default <S> CheckedFunction5<T1, T2, T3, S, T5, R> compose4(Function1<? super S, ? extends T4> before4) {
-        Objects.requireNonNull(before4, "before4 is null");
-        return (T1 t1, T2 t2, T3 t3, S s, T5 t5) -> apply(t1, t2, t3, before4.apply(s), t5);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
-     * 5th argument and then applies this CheckedFunction5 to the result and the other arguments.
-     *
-     * @param <S> argument type of before5
-     * @param before5 the function applied before this
-     * @return a function composed of before5 and this
-     * @throws NullPointerException if before5 is null
-     */
-    default <S> CheckedFunction5<T1, T2, T3, T4, S, R> compose5(Function1<? super S, ? extends T5> before5) {
-        Objects.requireNonNull(before5, "before5 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, S s) -> apply(t1, t2, t3, t4, before5.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -420,6 +350,75 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Serializable {
         return (t1, t2, t3, t4, t5) -> after.apply(apply(t1, t2, t3, t4, t5));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction5<S, T2, T3, T4, T5, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5) -> apply(before1.apply(s), t2, t3, t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction5<T1, S, T3, T4, T5, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5) -> apply(t1, before2.apply(s), t3, t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction5<T1, T2, S, T4, T5, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5) -> apply(t1, t2, before3.apply(s), t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this CheckedFunction5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> CheckedFunction5<T1, T2, T3, S, T5, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5) -> apply(t1, t2, t3, before4.apply(s), t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this CheckedFunction5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> CheckedFunction5<T1, T2, T3, T4, S, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s) -> apply(t1, t2, t3, t4, before5.apply(s));
+    }
 }
 
 interface CheckedFunction5Module {

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
@@ -224,6 +224,76 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Serializable {
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction5<S, T2, T3, T4, T5, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5) -> apply(before1.apply(s), t2, t3, t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction5<T1, S, T3, T4, T5, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5) -> apply(t1, before2.apply(s), t3, t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction5<T1, T2, S, T4, T5, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5) -> apply(t1, t2, before3.apply(s), t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this CheckedFunction5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> CheckedFunction5<T1, T2, T3, S, T5, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5) -> apply(t1, t2, t3, before4.apply(s), t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this CheckedFunction5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> CheckedFunction5<T1, T2, T3, T4, S, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s) -> apply(t1, t2, t3, t4, before5.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
@@ -245,6 +245,90 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Serializabl
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction6<S, T2, T3, T4, T5, T6, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(before1.apply(s), t2, t3, t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction6<T1, S, T3, T4, T5, T6, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(t1, before2.apply(s), t3, t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction6<T1, T2, S, T4, T5, T6, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6) -> apply(t1, t2, before3.apply(s), t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> CheckedFunction6<T1, T2, T3, S, T5, T6, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6) -> apply(t1, t2, t3, before4.apply(s), t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> CheckedFunction6<T1, T2, T3, T4, S, T6, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6) -> apply(t1, t2, t3, t4, before5.apply(s), t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
+     * 6th argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before6
+     * @param before6 the function applied before this
+     * @return a function composed of before6 and this
+     * @throws NullPointerException if before6 is null
+     */
+    default <S> CheckedFunction6<T1, T2, T3, T4, T5, S, R> compose6(Function1<? super S, ? extends T6> before6) {
+        Objects.requireNonNull(before6, "before6 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s) -> apply(t1, t2, t3, t4, t5, before6.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
@@ -245,90 +245,6 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Serializabl
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this CheckedFunction6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> CheckedFunction6<S, T2, T3, T4, T5, T6, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(before1.apply(s), t2, t3, t4, t5, t6);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this CheckedFunction6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> CheckedFunction6<T1, S, T3, T4, T5, T6, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(t1, before2.apply(s), t3, t4, t5, t6);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
-     * 3rd argument and then applies this CheckedFunction6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before3
-     * @param before3 the function applied before this
-     * @return a function composed of before3 and this
-     * @throws NullPointerException if before3 is null
-     */
-    default <S> CheckedFunction6<T1, T2, S, T4, T5, T6, R> compose3(Function1<? super S, ? extends T3> before3) {
-        Objects.requireNonNull(before3, "before3 is null");
-        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6) -> apply(t1, t2, before3.apply(s), t4, t5, t6);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
-     * 4th argument and then applies this CheckedFunction6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before4
-     * @param before4 the function applied before this
-     * @return a function composed of before4 and this
-     * @throws NullPointerException if before4 is null
-     */
-    default <S> CheckedFunction6<T1, T2, T3, S, T5, T6, R> compose4(Function1<? super S, ? extends T4> before4) {
-        Objects.requireNonNull(before4, "before4 is null");
-        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6) -> apply(t1, t2, t3, before4.apply(s), t5, t6);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
-     * 5th argument and then applies this CheckedFunction6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before5
-     * @param before5 the function applied before this
-     * @return a function composed of before5 and this
-     * @throws NullPointerException if before5 is null
-     */
-    default <S> CheckedFunction6<T1, T2, T3, T4, S, T6, R> compose5(Function1<? super S, ? extends T5> before5) {
-        Objects.requireNonNull(before5, "before5 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6) -> apply(t1, t2, t3, t4, before5.apply(s), t6);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
-     * 6th argument and then applies this CheckedFunction6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before6
-     * @param before6 the function applied before this
-     * @return a function composed of before6 and this
-     * @throws NullPointerException if before6 is null
-     */
-    default <S> CheckedFunction6<T1, T2, T3, T4, T5, S, R> compose6(Function1<? super S, ? extends T6> before6) {
-        Objects.requireNonNull(before6, "before6 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s) -> apply(t1, t2, t3, t4, t5, before6.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -455,6 +371,89 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Serializabl
         return (t1, t2, t3, t4, t5, t6) -> after.apply(apply(t1, t2, t3, t4, t5, t6));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction6<S, T2, T3, T4, T5, T6, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(before1.apply(s), t2, t3, t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction6<T1, S, T3, T4, T5, T6, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(t1, before2.apply(s), t3, t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction6<T1, T2, S, T4, T5, T6, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6) -> apply(t1, t2, before3.apply(s), t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> CheckedFunction6<T1, T2, T3, S, T5, T6, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6) -> apply(t1, t2, t3, before4.apply(s), t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> CheckedFunction6<T1, T2, T3, T4, S, T6, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6) -> apply(t1, t2, t3, t4, before5.apply(s), t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
+     * 6th argument and then applies this CheckedFunction6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before6
+     * @param before6 the function applied before this
+     * @return a function composed of before6 and this
+     * @throws NullPointerException if before6 is null
+     */
+    default <S> CheckedFunction6<T1, T2, T3, T4, T5, S, R> compose6(Function1<? super S, ? extends T6> before6) {
+        Objects.requireNonNull(before6, "before6 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s) -> apply(t1, t2, t3, t4, t5, before6.apply(s));
+    }
 }
 
 interface CheckedFunction6Module {

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
@@ -267,104 +267,6 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Seriali
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this CheckedFunction7 to the result and the other arguments.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> CheckedFunction7<S, T2, T3, T4, T5, T6, T7, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(before1.apply(s), t2, t3, t4, t5, t6, t7);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this CheckedFunction7 to the result and the other arguments.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> CheckedFunction7<T1, S, T3, T4, T5, T6, T7, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(t1, before2.apply(s), t3, t4, t5, t6, t7);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
-     * 3rd argument and then applies this CheckedFunction7 to the result and the other arguments.
-     *
-     * @param <S> argument type of before3
-     * @param before3 the function applied before this
-     * @return a function composed of before3 and this
-     * @throws NullPointerException if before3 is null
-     */
-    default <S> CheckedFunction7<T1, T2, S, T4, T5, T6, T7, R> compose3(Function1<? super S, ? extends T3> before3) {
-        Objects.requireNonNull(before3, "before3 is null");
-        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(t1, t2, before3.apply(s), t4, t5, t6, t7);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
-     * 4th argument and then applies this CheckedFunction7 to the result and the other arguments.
-     *
-     * @param <S> argument type of before4
-     * @param before4 the function applied before this
-     * @return a function composed of before4 and this
-     * @throws NullPointerException if before4 is null
-     */
-    default <S> CheckedFunction7<T1, T2, T3, S, T5, T6, T7, R> compose4(Function1<? super S, ? extends T4> before4) {
-        Objects.requireNonNull(before4, "before4 is null");
-        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6, T7 t7) -> apply(t1, t2, t3, before4.apply(s), t5, t6, t7);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
-     * 5th argument and then applies this CheckedFunction7 to the result and the other arguments.
-     *
-     * @param <S> argument type of before5
-     * @param before5 the function applied before this
-     * @return a function composed of before5 and this
-     * @throws NullPointerException if before5 is null
-     */
-    default <S> CheckedFunction7<T1, T2, T3, T4, S, T6, T7, R> compose5(Function1<? super S, ? extends T5> before5) {
-        Objects.requireNonNull(before5, "before5 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6, T7 t7) -> apply(t1, t2, t3, t4, before5.apply(s), t6, t7);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
-     * 6th argument and then applies this CheckedFunction7 to the result and the other arguments.
-     *
-     * @param <S> argument type of before6
-     * @param before6 the function applied before this
-     * @return a function composed of before6 and this
-     * @throws NullPointerException if before6 is null
-     */
-    default <S> CheckedFunction7<T1, T2, T3, T4, T5, S, T7, R> compose6(Function1<? super S, ? extends T6> before6) {
-        Objects.requireNonNull(before6, "before6 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s, T7 t7) -> apply(t1, t2, t3, t4, t5, before6.apply(s), t7);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before7} to the
-     * 7th argument and then applies this CheckedFunction7 to the result and the other arguments.
-     *
-     * @param <S> argument type of before7
-     * @param before7 the function applied before this
-     * @return a function composed of before7 and this
-     * @throws NullPointerException if before7 is null
-     */
-    default <S> CheckedFunction7<T1, T2, T3, T4, T5, T6, S, R> compose7(Function1<? super S, ? extends T7> before7) {
-        Objects.requireNonNull(before7, "before7 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, S s) -> apply(t1, t2, t3, t4, t5, t6, before7.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -491,6 +393,103 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Seriali
         return (t1, t2, t3, t4, t5, t6, t7) -> after.apply(apply(t1, t2, t3, t4, t5, t6, t7));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction7<S, T2, T3, T4, T5, T6, T7, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(before1.apply(s), t2, t3, t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction7<T1, S, T3, T4, T5, T6, T7, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(t1, before2.apply(s), t3, t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction7<T1, T2, S, T4, T5, T6, T7, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(t1, t2, before3.apply(s), t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> CheckedFunction7<T1, T2, T3, S, T5, T6, T7, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6, T7 t7) -> apply(t1, t2, t3, before4.apply(s), t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> CheckedFunction7<T1, T2, T3, T4, S, T6, T7, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6, T7 t7) -> apply(t1, t2, t3, t4, before5.apply(s), t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
+     * 6th argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before6
+     * @param before6 the function applied before this
+     * @return a function composed of before6 and this
+     * @throws NullPointerException if before6 is null
+     */
+    default <S> CheckedFunction7<T1, T2, T3, T4, T5, S, T7, R> compose6(Function1<? super S, ? extends T6> before6) {
+        Objects.requireNonNull(before6, "before6 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s, T7 t7) -> apply(t1, t2, t3, t4, t5, before6.apply(s), t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before7} to the
+     * 7th argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before7
+     * @param before7 the function applied before this
+     * @return a function composed of before7 and this
+     * @throws NullPointerException if before7 is null
+     */
+    default <S> CheckedFunction7<T1, T2, T3, T4, T5, T6, S, R> compose7(Function1<? super S, ? extends T7> before7) {
+        Objects.requireNonNull(before7, "before7 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, S s) -> apply(t1, t2, t3, t4, t5, t6, before7.apply(s));
+    }
 }
 
 interface CheckedFunction7Module {

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
@@ -267,6 +267,104 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Seriali
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction7<S, T2, T3, T4, T5, T6, T7, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(before1.apply(s), t2, t3, t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction7<T1, S, T3, T4, T5, T6, T7, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(t1, before2.apply(s), t3, t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction7<T1, T2, S, T4, T5, T6, T7, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(t1, t2, before3.apply(s), t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> CheckedFunction7<T1, T2, T3, S, T5, T6, T7, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6, T7 t7) -> apply(t1, t2, t3, before4.apply(s), t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> CheckedFunction7<T1, T2, T3, T4, S, T6, T7, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6, T7 t7) -> apply(t1, t2, t3, t4, before5.apply(s), t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
+     * 6th argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before6
+     * @param before6 the function applied before this
+     * @return a function composed of before6 and this
+     * @throws NullPointerException if before6 is null
+     */
+    default <S> CheckedFunction7<T1, T2, T3, T4, T5, S, T7, R> compose6(Function1<? super S, ? extends T6> before6) {
+        Objects.requireNonNull(before6, "before6 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s, T7 t7) -> apply(t1, t2, t3, t4, t5, before6.apply(s), t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before7} to the
+     * 7th argument and then applies this CheckedFunction7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before7
+     * @param before7 the function applied before this
+     * @return a function composed of before7 and this
+     * @throws NullPointerException if before7 is null
+     */
+    default <S> CheckedFunction7<T1, T2, T3, T4, T5, T6, S, R> compose7(Function1<? super S, ? extends T7> before7) {
+        Objects.requireNonNull(before7, "before7 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, S s) -> apply(t1, t2, t3, t4, t5, t6, before7.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
@@ -290,6 +290,118 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Ser
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction8<S, T2, T3, T4, T5, T6, T7, T8, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(before1.apply(s), t2, t3, t4, t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction8<T1, S, T3, T4, T5, T6, T7, T8, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, before2.apply(s), t3, t4, t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction8<T1, T2, S, T4, T5, T6, T7, T8, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, before3.apply(s), t4, t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> CheckedFunction8<T1, T2, T3, S, T5, T6, T7, T8, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, t3, before4.apply(s), t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> CheckedFunction8<T1, T2, T3, T4, S, T6, T7, T8, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, t3, t4, before5.apply(s), t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
+     * 6th argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before6
+     * @param before6 the function applied before this
+     * @return a function composed of before6 and this
+     * @throws NullPointerException if before6 is null
+     */
+    default <S> CheckedFunction8<T1, T2, T3, T4, T5, S, T7, T8, R> compose6(Function1<? super S, ? extends T6> before6) {
+        Objects.requireNonNull(before6, "before6 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s, T7 t7, T8 t8) -> apply(t1, t2, t3, t4, t5, before6.apply(s), t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before7} to the
+     * 7th argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before7
+     * @param before7 the function applied before this
+     * @return a function composed of before7 and this
+     * @throws NullPointerException if before7 is null
+     */
+    default <S> CheckedFunction8<T1, T2, T3, T4, T5, T6, S, T8, R> compose7(Function1<? super S, ? extends T7> before7) {
+        Objects.requireNonNull(before7, "before7 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, S s, T8 t8) -> apply(t1, t2, t3, t4, t5, t6, before7.apply(s), t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before8} to the
+     * 8th argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before8
+     * @param before8 the function applied before this
+     * @return a function composed of before8 and this
+     * @throws NullPointerException if before8 is null
+     */
+    default <S> CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, S, R> compose8(Function1<? super S, ? extends T8> before8) {
+        Objects.requireNonNull(before8, "before8 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, S s) -> apply(t1, t2, t3, t4, t5, t6, t7, before8.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
@@ -290,118 +290,6 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Ser
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this CheckedFunction8 to the result and the other arguments.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> CheckedFunction8<S, T2, T3, T4, T5, T6, T7, T8, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(before1.apply(s), t2, t3, t4, t5, t6, t7, t8);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this CheckedFunction8 to the result and the other arguments.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> CheckedFunction8<T1, S, T3, T4, T5, T6, T7, T8, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, before2.apply(s), t3, t4, t5, t6, t7, t8);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
-     * 3rd argument and then applies this CheckedFunction8 to the result and the other arguments.
-     *
-     * @param <S> argument type of before3
-     * @param before3 the function applied before this
-     * @return a function composed of before3 and this
-     * @throws NullPointerException if before3 is null
-     */
-    default <S> CheckedFunction8<T1, T2, S, T4, T5, T6, T7, T8, R> compose3(Function1<? super S, ? extends T3> before3) {
-        Objects.requireNonNull(before3, "before3 is null");
-        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, before3.apply(s), t4, t5, t6, t7, t8);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
-     * 4th argument and then applies this CheckedFunction8 to the result and the other arguments.
-     *
-     * @param <S> argument type of before4
-     * @param before4 the function applied before this
-     * @return a function composed of before4 and this
-     * @throws NullPointerException if before4 is null
-     */
-    default <S> CheckedFunction8<T1, T2, T3, S, T5, T6, T7, T8, R> compose4(Function1<? super S, ? extends T4> before4) {
-        Objects.requireNonNull(before4, "before4 is null");
-        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, t3, before4.apply(s), t5, t6, t7, t8);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
-     * 5th argument and then applies this CheckedFunction8 to the result and the other arguments.
-     *
-     * @param <S> argument type of before5
-     * @param before5 the function applied before this
-     * @return a function composed of before5 and this
-     * @throws NullPointerException if before5 is null
-     */
-    default <S> CheckedFunction8<T1, T2, T3, T4, S, T6, T7, T8, R> compose5(Function1<? super S, ? extends T5> before5) {
-        Objects.requireNonNull(before5, "before5 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, t3, t4, before5.apply(s), t6, t7, t8);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
-     * 6th argument and then applies this CheckedFunction8 to the result and the other arguments.
-     *
-     * @param <S> argument type of before6
-     * @param before6 the function applied before this
-     * @return a function composed of before6 and this
-     * @throws NullPointerException if before6 is null
-     */
-    default <S> CheckedFunction8<T1, T2, T3, T4, T5, S, T7, T8, R> compose6(Function1<? super S, ? extends T6> before6) {
-        Objects.requireNonNull(before6, "before6 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s, T7 t7, T8 t8) -> apply(t1, t2, t3, t4, t5, before6.apply(s), t7, t8);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before7} to the
-     * 7th argument and then applies this CheckedFunction8 to the result and the other arguments.
-     *
-     * @param <S> argument type of before7
-     * @param before7 the function applied before this
-     * @return a function composed of before7 and this
-     * @throws NullPointerException if before7 is null
-     */
-    default <S> CheckedFunction8<T1, T2, T3, T4, T5, T6, S, T8, R> compose7(Function1<? super S, ? extends T7> before7) {
-        Objects.requireNonNull(before7, "before7 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, S s, T8 t8) -> apply(t1, t2, t3, t4, t5, t6, before7.apply(s), t8);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before8} to the
-     * 8th argument and then applies this CheckedFunction8 to the result and the other arguments.
-     *
-     * @param <S> argument type of before8
-     * @param before8 the function applied before this
-     * @return a function composed of before8 and this
-     * @throws NullPointerException if before8 is null
-     */
-    default <S> CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, S, R> compose8(Function1<? super S, ? extends T8> before8) {
-        Objects.requireNonNull(before8, "before8 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, S s) -> apply(t1, t2, t3, t4, t5, t6, t7, before8.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -528,6 +416,117 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Ser
         return (t1, t2, t3, t4, t5, t6, t7, t8) -> after.apply(apply(t1, t2, t3, t4, t5, t6, t7, t8));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> CheckedFunction8<S, T2, T3, T4, T5, T6, T7, T8, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(before1.apply(s), t2, t3, t4, t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> CheckedFunction8<T1, S, T3, T4, T5, T6, T7, T8, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, before2.apply(s), t3, t4, t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> CheckedFunction8<T1, T2, S, T4, T5, T6, T7, T8, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, before3.apply(s), t4, t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> CheckedFunction8<T1, T2, T3, S, T5, T6, T7, T8, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, t3, before4.apply(s), t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> CheckedFunction8<T1, T2, T3, T4, S, T6, T7, T8, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, t3, t4, before5.apply(s), t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
+     * 6th argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before6
+     * @param before6 the function applied before this
+     * @return a function composed of before6 and this
+     * @throws NullPointerException if before6 is null
+     */
+    default <S> CheckedFunction8<T1, T2, T3, T4, T5, S, T7, T8, R> compose6(Function1<? super S, ? extends T6> before6) {
+        Objects.requireNonNull(before6, "before6 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s, T7 t7, T8 t8) -> apply(t1, t2, t3, t4, t5, before6.apply(s), t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before7} to the
+     * 7th argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before7
+     * @param before7 the function applied before this
+     * @return a function composed of before7 and this
+     * @throws NullPointerException if before7 is null
+     */
+    default <S> CheckedFunction8<T1, T2, T3, T4, T5, T6, S, T8, R> compose7(Function1<? super S, ? extends T7> before7) {
+        Objects.requireNonNull(before7, "before7 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, S s, T8 t8) -> apply(t1, t2, t3, t4, t5, t6, before7.apply(s), t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before8} to the
+     * 8th argument and then applies this CheckedFunction8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before8
+     * @param before8 the function applied before this
+     * @return a function composed of before8 and this
+     * @throws NullPointerException if before8 is null
+     */
+    default <S> CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, S, R> compose8(Function1<? super S, ? extends T8> before8) {
+        Objects.requireNonNull(before8, "before8 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, S s) -> apply(t1, t2, t3, t4, t5, t6, t7, before8.apply(s));
+    }
 }
 
 interface CheckedFunction8Module {

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -159,20 +159,6 @@ public interface Function1<T1, R> extends Serializable, Function<T1, R> {
     R apply(T1 t1);
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this Function1 to the result.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> Function1<S, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s) -> apply(before1.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -300,5 +286,19 @@ public interface Function1<T1, R> extends Serializable, Function<T1, R> {
     default <V> Function1<V, R> compose(Function<? super V, ? extends T1> before) {
         Objects.requireNonNull(before, "before is null");
         return v -> apply(before.apply(v));
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function1 to the result.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function1<S, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s) -> apply(before1.apply(s));
     }
 }

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -159,6 +159,20 @@ public interface Function1<T1, R> extends Serializable, Function<T1, R> {
     R apply(T1 t1);
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function1 to the result.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function1<S, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s) -> apply(before1.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/Function2.java
+++ b/vavr/src-gen/main/java/io/vavr/Function2.java
@@ -166,6 +166,34 @@ public interface Function2<T1, T2, R> extends Serializable, BiFunction<T1, T2, R
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function2 to the result and the other argument.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function2<S, T2, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2) -> apply(before1.apply(s), t2);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function2 to the result and the other argument.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function2<T1, S, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s) -> apply(t1, before2.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/Function2.java
+++ b/vavr/src-gen/main/java/io/vavr/Function2.java
@@ -166,34 +166,6 @@ public interface Function2<T1, T2, R> extends Serializable, BiFunction<T1, T2, R
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this Function2 to the result and the other argument.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> Function2<S, T2, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2) -> apply(before1.apply(s), t2);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this Function2 to the result and the other argument.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> Function2<T1, S, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s) -> apply(t1, before2.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -284,4 +256,31 @@ public interface Function2<T1, T2, R> extends Serializable, BiFunction<T1, T2, R
         return (t1, t2) -> after.apply(apply(t1, t2));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function2 to the result and the other argument.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function2<S, T2, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2) -> apply(before1.apply(s), t2);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function2 to the result and the other argument.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function2<T1, S, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s) -> apply(t1, before2.apply(s));
+    }
 }

--- a/vavr/src-gen/main/java/io/vavr/Function3.java
+++ b/vavr/src-gen/main/java/io/vavr/Function3.java
@@ -183,6 +183,48 @@ public interface Function3<T1, T2, T3, R> extends Serializable {
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function3<S, T2, T3, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3) -> apply(before1.apply(s), t2, t3);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function3<T1, S, T3, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3) -> apply(t1, before2.apply(s), t3);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this Function3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> Function3<T1, T2, S, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s) -> apply(t1, t2, before3.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/Function3.java
+++ b/vavr/src-gen/main/java/io/vavr/Function3.java
@@ -183,48 +183,6 @@ public interface Function3<T1, T2, T3, R> extends Serializable {
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this Function3 to the result and the other arguments.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> Function3<S, T2, T3, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2, T3 t3) -> apply(before1.apply(s), t2, t3);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this Function3 to the result and the other arguments.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> Function3<T1, S, T3, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s, T3 t3) -> apply(t1, before2.apply(s), t3);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
-     * 3rd argument and then applies this Function3 to the result and the other arguments.
-     *
-     * @param <S> argument type of before3
-     * @param before3 the function applied before this
-     * @return a function composed of before3 and this
-     * @throws NullPointerException if before3 is null
-     */
-    default <S> Function3<T1, T2, S, R> compose3(Function1<? super S, ? extends T3> before3) {
-        Objects.requireNonNull(before3, "before3 is null");
-        return (T1 t1, T2 t2, S s) -> apply(t1, t2, before3.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -315,4 +273,45 @@ public interface Function3<T1, T2, T3, R> extends Serializable {
         return (t1, t2, t3) -> after.apply(apply(t1, t2, t3));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function3<S, T2, T3, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3) -> apply(before1.apply(s), t2, t3);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function3<T1, S, T3, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3) -> apply(t1, before2.apply(s), t3);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this Function3 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> Function3<T1, T2, S, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s) -> apply(t1, t2, before3.apply(s));
+    }
 }

--- a/vavr/src-gen/main/java/io/vavr/Function4.java
+++ b/vavr/src-gen/main/java/io/vavr/Function4.java
@@ -202,62 +202,6 @@ public interface Function4<T1, T2, T3, T4, R> extends Serializable {
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this Function4 to the result and the other arguments.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> Function4<S, T2, T3, T4, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2, T3 t3, T4 t4) -> apply(before1.apply(s), t2, t3, t4);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this Function4 to the result and the other arguments.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> Function4<T1, S, T3, T4, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s, T3 t3, T4 t4) -> apply(t1, before2.apply(s), t3, t4);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
-     * 3rd argument and then applies this Function4 to the result and the other arguments.
-     *
-     * @param <S> argument type of before3
-     * @param before3 the function applied before this
-     * @return a function composed of before3 and this
-     * @throws NullPointerException if before3 is null
-     */
-    default <S> Function4<T1, T2, S, T4, R> compose3(Function1<? super S, ? extends T3> before3) {
-        Objects.requireNonNull(before3, "before3 is null");
-        return (T1 t1, T2 t2, S s, T4 t4) -> apply(t1, t2, before3.apply(s), t4);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
-     * 4th argument and then applies this Function4 to the result and the other arguments.
-     *
-     * @param <S> argument type of before4
-     * @param before4 the function applied before this
-     * @return a function composed of before4 and this
-     * @throws NullPointerException if before4 is null
-     */
-    default <S> Function4<T1, T2, T3, S, R> compose4(Function1<? super S, ? extends T4> before4) {
-        Objects.requireNonNull(before4, "before4 is null");
-        return (T1 t1, T2 t2, T3 t3, S s) -> apply(t1, t2, t3, before4.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -348,4 +292,59 @@ public interface Function4<T1, T2, T3, T4, R> extends Serializable {
         return (t1, t2, t3, t4) -> after.apply(apply(t1, t2, t3, t4));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function4<S, T2, T3, T4, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4) -> apply(before1.apply(s), t2, t3, t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function4<T1, S, T3, T4, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4) -> apply(t1, before2.apply(s), t3, t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this Function4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> Function4<T1, T2, S, T4, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4) -> apply(t1, t2, before3.apply(s), t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this Function4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> Function4<T1, T2, T3, S, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s) -> apply(t1, t2, t3, before4.apply(s));
+    }
 }

--- a/vavr/src-gen/main/java/io/vavr/Function4.java
+++ b/vavr/src-gen/main/java/io/vavr/Function4.java
@@ -202,6 +202,62 @@ public interface Function4<T1, T2, T3, T4, R> extends Serializable {
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function4<S, T2, T3, T4, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4) -> apply(before1.apply(s), t2, t3, t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function4<T1, S, T3, T4, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4) -> apply(t1, before2.apply(s), t3, t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this Function4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> Function4<T1, T2, S, T4, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4) -> apply(t1, t2, before3.apply(s), t4);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this Function4 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> Function4<T1, T2, T3, S, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s) -> apply(t1, t2, t3, before4.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/Function5.java
+++ b/vavr/src-gen/main/java/io/vavr/Function5.java
@@ -222,76 +222,6 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Serializable {
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this Function5 to the result and the other arguments.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> Function5<S, T2, T3, T4, T5, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2, T3 t3, T4 t4, T5 t5) -> apply(before1.apply(s), t2, t3, t4, t5);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this Function5 to the result and the other arguments.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> Function5<T1, S, T3, T4, T5, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s, T3 t3, T4 t4, T5 t5) -> apply(t1, before2.apply(s), t3, t4, t5);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
-     * 3rd argument and then applies this Function5 to the result and the other arguments.
-     *
-     * @param <S> argument type of before3
-     * @param before3 the function applied before this
-     * @return a function composed of before3 and this
-     * @throws NullPointerException if before3 is null
-     */
-    default <S> Function5<T1, T2, S, T4, T5, R> compose3(Function1<? super S, ? extends T3> before3) {
-        Objects.requireNonNull(before3, "before3 is null");
-        return (T1 t1, T2 t2, S s, T4 t4, T5 t5) -> apply(t1, t2, before3.apply(s), t4, t5);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
-     * 4th argument and then applies this Function5 to the result and the other arguments.
-     *
-     * @param <S> argument type of before4
-     * @param before4 the function applied before this
-     * @return a function composed of before4 and this
-     * @throws NullPointerException if before4 is null
-     */
-    default <S> Function5<T1, T2, T3, S, T5, R> compose4(Function1<? super S, ? extends T4> before4) {
-        Objects.requireNonNull(before4, "before4 is null");
-        return (T1 t1, T2 t2, T3 t3, S s, T5 t5) -> apply(t1, t2, t3, before4.apply(s), t5);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
-     * 5th argument and then applies this Function5 to the result and the other arguments.
-     *
-     * @param <S> argument type of before5
-     * @param before5 the function applied before this
-     * @return a function composed of before5 and this
-     * @throws NullPointerException if before5 is null
-     */
-    default <S> Function5<T1, T2, T3, T4, S, R> compose5(Function1<? super S, ? extends T5> before5) {
-        Objects.requireNonNull(before5, "before5 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, S s) -> apply(t1, t2, t3, t4, before5.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -382,4 +312,73 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Serializable {
         return (t1, t2, t3, t4, t5) -> after.apply(apply(t1, t2, t3, t4, t5));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function5<S, T2, T3, T4, T5, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5) -> apply(before1.apply(s), t2, t3, t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function5<T1, S, T3, T4, T5, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5) -> apply(t1, before2.apply(s), t3, t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this Function5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> Function5<T1, T2, S, T4, T5, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5) -> apply(t1, t2, before3.apply(s), t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this Function5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> Function5<T1, T2, T3, S, T5, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5) -> apply(t1, t2, t3, before4.apply(s), t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this Function5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> Function5<T1, T2, T3, T4, S, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s) -> apply(t1, t2, t3, t4, before5.apply(s));
+    }
 }

--- a/vavr/src-gen/main/java/io/vavr/Function5.java
+++ b/vavr/src-gen/main/java/io/vavr/Function5.java
@@ -222,6 +222,76 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Serializable {
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function5<S, T2, T3, T4, T5, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5) -> apply(before1.apply(s), t2, t3, t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function5<T1, S, T3, T4, T5, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5) -> apply(t1, before2.apply(s), t3, t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this Function5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> Function5<T1, T2, S, T4, T5, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5) -> apply(t1, t2, before3.apply(s), t4, t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this Function5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> Function5<T1, T2, T3, S, T5, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5) -> apply(t1, t2, t3, before4.apply(s), t5);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this Function5 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> Function5<T1, T2, T3, T4, S, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s) -> apply(t1, t2, t3, t4, before5.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/Function6.java
+++ b/vavr/src-gen/main/java/io/vavr/Function6.java
@@ -243,90 +243,6 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Serializable {
     }
 
     /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
-     * 1st argument and then applies this Function6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before1
-     * @param before1 the function applied before this
-     * @return a function composed of before1 and this
-     * @throws NullPointerException if before1 is null
-     */
-    default <S> Function6<S, T2, T3, T4, T5, T6, R> compose1(Function1<? super S, ? extends T1> before1) {
-        Objects.requireNonNull(before1, "before1 is null");
-        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(before1.apply(s), t2, t3, t4, t5, t6);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
-     * 2nd argument and then applies this Function6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before2
-     * @param before2 the function applied before this
-     * @return a function composed of before2 and this
-     * @throws NullPointerException if before2 is null
-     */
-    default <S> Function6<T1, S, T3, T4, T5, T6, R> compose2(Function1<? super S, ? extends T2> before2) {
-        Objects.requireNonNull(before2, "before2 is null");
-        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(t1, before2.apply(s), t3, t4, t5, t6);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
-     * 3rd argument and then applies this Function6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before3
-     * @param before3 the function applied before this
-     * @return a function composed of before3 and this
-     * @throws NullPointerException if before3 is null
-     */
-    default <S> Function6<T1, T2, S, T4, T5, T6, R> compose3(Function1<? super S, ? extends T3> before3) {
-        Objects.requireNonNull(before3, "before3 is null");
-        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6) -> apply(t1, t2, before3.apply(s), t4, t5, t6);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
-     * 4th argument and then applies this Function6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before4
-     * @param before4 the function applied before this
-     * @return a function composed of before4 and this
-     * @throws NullPointerException if before4 is null
-     */
-    default <S> Function6<T1, T2, T3, S, T5, T6, R> compose4(Function1<? super S, ? extends T4> before4) {
-        Objects.requireNonNull(before4, "before4 is null");
-        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6) -> apply(t1, t2, t3, before4.apply(s), t5, t6);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
-     * 5th argument and then applies this Function6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before5
-     * @param before5 the function applied before this
-     * @return a function composed of before5 and this
-     * @throws NullPointerException if before5 is null
-     */
-    default <S> Function6<T1, T2, T3, T4, S, T6, R> compose5(Function1<? super S, ? extends T5> before5) {
-        Objects.requireNonNull(before5, "before5 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6) -> apply(t1, t2, t3, t4, before5.apply(s), t6);
-    }
-
-    /**
-     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
-     * 6th argument and then applies this Function6 to the result and the other arguments.
-     *
-     * @param <S> argument type of before6
-     * @param before6 the function applied before this
-     * @return a function composed of before6 and this
-     * @throws NullPointerException if before6 is null
-     */
-    default <S> Function6<T1, T2, T3, T4, T5, S, R> compose6(Function1<? super S, ? extends T6> before6) {
-        Objects.requireNonNull(before6, "before6 is null");
-        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s) -> apply(t1, t2, t3, t4, t5, before6.apply(s));
-    }
-
-    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
@@ -417,4 +333,87 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Serializable {
         return (t1, t2, t3, t4, t5, t6) -> after.apply(apply(t1, t2, t3, t4, t5, t6));
     }
 
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function6<S, T2, T3, T4, T5, T6, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(before1.apply(s), t2, t3, t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function6<T1, S, T3, T4, T5, T6, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(t1, before2.apply(s), t3, t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> Function6<T1, T2, S, T4, T5, T6, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6) -> apply(t1, t2, before3.apply(s), t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> Function6<T1, T2, T3, S, T5, T6, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6) -> apply(t1, t2, t3, before4.apply(s), t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> Function6<T1, T2, T3, T4, S, T6, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6) -> apply(t1, t2, t3, t4, before5.apply(s), t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
+     * 6th argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before6
+     * @param before6 the function applied before this
+     * @return a function composed of before6 and this
+     * @throws NullPointerException if before6 is null
+     */
+    default <S> Function6<T1, T2, T3, T4, T5, S, R> compose6(Function1<? super S, ? extends T6> before6) {
+        Objects.requireNonNull(before6, "before6 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s) -> apply(t1, t2, t3, t4, t5, before6.apply(s));
+    }
 }

--- a/vavr/src-gen/main/java/io/vavr/Function6.java
+++ b/vavr/src-gen/main/java/io/vavr/Function6.java
@@ -243,6 +243,90 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Serializable {
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function6<S, T2, T3, T4, T5, T6, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(before1.apply(s), t2, t3, t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function6<T1, S, T3, T4, T5, T6, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6) -> apply(t1, before2.apply(s), t3, t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> Function6<T1, T2, S, T4, T5, T6, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6) -> apply(t1, t2, before3.apply(s), t4, t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> Function6<T1, T2, T3, S, T5, T6, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6) -> apply(t1, t2, t3, before4.apply(s), t5, t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> Function6<T1, T2, T3, T4, S, T6, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6) -> apply(t1, t2, t3, t4, before5.apply(s), t6);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
+     * 6th argument and then applies this Function6 to the result and the other arguments.
+     *
+     * @param <S> argument type of before6
+     * @param before6 the function applied before this
+     * @return a function composed of before6 and this
+     * @throws NullPointerException if before6 is null
+     */
+    default <S> Function6<T1, T2, T3, T4, T5, S, R> compose6(Function1<? super S, ? extends T6> before6) {
+        Objects.requireNonNull(before6, "before6 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s) -> apply(t1, t2, t3, t4, t5, before6.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/Function7.java
+++ b/vavr/src-gen/main/java/io/vavr/Function7.java
@@ -265,6 +265,104 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Serializable {
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function7<S, T2, T3, T4, T5, T6, T7, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(before1.apply(s), t2, t3, t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function7<T1, S, T3, T4, T5, T6, T7, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(t1, before2.apply(s), t3, t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this Function7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> Function7<T1, T2, S, T4, T5, T6, T7, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6, T7 t7) -> apply(t1, t2, before3.apply(s), t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this Function7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> Function7<T1, T2, T3, S, T5, T6, T7, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6, T7 t7) -> apply(t1, t2, t3, before4.apply(s), t5, t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this Function7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> Function7<T1, T2, T3, T4, S, T6, T7, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6, T7 t7) -> apply(t1, t2, t3, t4, before5.apply(s), t6, t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
+     * 6th argument and then applies this Function7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before6
+     * @param before6 the function applied before this
+     * @return a function composed of before6 and this
+     * @throws NullPointerException if before6 is null
+     */
+    default <S> Function7<T1, T2, T3, T4, T5, S, T7, R> compose6(Function1<? super S, ? extends T6> before6) {
+        Objects.requireNonNull(before6, "before6 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s, T7 t7) -> apply(t1, t2, t3, t4, t5, before6.apply(s), t7);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before7} to the
+     * 7th argument and then applies this Function7 to the result and the other arguments.
+     *
+     * @param <S> argument type of before7
+     * @param before7 the function applied before this
+     * @return a function composed of before7 and this
+     * @throws NullPointerException if before7 is null
+     */
+    default <S> Function7<T1, T2, T3, T4, T5, T6, S, R> compose7(Function1<? super S, ? extends T7> before7) {
+        Objects.requireNonNull(before7, "before7 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, S s) -> apply(t1, t2, t3, t4, t5, t6, before7.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/main/java/io/vavr/Function7.java
+++ b/vavr/src-gen/main/java/io/vavr/Function7.java
@@ -265,6 +265,97 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Serializable {
     }
 
     /**
+     * Returns the number of function arguments.
+     * @return an int value &gt;= 0
+     * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
+     */
+    default int arity() {
+        return 7;
+    }
+
+    /**
+     * Returns a curried version of this function.
+     *
+     * @return a curried function equivalent to this.
+     */
+    default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, Function1<T6, Function1<T7, R>>>>>>> curried() {
+        return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> t7 -> apply(t1, t2, t3, t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a tupled version of this function.
+     *
+     * @return a tupled function equivalent to this.
+     */
+    default Function1<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled() {
+        return t -> apply(t._1, t._2, t._3, t._4, t._5, t._6, t._7);
+    }
+
+    /**
+     * Returns a reversed version of this function. This may be useful in a recursive context.
+     *
+     * @return a reversed function equivalent to this.
+     */
+    default Function7<T7, T6, T5, T4, T3, T2, T1, R> reversed() {
+        return (t7, t6, t5, t4, t3, t2, t1) -> apply(t1, t2, t3, t4, t5, t6, t7);
+    }
+
+    /**
+     * Returns a memoizing version of this function, which computes the return value for given arguments only one time.
+     * On subsequent calls given the same arguments the memoized value is returned.
+     * <p>
+     * Please note that memoizing functions do not permit {@code null} as single argument or return value.
+     *
+     * @return a memoizing function equivalent to this.
+     */
+    default Function7<T1, T2, T3, T4, T5, T6, T7, R> memoized() {
+        if (isMemoized()) {
+            return this;
+        } else {
+            final Map<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> cache = new HashMap<>();
+            final ReentrantLock lock = new ReentrantLock();
+            return (Function7<T1, T2, T3, T4, T5, T6, T7, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7) -> {
+                final Tuple7<T1, T2, T3, T4, T5, T6, T7> key = Tuple.of(t1, t2, t3, t4, t5, t6, t7);
+                lock.lock();
+                try {
+                    if (cache.containsKey(key)) {
+                        return cache.get(key);
+                    } else {
+                        final R value = tupled().apply(key);
+                        cache.put(key, value);
+                        return value;
+                    }
+                } finally {
+                    lock.unlock();
+                }
+            };
+        }
+    }
+
+    /**
+     * Checks if this function is memoizing (= caching) computed values.
+     *
+     * @return true, if this function is memoizing, false otherwise
+     */
+    default boolean isMemoized() {
+        return this instanceof Memoized;
+    }
+
+    /**
+     * Returns a composed function that first applies this Function7 to the given argument and then applies
+     * {@linkplain Function} {@code after} to the result.
+     *
+     * @param <V> return type of after
+     * @param after the function applied after this
+     * @return a function composed of this and after
+     * @throws NullPointerException if after is null
+     */
+    default <V> Function7<T1, T2, T3, T4, T5, T6, T7, V> andThen(Function<? super R, ? extends V> after) {
+        Objects.requireNonNull(after, "after is null");
+        return (t1, t2, t3, t4, t5, t6, t7) -> after.apply(apply(t1, t2, t3, t4, t5, t6, t7));
+    }
+
+    /**
      * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
      * 1st argument and then applies this Function7 to the result and the other arguments.
      *
@@ -361,96 +452,4 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Serializable {
         Objects.requireNonNull(before7, "before7 is null");
         return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, S s) -> apply(t1, t2, t3, t4, t5, t6, before7.apply(s));
     }
-
-    /**
-     * Returns the number of function arguments.
-     * @return an int value &gt;= 0
-     * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>
-     */
-    default int arity() {
-        return 7;
-    }
-
-    /**
-     * Returns a curried version of this function.
-     *
-     * @return a curried function equivalent to this.
-     */
-    default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, Function1<T6, Function1<T7, R>>>>>>> curried() {
-        return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> t7 -> apply(t1, t2, t3, t4, t5, t6, t7);
-    }
-
-    /**
-     * Returns a tupled version of this function.
-     *
-     * @return a tupled function equivalent to this.
-     */
-    default Function1<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4, t._5, t._6, t._7);
-    }
-
-    /**
-     * Returns a reversed version of this function. This may be useful in a recursive context.
-     *
-     * @return a reversed function equivalent to this.
-     */
-    default Function7<T7, T6, T5, T4, T3, T2, T1, R> reversed() {
-        return (t7, t6, t5, t4, t3, t2, t1) -> apply(t1, t2, t3, t4, t5, t6, t7);
-    }
-
-    /**
-     * Returns a memoizing version of this function, which computes the return value for given arguments only one time.
-     * On subsequent calls given the same arguments the memoized value is returned.
-     * <p>
-     * Please note that memoizing functions do not permit {@code null} as single argument or return value.
-     *
-     * @return a memoizing function equivalent to this.
-     */
-    default Function7<T1, T2, T3, T4, T5, T6, T7, R> memoized() {
-        if (isMemoized()) {
-            return this;
-        } else {
-            final Map<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> cache = new HashMap<>();
-            final ReentrantLock lock = new ReentrantLock();
-            return (Function7<T1, T2, T3, T4, T5, T6, T7, R> & Memoized) (t1, t2, t3, t4, t5, t6, t7) -> {
-                final Tuple7<T1, T2, T3, T4, T5, T6, T7> key = Tuple.of(t1, t2, t3, t4, t5, t6, t7);
-                lock.lock();
-                try {
-                    if (cache.containsKey(key)) {
-                        return cache.get(key);
-                    } else {
-                        final R value = tupled().apply(key);
-                        cache.put(key, value);
-                        return value;
-                    }
-                } finally {
-                    lock.unlock();
-                }
-            };
-        }
-    }
-
-    /**
-     * Checks if this function is memoizing (= caching) computed values.
-     *
-     * @return true, if this function is memoizing, false otherwise
-     */
-    default boolean isMemoized() {
-        return this instanceof Memoized;
-    }
-
-    /**
-     * Returns a composed function that first applies this Function7 to the given argument and then applies
-     * {@linkplain Function} {@code after} to the result.
-     *
-     * @param <V> return type of after
-     * @param after the function applied after this
-     * @return a function composed of this and after
-     * @throws NullPointerException if after is null
-     */
-    default <V> Function7<T1, T2, T3, T4, T5, T6, T7, V> andThen(Function<? super R, ? extends V> after) {
-        Objects.requireNonNull(after, "after is null");
-        return (t1, t2, t3, t4, t5, t6, t7) -> after.apply(apply(t1, t2, t3, t4, t5, t6, t7));
-    }
-
 }

--- a/vavr/src-gen/main/java/io/vavr/Function8.java
+++ b/vavr/src-gen/main/java/io/vavr/Function8.java
@@ -288,6 +288,118 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Serializab
     }
 
     /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before1} to the
+     * 1st argument and then applies this Function8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before1
+     * @param before1 the function applied before this
+     * @return a function composed of before1 and this
+     * @throws NullPointerException if before1 is null
+     */
+    default <S> Function8<S, T2, T3, T4, T5, T6, T7, T8, R> compose1(Function1<? super S, ? extends T1> before1) {
+        Objects.requireNonNull(before1, "before1 is null");
+        return (S s, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(before1.apply(s), t2, t3, t4, t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before2} to the
+     * 2nd argument and then applies this Function8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before2
+     * @param before2 the function applied before this
+     * @return a function composed of before2 and this
+     * @throws NullPointerException if before2 is null
+     */
+    default <S> Function8<T1, S, T3, T4, T5, T6, T7, T8, R> compose2(Function1<? super S, ? extends T2> before2) {
+        Objects.requireNonNull(before2, "before2 is null");
+        return (T1 t1, S s, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, before2.apply(s), t3, t4, t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before3} to the
+     * 3rd argument and then applies this Function8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before3
+     * @param before3 the function applied before this
+     * @return a function composed of before3 and this
+     * @throws NullPointerException if before3 is null
+     */
+    default <S> Function8<T1, T2, S, T4, T5, T6, T7, T8, R> compose3(Function1<? super S, ? extends T3> before3) {
+        Objects.requireNonNull(before3, "before3 is null");
+        return (T1 t1, T2 t2, S s, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, before3.apply(s), t4, t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before4} to the
+     * 4th argument and then applies this Function8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before4
+     * @param before4 the function applied before this
+     * @return a function composed of before4 and this
+     * @throws NullPointerException if before4 is null
+     */
+    default <S> Function8<T1, T2, T3, S, T5, T6, T7, T8, R> compose4(Function1<? super S, ? extends T4> before4) {
+        Objects.requireNonNull(before4, "before4 is null");
+        return (T1 t1, T2 t2, T3 t3, S s, T5 t5, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, t3, before4.apply(s), t5, t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before5} to the
+     * 5th argument and then applies this Function8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before5
+     * @param before5 the function applied before this
+     * @return a function composed of before5 and this
+     * @throws NullPointerException if before5 is null
+     */
+    default <S> Function8<T1, T2, T3, T4, S, T6, T7, T8, R> compose5(Function1<? super S, ? extends T5> before5) {
+        Objects.requireNonNull(before5, "before5 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, S s, T6 t6, T7 t7, T8 t8) -> apply(t1, t2, t3, t4, before5.apply(s), t6, t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before6} to the
+     * 6th argument and then applies this Function8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before6
+     * @param before6 the function applied before this
+     * @return a function composed of before6 and this
+     * @throws NullPointerException if before6 is null
+     */
+    default <S> Function8<T1, T2, T3, T4, T5, S, T7, T8, R> compose6(Function1<? super S, ? extends T6> before6) {
+        Objects.requireNonNull(before6, "before6 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, S s, T7 t7, T8 t8) -> apply(t1, t2, t3, t4, t5, before6.apply(s), t7, t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before7} to the
+     * 7th argument and then applies this Function8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before7
+     * @param before7 the function applied before this
+     * @return a function composed of before7 and this
+     * @throws NullPointerException if before7 is null
+     */
+    default <S> Function8<T1, T2, T3, T4, T5, T6, S, T8, R> compose7(Function1<? super S, ? extends T7> before7) {
+        Objects.requireNonNull(before7, "before7 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, S s, T8 t8) -> apply(t1, t2, t3, t4, t5, t6, before7.apply(s), t8);
+    }
+
+    /**
+     * Returns a composed function that first applies the {@linkplain Function} {@code before8} to the
+     * 8th argument and then applies this Function8 to the result and the other arguments.
+     *
+     * @param <S> argument type of before8
+     * @param before8 the function applied before this
+     * @return a function composed of before8 and this
+     * @throws NullPointerException if before8 is null
+     */
+    default <S> Function8<T1, T2, T3, T4, T5, T6, T7, S, R> compose8(Function1<? super S, ? extends T8> before8) {
+        Objects.requireNonNull(before8, "before8 is null");
+        return (T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, S s) -> apply(t1, t2, t3, t4, t5, t6, t7, before8.apply(s));
+    }
+
+    /**
      * Returns the number of function arguments.
      * @return an int value &gt;= 0
      * @see <a href="http://en.wikipedia.org/wiki/Arity">Arity</a>

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction0Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction0Test.java
@@ -31,6 +31,7 @@ import java.lang.CharSequence;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class CheckedFunction0Test {
@@ -193,6 +194,11 @@ public class CheckedFunction0Test {
         final CheckedFunction1<Object, Object> after = o -> null;
         final CheckedFunction0<Object> composed = f.andThen(after);
         assertThat(composed).isNotNull();
+    }
+
+    @Nested
+    class ComposeTests {
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction1Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction1Test.java
@@ -202,11 +202,10 @@ public class CheckedFunction1Test {
     }
 
     @Test
-    public void shouldComposeWithCompose() {
-        final CheckedFunction1<Object, Object> f = (o1) -> null;
-        final CheckedFunction1<Object, Object> before = o -> null;
-        final CheckedFunction1<Object, Object> composed = f.compose(before);
-        assertThat(composed).isNotNull();
+    public void shouldCompose1()  throws Throwable {
+        final CheckedFunction1<String, String> concat = (String s1) -> s1;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx")).isEqualTo("XX");
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction1Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction1Test.java
@@ -31,6 +31,7 @@ import java.lang.CharSequence;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class CheckedFunction1Test {
@@ -201,11 +202,16 @@ public class CheckedFunction1Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1()  throws Throwable {
-        final CheckedFunction1<String, String> concat = (String s1) -> s1;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx")).isEqualTo("XX");
+    @Nested
+    class ComposeTests {
+
+      @Test
+      public void shouldCompose1()  throws Throwable {
+          final CheckedFunction1<String, String> concat = (String s1) -> s1;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx")).isEqualTo("XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction2Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction2Test.java
@@ -201,6 +201,20 @@ public class CheckedFunction2Test {
     }
 
     @Test
+    public void shouldCompose1()  throws Throwable {
+        final CheckedFunction2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2")).isEqualTo("XXs2");
+    }
+
+    @Test
+    public void shouldCompose2()  throws Throwable {
+        final CheckedFunction2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx")).isEqualTo("s1XX");
+    }
+
+    @Test
     public void shouldNarrow() throws Throwable{
         final CheckedFunction2<Number, Number, String> wideFunction = (o1, o2) -> String.format("Numbers are: %s, %s", o1, o2);
         final CheckedFunction2<Integer, Integer, CharSequence> narrowFunction = CheckedFunction2.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction2Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction2Test.java
@@ -31,6 +31,7 @@ import java.lang.CharSequence;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class CheckedFunction2Test {
@@ -200,18 +201,23 @@ public class CheckedFunction2Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1()  throws Throwable {
-        final CheckedFunction2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2")).isEqualTo("XXs2");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2()  throws Throwable {
-        final CheckedFunction2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx")).isEqualTo("s1XX");
+      @Test
+      public void shouldCompose1()  throws Throwable {
+          final CheckedFunction2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2")).isEqualTo("XXs2");
+      }
+
+      @Test
+      public void shouldCompose2()  throws Throwable {
+          final CheckedFunction2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx")).isEqualTo("s1XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction3Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction3Test.java
@@ -202,6 +202,27 @@ public class CheckedFunction3Test {
     }
 
     @Test
+    public void shouldCompose1()  throws Throwable {
+        final CheckedFunction3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3")).isEqualTo("XXs2s3");
+    }
+
+    @Test
+    public void shouldCompose2()  throws Throwable {
+        final CheckedFunction3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3")).isEqualTo("s1XXs3");
+    }
+
+    @Test
+    public void shouldCompose3()  throws Throwable {
+        final CheckedFunction3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx")).isEqualTo("s1s2XX");
+    }
+
+    @Test
     public void shouldNarrow() throws Throwable{
         final CheckedFunction3<Number, Number, Number, String> wideFunction = (o1, o2, o3) -> String.format("Numbers are: %s, %s, %s", o1, o2, o3);
         final CheckedFunction3<Integer, Integer, Integer, CharSequence> narrowFunction = CheckedFunction3.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction3Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction3Test.java
@@ -31,6 +31,7 @@ import java.lang.CharSequence;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class CheckedFunction3Test {
@@ -201,25 +202,30 @@ public class CheckedFunction3Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1()  throws Throwable {
-        final CheckedFunction3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3")).isEqualTo("XXs2s3");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2()  throws Throwable {
-        final CheckedFunction3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3")).isEqualTo("s1XXs3");
-    }
+      @Test
+      public void shouldCompose1()  throws Throwable {
+          final CheckedFunction3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3")).isEqualTo("XXs2s3");
+      }
 
-    @Test
-    public void shouldCompose3()  throws Throwable {
-        final CheckedFunction3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx")).isEqualTo("s1s2XX");
+      @Test
+      public void shouldCompose2()  throws Throwable {
+          final CheckedFunction3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3")).isEqualTo("s1XXs3");
+      }
+
+      @Test
+      public void shouldCompose3()  throws Throwable {
+          final CheckedFunction3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx")).isEqualTo("s1s2XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction4Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction4Test.java
@@ -203,6 +203,34 @@ public class CheckedFunction4Test {
     }
 
     @Test
+    public void shouldCompose1()  throws Throwable {
+        final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4")).isEqualTo("XXs2s3s4");
+    }
+
+    @Test
+    public void shouldCompose2()  throws Throwable {
+        final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4")).isEqualTo("s1XXs3s4");
+    }
+
+    @Test
+    public void shouldCompose3()  throws Throwable {
+        final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4")).isEqualTo("s1s2XXs4");
+    }
+
+    @Test
+    public void shouldCompose4()  throws Throwable {
+        final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx")).isEqualTo("s1s2s3XX");
+    }
+
+    @Test
     public void shouldNarrow() throws Throwable{
         final CheckedFunction4<Number, Number, Number, Number, String> wideFunction = (o1, o2, o3, o4) -> String.format("Numbers are: %s, %s, %s, %s", o1, o2, o3, o4);
         final CheckedFunction4<Integer, Integer, Integer, Integer, CharSequence> narrowFunction = CheckedFunction4.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction4Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction4Test.java
@@ -31,6 +31,7 @@ import java.lang.CharSequence;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class CheckedFunction4Test {
@@ -202,32 +203,37 @@ public class CheckedFunction4Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1()  throws Throwable {
-        final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4")).isEqualTo("XXs2s3s4");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2()  throws Throwable {
-        final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4")).isEqualTo("s1XXs3s4");
-    }
+      @Test
+      public void shouldCompose1()  throws Throwable {
+          final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4")).isEqualTo("XXs2s3s4");
+      }
 
-    @Test
-    public void shouldCompose3()  throws Throwable {
-        final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4")).isEqualTo("s1s2XXs4");
-    }
+      @Test
+      public void shouldCompose2()  throws Throwable {
+          final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4")).isEqualTo("s1XXs3s4");
+      }
 
-    @Test
-    public void shouldCompose4()  throws Throwable {
-        final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx")).isEqualTo("s1s2s3XX");
+      @Test
+      public void shouldCompose3()  throws Throwable {
+          final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4")).isEqualTo("s1s2XXs4");
+      }
+
+      @Test
+      public void shouldCompose4()  throws Throwable {
+          final CheckedFunction4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx")).isEqualTo("s1s2s3XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction5Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction5Test.java
@@ -31,6 +31,7 @@ import java.lang.CharSequence;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class CheckedFunction5Test {
@@ -203,39 +204,44 @@ public class CheckedFunction5Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1()  throws Throwable {
-        final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5")).isEqualTo("XXs2s3s4s5");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2()  throws Throwable {
-        final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5")).isEqualTo("s1XXs3s4s5");
-    }
+      @Test
+      public void shouldCompose1()  throws Throwable {
+          final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5")).isEqualTo("XXs2s3s4s5");
+      }
 
-    @Test
-    public void shouldCompose3()  throws Throwable {
-        final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5")).isEqualTo("s1s2XXs4s5");
-    }
+      @Test
+      public void shouldCompose2()  throws Throwable {
+          final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5")).isEqualTo("s1XXs3s4s5");
+      }
 
-    @Test
-    public void shouldCompose4()  throws Throwable {
-        final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5")).isEqualTo("s1s2s3XXs5");
-    }
+      @Test
+      public void shouldCompose3()  throws Throwable {
+          final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5")).isEqualTo("s1s2XXs4s5");
+      }
 
-    @Test
-    public void shouldCompose5()  throws Throwable {
-        final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx")).isEqualTo("s1s2s3s4XX");
+      @Test
+      public void shouldCompose4()  throws Throwable {
+          final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5")).isEqualTo("s1s2s3XXs5");
+      }
+
+      @Test
+      public void shouldCompose5()  throws Throwable {
+          final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx")).isEqualTo("s1s2s3s4XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction5Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction5Test.java
@@ -204,6 +204,41 @@ public class CheckedFunction5Test {
     }
 
     @Test
+    public void shouldCompose1()  throws Throwable {
+        final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5")).isEqualTo("XXs2s3s4s5");
+    }
+
+    @Test
+    public void shouldCompose2()  throws Throwable {
+        final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5")).isEqualTo("s1XXs3s4s5");
+    }
+
+    @Test
+    public void shouldCompose3()  throws Throwable {
+        final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5")).isEqualTo("s1s2XXs4s5");
+    }
+
+    @Test
+    public void shouldCompose4()  throws Throwable {
+        final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5")).isEqualTo("s1s2s3XXs5");
+    }
+
+    @Test
+    public void shouldCompose5()  throws Throwable {
+        final CheckedFunction5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx")).isEqualTo("s1s2s3s4XX");
+    }
+
+    @Test
     public void shouldNarrow() throws Throwable{
         final CheckedFunction5<Number, Number, Number, Number, Number, String> wideFunction = (o1, o2, o3, o4, o5) -> String.format("Numbers are: %s, %s, %s, %s, %s", o1, o2, o3, o4, o5);
         final CheckedFunction5<Integer, Integer, Integer, Integer, Integer, CharSequence> narrowFunction = CheckedFunction5.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction6Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction6Test.java
@@ -31,6 +31,7 @@ import java.lang.CharSequence;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class CheckedFunction6Test {
@@ -204,46 +205,51 @@ public class CheckedFunction6Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1()  throws Throwable {
-        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6")).isEqualTo("XXs2s3s4s5s6");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2()  throws Throwable {
-        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6")).isEqualTo("s1XXs3s4s5s6");
-    }
+      @Test
+      public void shouldCompose1()  throws Throwable {
+          final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6")).isEqualTo("XXs2s3s4s5s6");
+      }
 
-    @Test
-    public void shouldCompose3()  throws Throwable {
-        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6")).isEqualTo("s1s2XXs4s5s6");
-    }
+      @Test
+      public void shouldCompose2()  throws Throwable {
+          final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6")).isEqualTo("s1XXs3s4s5s6");
+      }
 
-    @Test
-    public void shouldCompose4()  throws Throwable {
-        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6")).isEqualTo("s1s2s3XXs5s6");
-    }
+      @Test
+      public void shouldCompose3()  throws Throwable {
+          final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6")).isEqualTo("s1s2XXs4s5s6");
+      }
 
-    @Test
-    public void shouldCompose5()  throws Throwable {
-        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6")).isEqualTo("s1s2s3s4XXs6");
-    }
+      @Test
+      public void shouldCompose4()  throws Throwable {
+          final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6")).isEqualTo("s1s2s3XXs5s6");
+      }
 
-    @Test
-    public void shouldCompose6()  throws Throwable {
-        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx")).isEqualTo("s1s2s3s4s5XX");
+      @Test
+      public void shouldCompose5()  throws Throwable {
+          final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6")).isEqualTo("s1s2s3s4XXs6");
+      }
+
+      @Test
+      public void shouldCompose6()  throws Throwable {
+          final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx")).isEqualTo("s1s2s3s4s5XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction6Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction6Test.java
@@ -205,6 +205,48 @@ public class CheckedFunction6Test {
     }
 
     @Test
+    public void shouldCompose1()  throws Throwable {
+        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6")).isEqualTo("XXs2s3s4s5s6");
+    }
+
+    @Test
+    public void shouldCompose2()  throws Throwable {
+        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6")).isEqualTo("s1XXs3s4s5s6");
+    }
+
+    @Test
+    public void shouldCompose3()  throws Throwable {
+        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6")).isEqualTo("s1s2XXs4s5s6");
+    }
+
+    @Test
+    public void shouldCompose4()  throws Throwable {
+        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6")).isEqualTo("s1s2s3XXs5s6");
+    }
+
+    @Test
+    public void shouldCompose5()  throws Throwable {
+        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6")).isEqualTo("s1s2s3s4XXs6");
+    }
+
+    @Test
+    public void shouldCompose6()  throws Throwable {
+        final CheckedFunction6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx")).isEqualTo("s1s2s3s4s5XX");
+    }
+
+    @Test
     public void shouldNarrow() throws Throwable{
         final CheckedFunction6<Number, Number, Number, Number, Number, Number, String> wideFunction = (o1, o2, o3, o4, o5, o6) -> String.format("Numbers are: %s, %s, %s, %s, %s, %s", o1, o2, o3, o4, o5, o6);
         final CheckedFunction6<Integer, Integer, Integer, Integer, Integer, Integer, CharSequence> narrowFunction = CheckedFunction6.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction7Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction7Test.java
@@ -31,6 +31,7 @@ import java.lang.CharSequence;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class CheckedFunction7Test {
@@ -205,53 +206,58 @@ public class CheckedFunction7Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1()  throws Throwable {
-        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7")).isEqualTo("XXs2s3s4s5s6s7");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2()  throws Throwable {
-        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7")).isEqualTo("s1XXs3s4s5s6s7");
-    }
+      @Test
+      public void shouldCompose1()  throws Throwable {
+          final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7")).isEqualTo("XXs2s3s4s5s6s7");
+      }
 
-    @Test
-    public void shouldCompose3()  throws Throwable {
-        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7")).isEqualTo("s1s2XXs4s5s6s7");
-    }
+      @Test
+      public void shouldCompose2()  throws Throwable {
+          final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7")).isEqualTo("s1XXs3s4s5s6s7");
+      }
 
-    @Test
-    public void shouldCompose4()  throws Throwable {
-        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7")).isEqualTo("s1s2s3XXs5s6s7");
-    }
+      @Test
+      public void shouldCompose3()  throws Throwable {
+          final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7")).isEqualTo("s1s2XXs4s5s6s7");
+      }
 
-    @Test
-    public void shouldCompose5()  throws Throwable {
-        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7")).isEqualTo("s1s2s3s4XXs6s7");
-    }
+      @Test
+      public void shouldCompose4()  throws Throwable {
+          final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7")).isEqualTo("s1s2s3XXs5s6s7");
+      }
 
-    @Test
-    public void shouldCompose6()  throws Throwable {
-        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7")).isEqualTo("s1s2s3s4s5XXs7");
-    }
+      @Test
+      public void shouldCompose5()  throws Throwable {
+          final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7")).isEqualTo("s1s2s3s4XXs6s7");
+      }
 
-    @Test
-    public void shouldCompose7()  throws Throwable {
-        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx")).isEqualTo("s1s2s3s4s5s6XX");
+      @Test
+      public void shouldCompose6()  throws Throwable {
+          final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7")).isEqualTo("s1s2s3s4s5XXs7");
+      }
+
+      @Test
+      public void shouldCompose7()  throws Throwable {
+          final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx")).isEqualTo("s1s2s3s4s5s6XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction7Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction7Test.java
@@ -206,6 +206,55 @@ public class CheckedFunction7Test {
     }
 
     @Test
+    public void shouldCompose1()  throws Throwable {
+        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7")).isEqualTo("XXs2s3s4s5s6s7");
+    }
+
+    @Test
+    public void shouldCompose2()  throws Throwable {
+        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7")).isEqualTo("s1XXs3s4s5s6s7");
+    }
+
+    @Test
+    public void shouldCompose3()  throws Throwable {
+        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7")).isEqualTo("s1s2XXs4s5s6s7");
+    }
+
+    @Test
+    public void shouldCompose4()  throws Throwable {
+        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7")).isEqualTo("s1s2s3XXs5s6s7");
+    }
+
+    @Test
+    public void shouldCompose5()  throws Throwable {
+        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7")).isEqualTo("s1s2s3s4XXs6s7");
+    }
+
+    @Test
+    public void shouldCompose6()  throws Throwable {
+        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7")).isEqualTo("s1s2s3s4s5XXs7");
+    }
+
+    @Test
+    public void shouldCompose7()  throws Throwable {
+        final CheckedFunction7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx")).isEqualTo("s1s2s3s4s5s6XX");
+    }
+
+    @Test
     public void shouldNarrow() throws Throwable{
         final CheckedFunction7<Number, Number, Number, Number, Number, Number, Number, String> wideFunction = (o1, o2, o3, o4, o5, o6, o7) -> String.format("Numbers are: %s, %s, %s, %s, %s, %s, %s", o1, o2, o3, o4, o5, o6, o7);
         final CheckedFunction7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, CharSequence> narrowFunction = CheckedFunction7.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction8Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction8Test.java
@@ -207,6 +207,62 @@ public class CheckedFunction8Test {
     }
 
     @Test
+    public void shouldCompose1()  throws Throwable {
+        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("XXs2s3s4s5s6s7s8");
+    }
+
+    @Test
+    public void shouldCompose2()  throws Throwable {
+        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1XXs3s4s5s6s7s8");
+    }
+
+    @Test
+    public void shouldCompose3()  throws Throwable {
+        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1s2XXs4s5s6s7s8");
+    }
+
+    @Test
+    public void shouldCompose4()  throws Throwable {
+        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7", "s8")).isEqualTo("s1s2s3XXs5s6s7s8");
+    }
+
+    @Test
+    public void shouldCompose5()  throws Throwable {
+        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7", "s8")).isEqualTo("s1s2s3s4XXs6s7s8");
+    }
+
+    @Test
+    public void shouldCompose6()  throws Throwable {
+        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7", "s8")).isEqualTo("s1s2s3s4s5XXs7s8");
+    }
+
+    @Test
+    public void shouldCompose7()  throws Throwable {
+        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx", "s8")).isEqualTo("s1s2s3s4s5s6XXs8");
+    }
+
+    @Test
+    public void shouldCompose8()  throws Throwable {
+        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose8(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "s7", "xx")).isEqualTo("s1s2s3s4s5s6s7XX");
+    }
+
+    @Test
     public void shouldNarrow() throws Throwable{
         final CheckedFunction8<Number, Number, Number, Number, Number, Number, Number, Number, String> wideFunction = (o1, o2, o3, o4, o5, o6, o7, o8) -> String.format("Numbers are: %s, %s, %s, %s, %s, %s, %s, %s", o1, o2, o3, o4, o5, o6, o7, o8);
         final CheckedFunction8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, CharSequence> narrowFunction = CheckedFunction8.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/CheckedFunction8Test.java
+++ b/vavr/src-gen/test/java/io/vavr/CheckedFunction8Test.java
@@ -31,6 +31,7 @@ import java.lang.CharSequence;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class CheckedFunction8Test {
@@ -206,60 +207,65 @@ public class CheckedFunction8Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1()  throws Throwable {
-        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("XXs2s3s4s5s6s7s8");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2()  throws Throwable {
-        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1XXs3s4s5s6s7s8");
-    }
+      @Test
+      public void shouldCompose1()  throws Throwable {
+          final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("XXs2s3s4s5s6s7s8");
+      }
 
-    @Test
-    public void shouldCompose3()  throws Throwable {
-        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1s2XXs4s5s6s7s8");
-    }
+      @Test
+      public void shouldCompose2()  throws Throwable {
+          final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1XXs3s4s5s6s7s8");
+      }
 
-    @Test
-    public void shouldCompose4()  throws Throwable {
-        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7", "s8")).isEqualTo("s1s2s3XXs5s6s7s8");
-    }
+      @Test
+      public void shouldCompose3()  throws Throwable {
+          final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1s2XXs4s5s6s7s8");
+      }
 
-    @Test
-    public void shouldCompose5()  throws Throwable {
-        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7", "s8")).isEqualTo("s1s2s3s4XXs6s7s8");
-    }
+      @Test
+      public void shouldCompose4()  throws Throwable {
+          final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7", "s8")).isEqualTo("s1s2s3XXs5s6s7s8");
+      }
 
-    @Test
-    public void shouldCompose6()  throws Throwable {
-        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7", "s8")).isEqualTo("s1s2s3s4s5XXs7s8");
-    }
+      @Test
+      public void shouldCompose5()  throws Throwable {
+          final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7", "s8")).isEqualTo("s1s2s3s4XXs6s7s8");
+      }
 
-    @Test
-    public void shouldCompose7()  throws Throwable {
-        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx", "s8")).isEqualTo("s1s2s3s4s5s6XXs8");
-    }
+      @Test
+      public void shouldCompose6()  throws Throwable {
+          final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7", "s8")).isEqualTo("s1s2s3s4s5XXs7s8");
+      }
 
-    @Test
-    public void shouldCompose8()  throws Throwable {
-        final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose8(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "s7", "xx")).isEqualTo("s1s2s3s4s5s6s7XX");
+      @Test
+      public void shouldCompose7()  throws Throwable {
+          final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx", "s8")).isEqualTo("s1s2s3s4s5s6XXs8");
+      }
+
+      @Test
+      public void shouldCompose8()  throws Throwable {
+          final CheckedFunction8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose8(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "s7", "xx")).isEqualTo("s1s2s3s4s5s6s7XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Function0Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function0Test.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.vavr.control.Try;
 import java.lang.CharSequence;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class Function0Test {
@@ -146,6 +147,11 @@ public class Function0Test {
         final Function1<Object, Object> after = o -> null;
         final Function0<Object> composed = f.andThen(after);
         assertThat(composed).isNotNull();
+    }
+
+    @Nested
+    class ComposeTests {
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Function1Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function1Test.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.vavr.control.Try;
 import java.lang.CharSequence;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class Function1Test {
@@ -178,11 +179,16 @@ public class Function1Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1() {
-        final Function1<String, String> concat = (String s1) -> s1;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx")).isEqualTo("XX");
+    @Nested
+    class ComposeTests {
+
+      @Test
+      public void shouldCompose1() {
+          final Function1<String, String> concat = (String s1) -> s1;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx")).isEqualTo("XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Function1Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function1Test.java
@@ -179,11 +179,10 @@ public class Function1Test {
     }
 
     @Test
-    public void shouldComposeWithCompose() {
-        final Function1<Object, Object> f = (o1) -> null;
-        final Function1<Object, Object> before = o -> null;
-        final Function1<Object, Object> composed = f.compose(before);
-        assertThat(composed).isNotNull();
+    public void shouldCompose1() {
+        final Function1<String, String> concat = (String s1) -> s1;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx")).isEqualTo("XX");
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Function2Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function2Test.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.vavr.control.Try;
 import java.lang.CharSequence;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class Function2Test {
@@ -158,18 +159,23 @@ public class Function2Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1() {
-        final Function2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2")).isEqualTo("XXs2");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2() {
-        final Function2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx")).isEqualTo("s1XX");
+      @Test
+      public void shouldCompose1() {
+          final Function2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2")).isEqualTo("XXs2");
+      }
+
+      @Test
+      public void shouldCompose2() {
+          final Function2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx")).isEqualTo("s1XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Function2Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function2Test.java
@@ -159,6 +159,20 @@ public class Function2Test {
     }
 
     @Test
+    public void shouldCompose1() {
+        final Function2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2")).isEqualTo("XXs2");
+    }
+
+    @Test
+    public void shouldCompose2() {
+        final Function2<String, String, String> concat = (String s1, String s2) -> s1 + s2;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx")).isEqualTo("s1XX");
+    }
+
+    @Test
     public void shouldNarrow(){
         final Function2<Number, Number, String> wideFunction = (o1, o2) -> String.format("Numbers are: %s, %s", o1, o2);
         final Function2<Integer, Integer, CharSequence> narrowFunction = Function2.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/Function3Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function3Test.java
@@ -160,6 +160,27 @@ public class Function3Test {
     }
 
     @Test
+    public void shouldCompose1() {
+        final Function3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3")).isEqualTo("XXs2s3");
+    }
+
+    @Test
+    public void shouldCompose2() {
+        final Function3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3")).isEqualTo("s1XXs3");
+    }
+
+    @Test
+    public void shouldCompose3() {
+        final Function3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx")).isEqualTo("s1s2XX");
+    }
+
+    @Test
     public void shouldNarrow(){
         final Function3<Number, Number, Number, String> wideFunction = (o1, o2, o3) -> String.format("Numbers are: %s, %s, %s", o1, o2, o3);
         final Function3<Integer, Integer, Integer, CharSequence> narrowFunction = Function3.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/Function3Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function3Test.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.vavr.control.Try;
 import java.lang.CharSequence;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class Function3Test {
@@ -159,25 +160,30 @@ public class Function3Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1() {
-        final Function3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3")).isEqualTo("XXs2s3");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2() {
-        final Function3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3")).isEqualTo("s1XXs3");
-    }
+      @Test
+      public void shouldCompose1() {
+          final Function3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3")).isEqualTo("XXs2s3");
+      }
 
-    @Test
-    public void shouldCompose3() {
-        final Function3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx")).isEqualTo("s1s2XX");
+      @Test
+      public void shouldCompose2() {
+          final Function3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3")).isEqualTo("s1XXs3");
+      }
+
+      @Test
+      public void shouldCompose3() {
+          final Function3<String, String, String, String> concat = (String s1, String s2, String s3) -> s1 + s2 + s3;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx")).isEqualTo("s1s2XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Function4Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function4Test.java
@@ -161,6 +161,34 @@ public class Function4Test {
     }
 
     @Test
+    public void shouldCompose1() {
+        final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4")).isEqualTo("XXs2s3s4");
+    }
+
+    @Test
+    public void shouldCompose2() {
+        final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4")).isEqualTo("s1XXs3s4");
+    }
+
+    @Test
+    public void shouldCompose3() {
+        final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4")).isEqualTo("s1s2XXs4");
+    }
+
+    @Test
+    public void shouldCompose4() {
+        final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx")).isEqualTo("s1s2s3XX");
+    }
+
+    @Test
     public void shouldNarrow(){
         final Function4<Number, Number, Number, Number, String> wideFunction = (o1, o2, o3, o4) -> String.format("Numbers are: %s, %s, %s, %s", o1, o2, o3, o4);
         final Function4<Integer, Integer, Integer, Integer, CharSequence> narrowFunction = Function4.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/Function4Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function4Test.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.vavr.control.Try;
 import java.lang.CharSequence;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class Function4Test {
@@ -160,32 +161,37 @@ public class Function4Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1() {
-        final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4")).isEqualTo("XXs2s3s4");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2() {
-        final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4")).isEqualTo("s1XXs3s4");
-    }
+      @Test
+      public void shouldCompose1() {
+          final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4")).isEqualTo("XXs2s3s4");
+      }
 
-    @Test
-    public void shouldCompose3() {
-        final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4")).isEqualTo("s1s2XXs4");
-    }
+      @Test
+      public void shouldCompose2() {
+          final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4")).isEqualTo("s1XXs3s4");
+      }
 
-    @Test
-    public void shouldCompose4() {
-        final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx")).isEqualTo("s1s2s3XX");
+      @Test
+      public void shouldCompose3() {
+          final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4")).isEqualTo("s1s2XXs4");
+      }
+
+      @Test
+      public void shouldCompose4() {
+          final Function4<String, String, String, String, String> concat = (String s1, String s2, String s3, String s4) -> s1 + s2 + s3 + s4;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx")).isEqualTo("s1s2s3XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Function5Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function5Test.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.vavr.control.Try;
 import java.lang.CharSequence;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class Function5Test {
@@ -161,39 +162,44 @@ public class Function5Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1() {
-        final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5")).isEqualTo("XXs2s3s4s5");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2() {
-        final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5")).isEqualTo("s1XXs3s4s5");
-    }
+      @Test
+      public void shouldCompose1() {
+          final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5")).isEqualTo("XXs2s3s4s5");
+      }
 
-    @Test
-    public void shouldCompose3() {
-        final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5")).isEqualTo("s1s2XXs4s5");
-    }
+      @Test
+      public void shouldCompose2() {
+          final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5")).isEqualTo("s1XXs3s4s5");
+      }
 
-    @Test
-    public void shouldCompose4() {
-        final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5")).isEqualTo("s1s2s3XXs5");
-    }
+      @Test
+      public void shouldCompose3() {
+          final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5")).isEqualTo("s1s2XXs4s5");
+      }
 
-    @Test
-    public void shouldCompose5() {
-        final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx")).isEqualTo("s1s2s3s4XX");
+      @Test
+      public void shouldCompose4() {
+          final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5")).isEqualTo("s1s2s3XXs5");
+      }
+
+      @Test
+      public void shouldCompose5() {
+          final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx")).isEqualTo("s1s2s3s4XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Function5Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function5Test.java
@@ -162,6 +162,41 @@ public class Function5Test {
     }
 
     @Test
+    public void shouldCompose1() {
+        final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5")).isEqualTo("XXs2s3s4s5");
+    }
+
+    @Test
+    public void shouldCompose2() {
+        final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5")).isEqualTo("s1XXs3s4s5");
+    }
+
+    @Test
+    public void shouldCompose3() {
+        final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5")).isEqualTo("s1s2XXs4s5");
+    }
+
+    @Test
+    public void shouldCompose4() {
+        final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5")).isEqualTo("s1s2s3XXs5");
+    }
+
+    @Test
+    public void shouldCompose5() {
+        final Function5<String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5) -> s1 + s2 + s3 + s4 + s5;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx")).isEqualTo("s1s2s3s4XX");
+    }
+
+    @Test
     public void shouldNarrow(){
         final Function5<Number, Number, Number, Number, Number, String> wideFunction = (o1, o2, o3, o4, o5) -> String.format("Numbers are: %s, %s, %s, %s, %s", o1, o2, o3, o4, o5);
         final Function5<Integer, Integer, Integer, Integer, Integer, CharSequence> narrowFunction = Function5.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/Function6Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function6Test.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.vavr.control.Try;
 import java.lang.CharSequence;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class Function6Test {
@@ -162,46 +163,51 @@ public class Function6Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1() {
-        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6")).isEqualTo("XXs2s3s4s5s6");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2() {
-        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6")).isEqualTo("s1XXs3s4s5s6");
-    }
+      @Test
+      public void shouldCompose1() {
+          final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6")).isEqualTo("XXs2s3s4s5s6");
+      }
 
-    @Test
-    public void shouldCompose3() {
-        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6")).isEqualTo("s1s2XXs4s5s6");
-    }
+      @Test
+      public void shouldCompose2() {
+          final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6")).isEqualTo("s1XXs3s4s5s6");
+      }
 
-    @Test
-    public void shouldCompose4() {
-        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6")).isEqualTo("s1s2s3XXs5s6");
-    }
+      @Test
+      public void shouldCompose3() {
+          final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6")).isEqualTo("s1s2XXs4s5s6");
+      }
 
-    @Test
-    public void shouldCompose5() {
-        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6")).isEqualTo("s1s2s3s4XXs6");
-    }
+      @Test
+      public void shouldCompose4() {
+          final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6")).isEqualTo("s1s2s3XXs5s6");
+      }
 
-    @Test
-    public void shouldCompose6() {
-        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx")).isEqualTo("s1s2s3s4s5XX");
+      @Test
+      public void shouldCompose5() {
+          final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6")).isEqualTo("s1s2s3s4XXs6");
+      }
+
+      @Test
+      public void shouldCompose6() {
+          final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx")).isEqualTo("s1s2s3s4s5XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Function6Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function6Test.java
@@ -163,6 +163,48 @@ public class Function6Test {
     }
 
     @Test
+    public void shouldCompose1() {
+        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6")).isEqualTo("XXs2s3s4s5s6");
+    }
+
+    @Test
+    public void shouldCompose2() {
+        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6")).isEqualTo("s1XXs3s4s5s6");
+    }
+
+    @Test
+    public void shouldCompose3() {
+        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6")).isEqualTo("s1s2XXs4s5s6");
+    }
+
+    @Test
+    public void shouldCompose4() {
+        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6")).isEqualTo("s1s2s3XXs5s6");
+    }
+
+    @Test
+    public void shouldCompose5() {
+        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6")).isEqualTo("s1s2s3s4XXs6");
+    }
+
+    @Test
+    public void shouldCompose6() {
+        final Function6<String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6) -> s1 + s2 + s3 + s4 + s5 + s6;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx")).isEqualTo("s1s2s3s4s5XX");
+    }
+
+    @Test
     public void shouldNarrow(){
         final Function6<Number, Number, Number, Number, Number, Number, String> wideFunction = (o1, o2, o3, o4, o5, o6) -> String.format("Numbers are: %s, %s, %s, %s, %s, %s", o1, o2, o3, o4, o5, o6);
         final Function6<Integer, Integer, Integer, Integer, Integer, Integer, CharSequence> narrowFunction = Function6.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/Function7Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function7Test.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.vavr.control.Try;
 import java.lang.CharSequence;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class Function7Test {
@@ -163,53 +164,58 @@ public class Function7Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1() {
-        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7")).isEqualTo("XXs2s3s4s5s6s7");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2() {
-        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7")).isEqualTo("s1XXs3s4s5s6s7");
-    }
+      @Test
+      public void shouldCompose1() {
+          final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7")).isEqualTo("XXs2s3s4s5s6s7");
+      }
 
-    @Test
-    public void shouldCompose3() {
-        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7")).isEqualTo("s1s2XXs4s5s6s7");
-    }
+      @Test
+      public void shouldCompose2() {
+          final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7")).isEqualTo("s1XXs3s4s5s6s7");
+      }
 
-    @Test
-    public void shouldCompose4() {
-        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7")).isEqualTo("s1s2s3XXs5s6s7");
-    }
+      @Test
+      public void shouldCompose3() {
+          final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7")).isEqualTo("s1s2XXs4s5s6s7");
+      }
 
-    @Test
-    public void shouldCompose5() {
-        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7")).isEqualTo("s1s2s3s4XXs6s7");
-    }
+      @Test
+      public void shouldCompose4() {
+          final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7")).isEqualTo("s1s2s3XXs5s6s7");
+      }
 
-    @Test
-    public void shouldCompose6() {
-        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7")).isEqualTo("s1s2s3s4s5XXs7");
-    }
+      @Test
+      public void shouldCompose5() {
+          final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7")).isEqualTo("s1s2s3s4XXs6s7");
+      }
 
-    @Test
-    public void shouldCompose7() {
-        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx")).isEqualTo("s1s2s3s4s5s6XX");
+      @Test
+      public void shouldCompose6() {
+          final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7")).isEqualTo("s1s2s3s4s5XXs7");
+      }
+
+      @Test
+      public void shouldCompose7() {
+          final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx")).isEqualTo("s1s2s3s4s5s6XX");
+      }
+
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Function7Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function7Test.java
@@ -164,6 +164,55 @@ public class Function7Test {
     }
 
     @Test
+    public void shouldCompose1() {
+        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7")).isEqualTo("XXs2s3s4s5s6s7");
+    }
+
+    @Test
+    public void shouldCompose2() {
+        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7")).isEqualTo("s1XXs3s4s5s6s7");
+    }
+
+    @Test
+    public void shouldCompose3() {
+        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7")).isEqualTo("s1s2XXs4s5s6s7");
+    }
+
+    @Test
+    public void shouldCompose4() {
+        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7")).isEqualTo("s1s2s3XXs5s6s7");
+    }
+
+    @Test
+    public void shouldCompose5() {
+        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7")).isEqualTo("s1s2s3s4XXs6s7");
+    }
+
+    @Test
+    public void shouldCompose6() {
+        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7")).isEqualTo("s1s2s3s4s5XXs7");
+    }
+
+    @Test
+    public void shouldCompose7() {
+        final Function7<String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7) -> s1 + s2 + s3 + s4 + s5 + s6 + s7;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx")).isEqualTo("s1s2s3s4s5s6XX");
+    }
+
+    @Test
     public void shouldNarrow(){
         final Function7<Number, Number, Number, Number, Number, Number, Number, String> wideFunction = (o1, o2, o3, o4, o5, o6, o7) -> String.format("Numbers are: %s, %s, %s, %s, %s, %s, %s", o1, o2, o3, o4, o5, o6, o7);
         final Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, CharSequence> narrowFunction = Function7.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/Function8Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function8Test.java
@@ -165,6 +165,62 @@ public class Function8Test {
     }
 
     @Test
+    public void shouldCompose1() {
+        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("XXs2s3s4s5s6s7s8");
+    }
+
+    @Test
+    public void shouldCompose2() {
+        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1XXs3s4s5s6s7s8");
+    }
+
+    @Test
+    public void shouldCompose3() {
+        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1s2XXs4s5s6s7s8");
+    }
+
+    @Test
+    public void shouldCompose4() {
+        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7", "s8")).isEqualTo("s1s2s3XXs5s6s7s8");
+    }
+
+    @Test
+    public void shouldCompose5() {
+        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7", "s8")).isEqualTo("s1s2s3s4XXs6s7s8");
+    }
+
+    @Test
+    public void shouldCompose6() {
+        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7", "s8")).isEqualTo("s1s2s3s4s5XXs7s8");
+    }
+
+    @Test
+    public void shouldCompose7() {
+        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx", "s8")).isEqualTo("s1s2s3s4s5s6XXs8");
+    }
+
+    @Test
+    public void shouldCompose8() {
+        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+        final Function1<String, String> toUpperCase = String::toUpperCase;
+        assertThat(concat.compose8(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "s7", "xx")).isEqualTo("s1s2s3s4s5s6s7XX");
+    }
+
+    @Test
     public void shouldNarrow(){
         final Function8<Number, Number, Number, Number, Number, Number, Number, Number, String> wideFunction = (o1, o2, o3, o4, o5, o6, o7, o8) -> String.format("Numbers are: %s, %s, %s, %s, %s, %s, %s, %s", o1, o2, o3, o4, o5, o6, o7, o8);
         final Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, CharSequence> narrowFunction = Function8.narrow(wideFunction);

--- a/vavr/src-gen/test/java/io/vavr/Function8Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Function8Test.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.vavr.control.Try;
 import java.lang.CharSequence;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class Function8Test {
@@ -164,60 +165,65 @@ public class Function8Test {
         assertThat(composed).isNotNull();
     }
 
-    @Test
-    public void shouldCompose1() {
-        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("XXs2s3s4s5s6s7s8");
-    }
+    @Nested
+    class ComposeTests {
 
-    @Test
-    public void shouldCompose2() {
-        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1XXs3s4s5s6s7s8");
-    }
+      @Test
+      public void shouldCompose1() {
+          final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose1(toUpperCase).apply("xx", "s2", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("XXs2s3s4s5s6s7s8");
+      }
 
-    @Test
-    public void shouldCompose3() {
-        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1s2XXs4s5s6s7s8");
-    }
+      @Test
+      public void shouldCompose2() {
+          final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose2(toUpperCase).apply("s1", "xx", "s3", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1XXs3s4s5s6s7s8");
+      }
 
-    @Test
-    public void shouldCompose4() {
-        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7", "s8")).isEqualTo("s1s2s3XXs5s6s7s8");
-    }
+      @Test
+      public void shouldCompose3() {
+          final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose3(toUpperCase).apply("s1", "s2", "xx", "s4", "s5", "s6", "s7", "s8")).isEqualTo("s1s2XXs4s5s6s7s8");
+      }
 
-    @Test
-    public void shouldCompose5() {
-        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7", "s8")).isEqualTo("s1s2s3s4XXs6s7s8");
-    }
+      @Test
+      public void shouldCompose4() {
+          final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose4(toUpperCase).apply("s1", "s2", "s3", "xx", "s5", "s6", "s7", "s8")).isEqualTo("s1s2s3XXs5s6s7s8");
+      }
 
-    @Test
-    public void shouldCompose6() {
-        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7", "s8")).isEqualTo("s1s2s3s4s5XXs7s8");
-    }
+      @Test
+      public void shouldCompose5() {
+          final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose5(toUpperCase).apply("s1", "s2", "s3", "s4", "xx", "s6", "s7", "s8")).isEqualTo("s1s2s3s4XXs6s7s8");
+      }
 
-    @Test
-    public void shouldCompose7() {
-        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx", "s8")).isEqualTo("s1s2s3s4s5s6XXs8");
-    }
+      @Test
+      public void shouldCompose6() {
+          final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose6(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "xx", "s7", "s8")).isEqualTo("s1s2s3s4s5XXs7s8");
+      }
 
-    @Test
-    public void shouldCompose8() {
-        final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
-        final Function1<String, String> toUpperCase = String::toUpperCase;
-        assertThat(concat.compose8(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "s7", "xx")).isEqualTo("s1s2s3s4s5s6s7XX");
+      @Test
+      public void shouldCompose7() {
+          final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose7(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "xx", "s8")).isEqualTo("s1s2s3s4s5s6XXs8");
+      }
+
+      @Test
+      public void shouldCompose8() {
+          final Function8<String, String, String, String, String, String, String, String, String> concat = (String s1, String s2, String s3, String s4, String s5, String s6, String s7, String s8) -> s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+          final Function1<String, String> toUpperCase = String::toUpperCase;
+          assertThat(concat.compose8(toUpperCase).apply("s1", "s2", "s3", "s4", "s5", "s6", "s7", "xx")).isEqualTo("s1s2s3s4s5s6s7XX");
+      }
+
     }
 
     @Test


### PR DESCRIPTION
I was in need of function composition for 2+ arity functions, but these were not present on the function types.

- [x] Add (generated) `composeN` method(s) to `Function`, adding a composition function to the nth parameter
  - `composeN` method name is numbered (e.g. `compose1`) to prevent ambiguity
- [x] Add (generated) tests

Open considerations:
- `Function1#compose` now has a (virtually) duplicate `compose1`, is this an issue?
- Should the input argument be `Function` or `Function1`?
- This pattern and naming scheme could also be used to add `curryN`, `applyN` etc.,
