### PR TITLE
Fix: Missing type overrides for .mapTo and .mapToVoid

### DIFF
--- a/vavr/src/main/java/io/vavr/Lazy.java
+++ b/vavr/src/main/java/io/vavr/Lazy.java
@@ -224,6 +224,16 @@ public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
     }
 
     @Override
+    public <U> Lazy<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public Lazy<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     public Lazy<T> peek(Consumer<? super T> action) {
         action.accept(get());
         return this;

--- a/vavr/src/main/java/io/vavr/Value.java
+++ b/vavr/src/main/java/io/vavr/Value.java
@@ -70,6 +70,8 @@ import static io.vavr.API.*;
  * <li>{@link #getOrElseTry(CheckedFunction0)}</li>
  * <li>{@link #getOrNull()}</li>
  * <li>{@link #map(Function)}</li>
+ * <li>{@link #mapTo(Object)}</li>
+ * <li>{@link #mapToVoid()}</li>
  * <li>{@link #stringPrefix()}</li>
  * </ul>
  *

--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -972,6 +972,16 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    public <U> Array<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public Array<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     public Array<T> orElse(Iterable<? extends T> other) {
         return isEmpty() ? ofAll(other) : this;
     }

--- a/vavr/src/main/java/io/vavr/collection/BitSet.java
+++ b/vavr/src/main/java/io/vavr/collection/BitSet.java
@@ -589,6 +589,16 @@ public interface BitSet<T> extends SortedSet<T> {
     }
 
     @Override
+    default <U> SortedSet<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default SortedSet<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     BitSet<T> remove(T element);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -669,6 +669,16 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     }
 
     @Override
+    public <U> IndexedSeq<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public IndexedSeq<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     public String mkString() {
         return back;
     }

--- a/vavr/src/main/java/io/vavr/collection/HashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/HashSet.java
@@ -715,6 +715,16 @@ public final class HashSet<T> implements Set<T>, Serializable {
     }
 
     @Override
+    public <U> HashSet<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public HashSet<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     public String mkString(CharSequence prefix, CharSequence delimiter, CharSequence suffix) {
         return iterator().mkString(prefix, delimiter, suffix);
     }

--- a/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/IndexedSeq.java
@@ -231,6 +231,16 @@ public interface IndexedSeq<T> extends Seq<T> {
     <U> IndexedSeq<U> map(Function<? super T, ? extends U> mapper);
 
     @Override
+    default <U> IndexedSeq<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default IndexedSeq<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     IndexedSeq<T> orElse(Iterable<? extends T> other);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Iterator.java
+++ b/vavr/src/main/java/io/vavr/collection/Iterator.java
@@ -1702,6 +1702,16 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     }
 
     @Override
+    default <U> Iterator<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Iterator<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     default Iterator<T> orElse(Iterable<? extends T> other) {
         return isEmpty() ? ofAll(other) : this;
     }

--- a/vavr/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/LinearSeq.java
@@ -213,6 +213,16 @@ public interface LinearSeq<T> extends Seq<T> {
     <U> LinearSeq<U> map(Function<? super T, ? extends U> mapper);
 
     @Override
+    default <U> LinearSeq<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default LinearSeq<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     LinearSeq<T> orElse(Iterable<? extends T> other);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -736,6 +736,16 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
     }
 
     @Override
+    public <U> LinkedHashSet<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public LinkedHashSet<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     public String mkString(CharSequence prefix, CharSequence delimiter, CharSequence suffix) {
         return iterator().mkString(prefix, delimiter, suffix);
     }

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -1057,6 +1057,16 @@ public interface List<T> extends LinearSeq<T> {
     }
 
     @Override
+    default <U> List<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default List<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     default List<T> orElse(Iterable<? extends T> other) {
         return isEmpty() ? ofAll(other) : this;
     }

--- a/vavr/src/main/java/io/vavr/collection/Map.java
+++ b/vavr/src/main/java/io/vavr/collection/Map.java
@@ -424,6 +424,16 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
         return (Seq<U>) iterator().map(mapper).toStream();
     }
 
+    @Override
+    default <U> Seq<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Seq<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
     /**
      * Maps the entries of this {@code Map} to form a new {@code Map}.
      *

--- a/vavr/src/main/java/io/vavr/collection/Multimap.java
+++ b/vavr/src/main/java/io/vavr/collection/Multimap.java
@@ -410,6 +410,16 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
         return (Seq<U>) iterator().map(mapper).toStream();
     }
 
+    @Override
+    default <U> Seq<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Seq<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
     /**
      * Maps the values of this {@code Multimap} while preserving the corresponding keys.
      *

--- a/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
+++ b/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
@@ -464,6 +464,16 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
         return map(Comparators.naturalComparator(), mapper);
     }
 
+    @Override
+    public <U> PriorityQueue<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public PriorityQueue<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
     public <U> PriorityQueue<U> map(Comparator<U> comparator, Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(comparator, "comparator is null");
         Objects.requireNonNull(mapper, "mapper is null");

--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -995,6 +995,16 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     }
 
     @Override
+    public <U> Queue<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public Queue<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     public Queue<T> orElse(Iterable<? extends T> other) {
         return isEmpty() ? ofAll(other) : this;
     }

--- a/vavr/src/main/java/io/vavr/collection/Seq.java
+++ b/vavr/src/main/java/io/vavr/collection/Seq.java
@@ -1217,6 +1217,16 @@ public interface Seq<T> extends Traversable<T>, PartialFunction<Integer, T>, Ser
     <U> Seq<U> map(Function<? super T, ? extends U> mapper);
 
     @Override
+    default <U> Seq<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Seq<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     Seq<T> orElse(Iterable<? extends T> other);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Set.java
+++ b/vavr/src/main/java/io/vavr/collection/Set.java
@@ -249,6 +249,16 @@ public interface Set<T> extends Traversable<T>, Function1<T, Boolean>, Serializa
     <U> Set<U> map(Function<? super T, ? extends U> mapper);
 
     @Override
+    default <U> Set<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Set<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     Set<T> orElse(Iterable<? extends T> other);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/SortedSet.java
+++ b/vavr/src/main/java/io/vavr/collection/SortedSet.java
@@ -150,6 +150,16 @@ public interface SortedSet<T> extends Set<T>, Ordered<T> {
     <U> SortedSet<U> map(Function<? super T, ? extends U> mapper);
 
     @Override
+    default <U> SortedSet<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default SortedSet<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     SortedSet<T> orElse(Iterable<? extends T> other);
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -1237,6 +1237,16 @@ public interface Stream<T> extends LinearSeq<T> {
     }
 
     @Override
+    default <U> Stream<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Stream<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     default Stream<T> padTo(int length, T element) {
         if (length <= 0) {
             return this;

--- a/vavr/src/main/java/io/vavr/collection/Traversable.java
+++ b/vavr/src/main/java/io/vavr/collection/Traversable.java
@@ -808,6 +808,16 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
     @Override
     <U> Traversable<U> map(Function<? super T, ? extends U> mapper);
 
+    @Override
+    default <U> Traversable<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Traversable<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
     /**
      * Calculates the maximum of this elements according to their natural order. Especially the underlying
      * order of sorted collections is not taken into account.

--- a/vavr/src/main/java/io/vavr/collection/Tree.java
+++ b/vavr/src/main/java/io/vavr/collection/Tree.java
@@ -630,6 +630,16 @@ public interface Tree<T> extends Traversable<T>, Serializable {
     }
 
     @Override
+    default <U> Tree<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Tree<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     default Tree<T> orElse(Iterable<? extends T> other) {
         return isEmpty() ? ofAll(other) : this;
     }

--- a/vavr/src/main/java/io/vavr/collection/TreeSet.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeSet.java
@@ -771,6 +771,16 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
         return map(Comparators.naturalComparator(), mapper);
     }
 
+    @Override
+    public <U> TreeSet<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public TreeSet<Void> mapToVoid() {
+        return map((o1, o2) -> 0, ignored -> null);
+    }
+
     /**
      * Returns this {@code TreeSet} if it is nonempty,
      * otherwise {@code TreeSet} created from iterable, using existing comparator.
@@ -1015,11 +1025,6 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     @Override
     public <U> SortedSet<U> zipWithIndex(BiFunction<? super T, ? super Integer, ? extends U> mapper) {
         return TreeSet.ofAll(Comparators.naturalComparator(), iterator().zipWithIndex(mapper));
-    }
-
-    @Override
-    public TreeSet<Void> mapToVoid() {
-        return map((o1, o2) -> 0, ignored -> null);
     }
 
     // -- Object

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -870,6 +870,16 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
     }
 
     @Override
+    public <U> Vector<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public Vector<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     public Vector<T> orElse(Iterable<? extends T> other) {
         return isEmpty() ? ofAll(other) : this;
     }

--- a/vavr/src/main/java/io/vavr/concurrent/Future.java
+++ b/vavr/src/main/java/io/vavr/concurrent/Future.java
@@ -1282,6 +1282,16 @@ public interface Future<T> extends Value<T> {
         return transformValue(t -> t.map(mapper));
     }
 
+    @Override
+    default <U> Future<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Future<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
     default <U> Future<U> mapTry(CheckedFunction1<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return transformValue(t -> t.mapTry(mapper));

--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -390,6 +390,15 @@ public interface Option<T> extends Value<T>, Serializable {
         return isEmpty() ? none() : some(mapper.apply(get()));
     }
 
+    @Override
+    default <U> Option<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Option<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
 
     /**
      * Converts this to a {@link Try}, then runs the given checked function if this is a {@link Try.Success},

--- a/vavr/src/main/java/io/vavr/control/Try.java
+++ b/vavr/src/main/java/io/vavr/control/Try.java
@@ -583,6 +583,16 @@ public interface Try<T> extends Value<T>, Serializable {
         return mapTry(mapper::apply);
     }
 
+    @Override
+    default <U> Try<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    default Try<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
     /**
      * Maps the cause to a new exception if this is a {@code Failure} or returns this instance if this is a {@code Success}.
      * <p>

--- a/vavr/src/test/java/io/vavr/collection/IntMap.java
+++ b/vavr/src/test/java/io/vavr/collection/IntMap.java
@@ -224,6 +224,16 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
+    public <U> Seq<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public Seq<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     public IntMap<T> orElse(Iterable<? extends T> other) {
         return unit(original.orElse(List.ofAll(other).zipWithIndex().map(t -> Tuple.of(t._2, t._1))));
     }

--- a/vavr/src/test/java/io/vavr/collection/IntMultimap.java
+++ b/vavr/src/test/java/io/vavr/collection/IntMultimap.java
@@ -225,6 +225,16 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
     }
 
     @Override
+    public <U> Seq<U> mapTo(U value) {
+        return map(ignored -> value);
+    }
+
+    @Override
+    public Seq<Void> mapToVoid() {
+        return map(ignored -> null);
+    }
+
+    @Override
     public IntMultimap<T> orElse(Iterable<? extends T> other) {
         return unit(original.orElse(List.ofAll(other).zipWithIndex().map(t -> Tuple.of(t._2, t._1))));
     }


### PR DESCRIPTION
It completes the feature we just merged here: https://github.com/vavr-io/vavr/pull/3086
