### PR TITLE
Upgrade min JDK requirement to 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21', '24', '25']
+        java: ['21', '22', '23', '24', '25', '26-ea']
         architecture: [ 'x64' ]
       fail-fast: false
     name: Build with JDK ${{ matrix.java }} on ${{ matrix.architecture }}

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.vavr</groupId>
     <artifactId>vavr-parent</artifactId>
-    <version>0.11.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Vavr Parent</name>
     <description>Vavr (formerly called Javaslang) is an object-functional language extension to Java 8+.</description>
@@ -39,7 +39,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <assertj.core.version>3.27.6</assertj.core.version>
         <eclipse.lifecycle.mapping.version>1.0.0</eclipse.lifecycle.mapping.version>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
         <jmh.version>1.37</jmh.version>
         <junit.version>5.13.4</junit.version>
         <maven.enforcer.version>3.6.2</maven.enforcer.version>
@@ -59,7 +59,6 @@
         <spotless.version>3.1.0</spotless.version>
         <maven.source.version>3.4.0</maven.source.version>
         <maven.exec.version>3.6.2</maven.exec.version>
-        <moditect.version>1.3.0.Final</moditect.version>
         <scala.maven.version>4.9.8</scala.maven.version>
         <scala.version>3.7.4</scala.version>
     </properties>
@@ -119,11 +118,6 @@
         </plugins>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.moditect</groupId>
-                    <artifactId>moditect-maven-plugin</artifactId>
-                    <version>${moditect.version}</version>
-                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
@@ -217,19 +211,47 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compiler.version}</version>
                     <configuration>
+                        <release>${java.version}</release>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
                         <showDeprecation>true</showDeprecation>
                         <showWarnings>true</showWarnings>
                         <compilerArgs>
-                            <arg>-Werror</arg>
                             <arg>-Xlint:all</arg>
-                            <!-- Workaround for JDK bug https://bugs.openjdk.java.net/browse/JDK-6999068 -->
-                            <arg>-Xlint:-processing</arg>
-                            <!-- Enable Java 9 compilation with 1.8 compatibility -->
-                            <arg>-Xlint:-options</arg>
+                            <arg>-Xlint:-processing</arg> <!-- Workaround for JDK bug https://bugs.openjdk.java.net/browse/JDK-6999068 -->
                         </compilerArgs>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>io.vavr</groupId>
+                                <artifactId>vavr-match</artifactId>
+                                <version>0.11.0</version>
+                            </path>
+                            <path>
+                                <groupId>io.vavr</groupId>
+                                <artifactId>vavr-match-processor</artifactId>
+                                <version>0.11.0</version>
+                            </path>
+                        </annotationProcessorPaths>
+                        <annotationProcessors>
+                            <annotationProcessor>
+                                io.vavr.match.PatternsProcessor
+                            </annotationProcessor>
+                        </annotationProcessors>
                     </configuration>
+
+                    <executions>
+                        <execution>
+                            <id>default-testCompile</id>
+                            <goals>
+                                <goal>testCompile</goal>
+                            </goals>
+                            <configuration>
+                                <compilerArgs>
+                                    <arg>-Xlint:none</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -257,7 +279,6 @@
                             <phase>prepare-package</phase>
                             <goals>
                                 <goal>jar-no-fork</goal>
-                                <goal>test-jar-no-fork</goal>
                             </goals>
                         </execution>
                     </executions>
@@ -303,36 +324,6 @@
         </pluginManagement>
     </build>
     <profiles>
-        <profile>
-            <!-- https://github.com/jspecify/jspecify/issues/302 -->
-            <id>jdk8-no-werror</id>
-            <activation>
-                <jdk>[1.8,1.8]</jdk>
-            </activation>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${maven.compiler.version}</version>
-                        <configuration>
-                            <source>${java.version}</source>
-                            <target>${java.version}</target>
-                            <showDeprecation>true</showDeprecation>
-                            <showWarnings>true</showWarnings>
-                            <compilerArgs>
-                                <arg>-Xlint:all</arg>
-                                <!-- Workaround for JDK bug https://bugs.openjdk.java.net/browse/JDK-6999068 -->
-                                <arg>-Xlint:-processing</arg>
-                                <!-- Enable Java 9 compilation with 1.8 compatibility -->
-                                <arg>-Xlint:-options</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>maven-central-release</id>
             <build>

--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.vavr</groupId>
         <artifactId>vavr-parent</artifactId>
-        <version>0.11.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>vavr</artifactId>
@@ -70,13 +70,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessors>
-                        <annotationProcessor>
-                            io.vavr.match.PatternsProcessor
-                        </annotationProcessor>
-                    </annotationProcessors>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -89,35 +82,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.moditect</groupId>
-                <artifactId>moditect-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-module-infos</id>
-                        <goals>
-                            <goal>add-module-info</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <jvmVersion>9</jvmVersion>
-                            <module>
-                                <moduleInfoSource>
-                                    module io.vavr {
-                                        exports io.vavr;
-                                        exports io.vavr.collection;
-                                        exports io.vavr.control;
-                                        exports io.vavr.concurrent;
-                                        requires io.vavr.match;
-                                        requires static org.jspecify;
-                                    }
-                                </moduleInfoSource>
-                            </module>
-                            <overwriteExistingFiles>true</overwriteExistingFiles>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/vavr/src/main/java/module-info.java
+++ b/vavr/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module io.vavr {
+    exports io.vavr;
+    exports io.vavr.collection;
+    exports io.vavr.control;
+    exports io.vavr.concurrent;
+    requires io.vavr.match;
+    requires static org.jspecify;
+}


### PR DESCRIPTION
This change updates Vavr's minimum required JDK to 21.

With JDK 21, we can safely default Vavr’s asynchronous execution to **virtual threads** instead of the traditional ForkJoinPool.

JDK 21 introduces [record patterns](https://openjdk.org/jeps/440), which allow cleaner, type-safe pattern matching in our monads, and makes it possible to move away from home-grown pattern matching.

 For example:

```java
switch (Option.of("")) {
    case Some<>(String foo) -> ...
    case None<String> none -> ...
}
```
