### PR TITLE
Make Lazy.value explicitly volatile

### DIFF
--- a/vavr/src/main/java/io/vavr/Lazy.java
+++ b/vavr/src/main/java/io/vavr/Lazy.java
@@ -68,7 +68,7 @@ public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
     private transient volatile Supplier<? extends T> supplier;
 
     @SuppressWarnings("serial") // Conditionally serializable
-    private T value; // will behave as a volatile in reality, because a supplier volatile read will update all fields (see https://www.cs.umd.edu/~pugh/java/memoryModel/jsr-133-faq.html#volatile)
+    private volatile T value;
 
     // should not be called directly
     private Lazy(Supplier<? extends T> supplier) {
@@ -118,10 +118,9 @@ public final class Lazy<T> implements Value<T>, Supplier<T>, Serializable {
      * @return a {@code Lazy} containing a sequence of the evaluated values
      * @throws NullPointerException if {@code values} is null
      */
-    @SuppressWarnings("Convert2MethodRef") // TODO should be fixed in JDK 9 and Idea
     public static <T> Lazy<Seq<T>> sequence(@NonNull Iterable<? extends Lazy<? extends T>> values) {
         Objects.requireNonNull(values, "values is null");
-        return Lazy.of(() -> Vector.ofAll(values).map(lazy -> lazy.get()));
+        return Lazy.of(() -> Vector.ofAll(values).map(Lazy::get));
     }
 
     /**


### PR DESCRIPTION
While the comment is correct, it's way more pragmatic to explicitly mark the field as _volatile_