### PR TITLE
require static 'io.vavr.match'

### DIFF
--- a/vavr/src/main/java/module-info.java
+++ b/vavr/src/main/java/module-info.java
@@ -3,6 +3,6 @@ module io.vavr {
     exports io.vavr.collection;
     exports io.vavr.control;
     exports io.vavr.concurrent;
-    requires io.vavr.match;
+    requires static io.vavr.match;
     requires static org.jspecify;
 }


### PR DESCRIPTION
those annotations are required only during compilation