### PR TITLE
Use snapshot version of 'vavr-match' and 'vavr-match-processor'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,12 @@ jobs:
           architecture: ${{ matrix.architecture }}
           cache: 'maven'
 
+      # this is a temporary workaround until new Maven Central snapshot publishing is sorted out
+      - name: Build vavr-match snapshot
+        run: git clone https://github.com/vavr-io/vavr-match.git && mvn -f vavr-match/pom.xml install -DskipTests
+
+      - name: Build vavr-match-processor snapshot
+        run: git clone https://github.com/vavr-io/vavr-match-processor.git && mvn -f vavr-match-processor/pom.xml install -DskipTests
+
       - name: Build with Maven
         run: mvn test

--- a/.github/workflows/doclint-version.yml
+++ b/.github/workflows/doclint-version.yml
@@ -21,5 +21,12 @@ jobs:
           architecture: 'x64'
           cache: 'maven'
 
+      # this is a temporary workaround until new Maven Central snapshot publishing is sorted out
+      - name: Build vavr-match snapshot
+        run: git clone https://github.com/vavr-io/vavr-match.git && mvn -f vavr-match/pom.xml install -DskipTests
+
+      - name: Build vavr-match-processor snapshot
+        run: git clone https://github.com/vavr-io/vavr-match-processor.git && mvn -f vavr-match-processor/pom.xml install -DskipTests
+
       - name: Validate JavaDocs
         run: mvn javadoc:javadoc

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,3 @@
-<!--
-
-Before creating a pull request, the following goals should be executed locally:
-
-* Executing tests: `mvn clean test`
-* Executing doclint: `mvn javadoc:javadoc`
-
-Tests & Code coverage:
-
-* Executing benchmark assertions: `mvn clean test -Pbenchmark`
-* Executing benchmarks (long running!): `mvn test -Pbenchmark -pl vavr-benchmark`
-
-We use these goals frequently to keep the dependencies and plugins up-to-date:
-
-* Update version properties: `mvn versions:update-properties`
-* Check for new plugin version: `mvn versions:display-plugin-updates`
-
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.vavr</groupId>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -22,13 +22,13 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>vavr-match</artifactId>
-            <version>0.10.6</version>
+            <version>0.11.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>vavr-match-processor</artifactId>
-            <version>0.10.6</version>
+            <version>0.11.0-SNAPSHOT</version>
             <optional>true</optional>
         </dependency>
 


### PR DESCRIPTION
since the new Maven Central publishing is not sorted out, we need to leave with a workaround for a short while