### PR TITLE
Fix javadoc stylesheet location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
                         <links>
                             <link>https://docs.oracle.com/javase/8/docs/api/</link>
                         </links>
-                        <stylesheetfile>${basedir}/../.javadoc/stylesheet.css</stylesheetfile>
+                        <stylesheetfile>${basedir}/.javadoc/stylesheet.css</stylesheetfile>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -330,7 +330,7 @@
                             <links>
                                 <link>https://docs.oracle.com/javase/8/docs/api/</link>
                             </links>
-                            <stylesheetfile>${basedir}/../.javadoc/stylesheet.css</stylesheetfile>
+                            <stylesheetfile>${basedir}/.javadoc/stylesheet.css</stylesheetfile>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
### before:
<img width="787" height="557" alt="Screenshot 2025-07-20 at 08 30 10" src="https://github.com/user-attachments/assets/758b04d9-2710-49a5-ac46-5100c39cc9c5" />
### after:
<img width="1240" height="453" alt="Screenshot 2025-07-20 at 08 30 51" src="https://github.com/user-attachments/assets/ce06488e-a255-4ae6-97a3-4bb7334e2d54" />

---

fixes: https://github.com/vavr-io/vavr/issues/3049
