### PR TITLE
New feature: Either.cond

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Either.java
+++ b/vavr/src/main/java/io/vavr/control/Either.java
@@ -112,6 +112,101 @@ public interface Either<L, R> extends Value<R>, Serializable {
     }
 
     /**
+     * Decides which {@code Either<L, R>} to return, depending on the test value -
+     * if it's true, the result will be a {@link Either.Right},
+     * if it's false - the result will be a {@link Either.Left}
+     *
+     * @param test   A {@code Boolean} value to evaluate
+     * @param right  A {@code Supplier<? extends R>} supplier of right value, called if test is true
+     * @param left   A {@code Supplier<? extends L>} supplier of left value, called if test is false
+     * @param <L>    Type of left value
+     * @param <R>    Type of right value
+     *
+     * @return {@code Either<L, R>} with right or left value, depending on the test condition evaluation
+     *
+     * @throws NullPointerException if any of the arguments is null
+     * @author Adam Kopeć
+     */
+    static <L, R> Either<L, R> cond(Boolean test, Supplier<? extends R> right, Supplier<? extends L> left) {
+        Objects.requireNonNull(test, "test is null");
+        Objects.requireNonNull(right, "right is null");
+        Objects.requireNonNull(left, "left is null");
+
+        return test ? right(right.get()) : left(left.get());
+    }
+
+    /**
+     * Decides which {@code Either<L, R>} to return, depending on the test value -
+     * if it's true, the result will be a {@link Either.Right},
+     * if it's false - the result will be a {@link Either.Left}
+     *
+     * @param test   A {@code Boolean} value to evaluate
+     * @param right  A n{@code R} right value, returned if test is true
+     * @param left   A {@code L} left value, returned if test is false
+     * @param <L>    Type of left value
+     * @param <R>    Type of right value
+     *
+     * @return {@code Either<L, R>} with right or left value, depending on the test condition evaluation
+     *
+     * @throws NullPointerException if any of the arguments is null
+     * @author Adam Kopeć
+     */
+    static <L, R> Either<L, R> cond(Boolean test, R right, L left) {
+        Objects.requireNonNull(test, "test is null");
+        Objects.requireNonNull(right, "right is null");
+        Objects.requireNonNull(left, "left is null");
+
+        return cond(test, () -> right, () -> left);
+    }
+
+    /**
+     * Decides which {@code Either<L, R>} to return, depending on the test value -
+     * if it's true, the result will be a {@link Either.Right},
+     * if it's false - the result will be a {@link Either.Left}
+     *
+     * @param test   A {@code Boolean} value to evaluate
+     * @param right  A {@code Supplier<? extends R>} supplier of right value, called if test is true
+     * @param left   A {@code L} left value, returned if test is false
+     * @param <L>    Type of left value
+     * @param <R>    Type of right value
+     *
+     * @return {@code Either<L, R>} with right or left value, depending on the test condition evaluation
+     *
+     * @throws NullPointerException if any of the arguments is null
+     * @author Adam Kopeć
+     */
+    static <L, R> Either<L, R> cond(Boolean test, Supplier<? extends R> right, L left) {
+        Objects.requireNonNull(test, "test is null");
+        Objects.requireNonNull(right, "right is null");
+        Objects.requireNonNull(left, "left is null");
+
+        return cond(test, right, () -> left);
+    }
+
+    /**
+     * Decides which {@code Either<L, R>} to return, depending on the test value -
+     * if it's true, the result will be a {@link Either.Right},
+     * if it's false - the result will be a {@link Either.Left}
+     *
+     * @param test   A {@code Boolean} value to evaluate
+     * @param right  A {@code R} right value, returned if test is true
+     * @param left   A {@code Supplier<? extends L>} supplier of left value, called if test is false
+     * @param <L>    Type of left value
+     * @param <R>    Type of right value
+     *
+     * @return {@code Either<L, R>} with right or left value, depending on the test condition evaluation
+     *
+     * @throws NullPointerException if any of the arguments is null
+     * @author Adam Kopeć
+     */
+    static <L, R> Either<L, R> cond(Boolean test, R right, Supplier<? extends L> left) {
+        Objects.requireNonNull(test, "test is null");
+        Objects.requireNonNull(right, "right is null");
+        Objects.requireNonNull(left, "left is null");
+
+        return cond(test, () -> right, left);
+    }
+    /**
      * Returns the left value.
      *
      * @return The left value.

--- a/vavr/src/test/java/io/vavr/control/EitherTest.java
+++ b/vavr/src/test/java/io/vavr/control/EitherTest.java
@@ -32,6 +32,7 @@ import static io.vavr.API.Left;
 import static io.vavr.API.Right;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("deprecation")
 public class EitherTest extends AbstractValueTest {
@@ -330,6 +331,93 @@ public class EitherTest extends AbstractValueTest {
             Either<String, Integer> either = Either.left("vavr");
             Either<CharSequence, Number> narrow = Either.narrow(either);
             assertThat(narrow.getLeft()).isEqualTo("vavr");
+        }
+    }
+
+    @Nested
+    public class CondTests {
+
+        @Test
+        public void shouldReturnRightIfTestTrue() {
+            Either<String, Integer> either = Either.cond(true, () -> 21, () -> "vavr");
+            assertThat(either).isEqualTo(Either.right(21));
+        }
+
+        @Test
+        public void shouldReturnLeftIfTestFalse() {
+            Either<String, Integer> either = Either.cond(false, () -> 21, () -> "vavr");
+            assertThat(either).isEqualTo(Either.left("vavr"));
+        }
+
+        @Test
+        public void shouldNotEvaluateRightSupplierOnFalse() {
+            Either<String, Integer> either = Either.cond(false, () -> {
+                fail("Should not be called");
+                return 21;
+            }, () -> "vavr");
+            assertThat(either).isEqualTo(Either.left("vavr"));
+        }
+
+        @Test
+        public void shouldNotEvaluateLeftSupplierOnTrue() {
+            Either<String, Integer> either = Either.cond(true, () -> 21, () -> {
+                fail("Should not be called");
+                return "vavr";
+            });
+            assertThat(either).isEqualTo(Either.right(21));
+        }
+        private class Animal {
+            String name;
+            Animal(String name) { this.name = name; }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (!(o instanceof Animal)) return false;
+                Animal other = (Animal) o;
+                return name.equals(other.name);
+            }
+
+            @Override
+            public int hashCode() {
+                return name.hashCode();
+            }
+        }
+
+        private class Dog extends Animal {
+            Dog(String name) { super(name); }
+        }
+
+        private class Cat extends Animal {
+            Cat(String name) { super(name); }
+        }
+
+        @Test
+        public void shouldBeFineWithCovariantLeft() {
+            Either<Animal, Integer> either = Either.cond(false, () -> 21, () -> new Cat("vavr"));
+            assertThat(either).isEqualTo(Either.left(new Cat("vavr")));
+        }
+
+        @Test
+        public void shouldBeFineWithCovariantRight() {
+            Either<String, Animal> either = Either.cond(true, () -> new Dog("vavr"), () -> "vavr");
+            assertThat(either).isEqualTo(Either.right(new Dog("vavr")));
+        }
+
+        @Test
+        public void shouldMakeTheSameDecisionNoMatterHowItsCalled() {
+            Either<String, Integer> e1 = Either.cond(true, () -> 21, () -> "vavr");
+            Either<String, Integer> e3 = Either.cond(true, 21, "vavr");
+            Either<String, Integer> e2 = Either.cond(true, 21, () -> "vavr");
+            Either<String, Integer> e4 = Either.cond(true, () -> 21, "vavr");
+
+            Either<String, Integer> e5 = Either.cond(false, () -> 21, () -> "vavr");
+            Either<String, Integer> e6 = Either.cond(false, 21, "vavr");
+            Either<String, Integer> e7 = Either.cond(false, 21, () -> "vavr");
+            Either<String, Integer> e8 = Either.cond(false, () -> 21, "vavr");
+
+            assertThat(List.of(e1, e2, e3, e4)).allMatch(e -> e.equals(Either.right(21)));
+            assertThat(List.of(e5, e6, e7, e8)).allMatch(e -> e.equals(Either.left("vavr")));
         }
     }
 


### PR DESCRIPTION
Added support for Either.cond, similar to the one we can find in the Scala library:
https://github.com/scala/scala/blob/6a23d33c53afa7b42f64bebaee9e0fc24479df6f/src/library/scala/util/Either.scala#L507