### PR TITLE
Fix: flaky tests of set comparison

### DIFF
--- a/vavr/src/test/java/io/vavr/AbstractValueTest.java
+++ b/vavr/src/test/java/io/vavr/AbstractValueTest.java
@@ -804,9 +804,9 @@ public abstract class AbstractValueTest {
         final Value<Integer> value = of(1, 2, 3);
         final java.util.Set<Integer> set = value.toJavaSet();
         if (value.isSingleValued()) {
-            assertThat(set).isEqualTo(JavaCollections.javaSet(1));
+            assertThat(set).containsExactlyInAnyOrderElementsOf(JavaCollections.javaSet(1));
         } else {
-            assertThat(set).isEqualTo(JavaCollections.javaSet(1, 2, 3));
+            assertThat(set).containsExactlyInAnyOrderElementsOf(JavaCollections.javaSet(1, 2, 3));
         }
     }
 
@@ -815,9 +815,9 @@ public abstract class AbstractValueTest {
         final Value<Integer> value = of(1, 2, 3);
         final java.util.Set<Integer> set = value.toJavaSet(java.util.HashSet::new);
         if (value.isSingleValued()) {
-            assertThat(set).isEqualTo(JavaCollections.javaSet(1));
+            assertThat(set).containsExactlyInAnyOrderElementsOf(JavaCollections.javaSet(1));
         } else {
-            assertThat(set).isEqualTo(JavaCollections.javaSet(1, 2, 3));
+            assertThat(set).containsExactlyInAnyOrderElementsOf(JavaCollections.javaSet(1, 2, 3));
         }
     }
 

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -2601,7 +2601,7 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         expected.add(2);
         expected.add(1);
         expected.add(3);
-        assertThat(of(1, 2, 2, 3).toJavaSet()).isEqualTo(expected);
+        assertThat(of(1, 2, 2, 3).toJavaSet()).containsExactlyInAnyOrderElementsOf(expected);
     }
 
     // toTree


### PR DESCRIPTION
### Description

The flaky tests below were found with [NonDex](https://github.com/TestingResearchIllinois/NonDex), which explores non-determinism in tests. These tests can fail due to different iteration orders under different JVMs, hash seeds, etc.

- `AbstractValueTest.shouldConvertToJavaSetUsingSupplier`
- `AbstractValueTest.shouldConvertToJavaSet`
- `AbstractTraversableTest.shouldConvertNonNilToHashSet`

### Root Cause
The `assertThat(Iterable<T>)` returns an `IterableAssert`, even when we pass a Set. The comparator `isEqualTo(...)` for `IterableAssert` is order-sensitive and can iterate through the sets in difference orders.

### Fix 
Use `containsExactlyInAnyOrderElementsOf` from assertJ which is order-insensitive.

### Notes
The fix only modifies test code but not production code.

### Failure Reproduction
- Java version:
```
openjdk 17.0.16 2025-07-15
OpenJDK Runtime Environment (build 17.0.16+8-Ubuntu-0ubuntu124.04.1)
OpenJDK 64-Bit Server VM (build 17.0.16+8-Ubuntu-0ubuntu124.04.1, mixed mode, sharing)
```
- OS version:
`Ubuntu 24.04.3 LTS`

Build the module and run tests with [NonDex](https://github.com/TestingResearchIllinois/NonDex), for example:
```
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -pl vavr \
    -Dtest=IteratorTest#shouldConvertToJavaSetUsingSupplier \
    -Djacoco.skip -Drat.skip -Dpmd.skip -Denforcer.skip
```