### PR TITLE
spike: migrate Tuple* to record types

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -51,7 +51,7 @@ case class Arity(i: Int) {
   val paramsDecl: String = (1 to i).gen(j => s"T$j t$j")(using ", ") // "T1 t1, T2 t2, T3 t3"
   val params: String = (1 to i).gen(j => s"t$j")(using ", ") // "t1, t2, t3"
   val paramsReversed: String = (1 to i).reverse.gen(j => s"t$j")(using ", ") // "t3, t2, t1"
-  val tupled: String = (1 to i).gen(j => s"t._$j")(using ", ") // "t._1, t._2, t._3"
+  val tupled: String = (1 to i).gen(j => s"t._$j()")(using ", ") // "t._1(), t._2(), t._3()"
   val underscoreParams: String = (1 to i).gen(j => s"_$j")(using ", ") // "_1, _2, _3"
 
   /** Generates @param javadoc tags for type parameters T1..Ti */
@@ -1593,7 +1593,7 @@ def genAPIMatch(im: ImportManager): String = {
                         @Override
                         public $resultType apply(T obj) {
                             ${if (i == 1) xs"""
-                              return (T1) unapply.apply(obj)._1;
+                              return (T1) unapply.apply(obj)._1();
                             """ else xs"""
                               return ($resultType) unapply.apply(obj);
                             """}
@@ -1605,7 +1605,7 @@ def genAPIMatch(im: ImportManager): String = {
                             if (type.isInstance(obj)) {
                                 final $unapplyTupleType u = unapply.apply(obj);
                                 return
-                                        ${(1 to i).gen(j => s"((Pattern<U$j, ?>) p$j).isDefinedAt(u._$j)")(using " &&\n")};
+                                        ${(1 to i).gen(j => s"((Pattern<U$j, ?>) p$j).isDefinedAt(u._$j())")(using " &&\n")};
                             } else {
                                 return false;
                             }
@@ -2262,34 +2262,20 @@ def generateMainClasses(): Unit = {
         /**
          * A tuple of ${i.numerus("element")} which can be seen as cartesian product of ${i.numerus("component")}.
          ${(0 to i).gen(j => if (j == 0) "*" else s"* @param <T$j> type of the ${j.ordinal} element")(using "\n")}
-         * @author Daniel Dietrich
+         * @author Daniel Dietrich, Grzegorz Piwowarek
          */
-        public final class $className$generics implements Tuple, Comparable<$className$generics>, ${im.getType("java.io.Serializable")} {
-
-            private static final long serialVersionUID = 1L;
-
-            ${(1 to i).gen(j => xs"""
-              /$javadoc
-               * The ${j.ordinal} element of this tuple.
-               */
-              @SuppressWarnings("serial") // Conditionally serializable
-              public final T$j _$j;
-            """)(using "\n\n")}
+        public record $className$generics(${(1 to i).gen(j => xs"T$j _$j")(using ", ")}) implements Tuple, Comparable<$className$generics>, ${im.getType("java.io.Serializable")} {
 
             ${if (i == 0) xs"""
               /$javadoc
                * The singleton instance of Tuple0.
                */
-              private static final Tuple0 INSTANCE = new Tuple0 ();
+              private static final Tuple0 INSTANCE = new Tuple0();
 
               /$javadoc
                * The singleton Tuple0 comparator.
                */
               private static final Comparator<Tuple0> COMPARATOR = (Comparator<Tuple0> & Serializable) (t1, t2) -> 0;
-
-              // hidden constructor, internally called
-              private Tuple0 () {
-              }
 
               /$javadoc
                * Returns the singleton instance of Tuple0.
@@ -2299,30 +2285,20 @@ def generateMainClasses(): Unit = {
               public static Tuple0 instance() {
                   return INSTANCE;
               }
-            """ else xs"""
-              /$javadoc
-               * Constructs a tuple of ${i.numerus("element")}.
-               ${(0 to i).gen(j => if (j == 0) "*" else s"* @param t$j the ${j.ordinal} element")(using "\n")}
-               */
-              public $className($paramsDecl) {
-                  ${(1 to i).gen(j => s"this._$j = t$j;")(using "\n")}
-              }
-            """}
+            """ else ""}
 
             public static $generics $Comparator<$className$generics> comparator(${(1 to i).gen(j => s"$Comparator<? super T$j> t${j}Comp")(using ", ")}) {
                 ${if (i == 0) xs"""
                   return COMPARATOR;
                 """ else xs"""
                   return (Comparator<$className$generics> & Serializable) (t1, t2) -> {
-                      ${(1 to i).gen(j => xs"""
+                      ${(1 until i).gen(j => xs"""
                         final int check$j = t${j}Comp.compare(t1._$j, t2._$j);
                         if (check$j != 0) {
                             return check$j;
                         }
                       """)(using "\n\n")}
-
-                      // all components are equal
-                      return 0;
+                      return t${i}Comp.compare(t1._$i, t2._$i);
                   };
                 """}
             }
@@ -2333,15 +2309,13 @@ def generateMainClasses(): Unit = {
                   final $className$resultGenerics t1 = ($className$resultGenerics) o1;
                   final $className$resultGenerics t2 = ($className$resultGenerics) o2;
 
-                  ${(1 to i).gen(j => xs"""
+                  ${(1 until i).gen(j => xs"""
                     final int check$j = t1._$j.compareTo(t2._$j);
                     if (check$j != 0) {
                         return check$j;
                     }
                   """)(using "\n\n")}
-
-                  // all components are equal
-                  return 0;
+                  return t1._$i.compareTo(t2._$i);
               }
             """)}
 
@@ -2360,15 +2334,6 @@ def generateMainClasses(): Unit = {
             }
 
             ${(1 to i).gen(j => xs"""
-              /$javadoc
-               * Getter of the ${j.ordinal} element of this tuple.
-               *
-               * @return the ${j.ordinal} element of this Tuple.
-               */
-              public T$j _$j() {
-                  return _$j;
-              }
-
               /$javadoc
                * Sets the ${j.ordinal} element of this tuple to the given {@code value}.
                *
@@ -2394,7 +2359,7 @@ def generateMainClasses(): Unit = {
               /$javadoc
                * Converts the tuple to java.util.Map.Entry {@code Tuple}.
                *
-               * @return A  java.util.Map.Entry where the first element is the key and the second
+               * @return A java.util.Map.Entry where the first element is the key and the second
                * element is the value.
                */
               public Map.Entry$generics toEntry() {
@@ -2409,7 +2374,7 @@ def generateMainClasses(): Unit = {
                *
                * @param mapper the mapper function
                ${(1 to i).gen(j => s"* @param <U$j> new type of the ${j.ordinal} component")(using "\n")}
-               * @return A new Tuple of same arity.
+               * @return A new Tuple of the same arity.
                * @throws NullPointerException if {@code mapper} is null
                */
               public $resultGenerics $className$resultGenerics map(@NonNull $functionType<$paramTypes, $mapResult> mapper) {
@@ -2427,7 +2392,7 @@ def generateMainClasses(): Unit = {
                * Maps the components of this tuple using a mapper function for each component.
                ${(0 to i).gen(j => if (j == 0) "*" else s"* @param f$j the mapper function of the ${j.ordinal} component")(using "\n")}
                ${(1 to i).gen(j => s"* @param <U$j> new type of the ${j.ordinal} component")(using "\n")}
-               * @return A new Tuple of same arity.
+               * @return A new Tuple of the same arity.
                * @throws NullPointerException if one of the arguments is null
                */
               public $resultGenerics $className$resultGenerics map(${(1 to i).gen(j => s"@NonNull ${im.getType("java.util.function.Function")}<? super T$j, ? extends U$j> f$j")(using ", ")}) {
@@ -2444,10 +2409,9 @@ def generateMainClasses(): Unit = {
                * @param mapper A mapping function
                * @return a new tuple based on this tuple and substituted ${j.ordinal} component
                */
-              public <U> $className<${(1 to i).gen(k => if (j == k) "U" else s"T$k")(using ", ")}> map$j(${im.getType("java.util.function.Function")}<? super T$j, ? extends U> mapper) {
+              public <U> $className<${(1 to i).gen(k => if (j == k) "U" else s"T$k")(using ", ")}> map$j(@NonNull ${im.getType("java.util.function.Function")}<? super T$j, ? extends U> mapper) {
                   Objects.requireNonNull(mapper, "mapper is null");
-                  final U u = mapper.apply(_$j);
-                  return Tuple.of(${(1 to i).gen(k => if (j == k) "u" else s"_$k")(using ", ")});
+                  return Tuple.of(${(1 to i).gen(k => if (j == k) s"mapper.apply(_$j)" else s"_$k")(using ", ")});
               }
             """)(using "\n\n")}
 
@@ -2504,35 +2468,12 @@ def generateMainClasses(): Unit = {
                */
               public <${(i+1 to i+j).gen(k => s"T$k")(using ", ")}> Tuple${i+j}<${(1 to i+j).gen(k => s"T$k")(using ", ")}> concat(@NonNull Tuple$j<${(i+1 to i+j).gen(k => s"T$k")(using ", ")}> tuple) {
                   Objects.requireNonNull(tuple, "tuple is null");
-                  return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(using ", ")}${(i > 0).gen(", ")}${(1 to j).gen(k => s"tuple._$k")(using ", ")});
+                  return ${im.getType("io.vavr.Tuple")}.of(${(1 to i).gen(k => s"_$k")(using ", ")}${(i > 0).gen(", ")}${(1 to j).gen(k => s"tuple._$k()")(using ", ")});
               }
             """)(using "\n\n")}
 
-            // -- Object
-
             @Override
-            public boolean equals(Object o) {
-                ${if (i == 0) xs"""
-                  return o == this;
-                """ else xs"""
-                  if (o == this) {
-                      return true;
-                  } else if (!(o instanceof $className)) {
-                      return false;
-                  } else {
-                      final $className$untyped that = ($className$untyped) o;
-                      return ${(1 to i).gen(j => s"${im.getType("java.util.Objects")}.equals(this._$j, that._$j)")(using "\n                             && ")};
-                  }"""
-                }
-            }
-
-            @Override
-            public int hashCode() {
-                return ${if (i == 0) "1" else s"""Tuple.hash(${(1 to i).gen(j => s"_$j")(using ", ")})"""};
-            }
-
-            @Override
-            public String toString() {
+            public @NonNull String toString() {
                 return ${if (i == 0) "\"()\"" else s""""(" + ${(1 to i).gen(j => s"_$j")(using " + \", \" + ")} + ")""""};
             }
 
@@ -2653,7 +2594,7 @@ def generateMainClasses(): Unit = {
             long serialVersionUID = 1L;
 
             /**
-             * The maximum arity of an Tuple.
+             * The maximum arity of a Tuple.
              * <p>
              * Note: This value might be changed in a future version of Vavr.
              * So it is recommended to use this constant instead of hardcoding the current maximum arity.
@@ -3900,7 +3841,7 @@ def generateTestClasses(): Unit = {
                 @$test
                 public void shouldReturnElements() {
                     final Tuple$i$intGenerics tuple = createIntTuple(${(1 to i).gen(j => s"$j")(using ", ")});
-                    ${(1 to i).gen(j => s"$assertThat(tuple._$j).isEqualTo($j);\n")}
+                    ${(1 to i).gen(j => s"$assertThat(tuple._$j()).isEqualTo($j);\n")}
                 }
               """)}
 
@@ -3909,7 +3850,7 @@ def generateTestClasses(): Unit = {
                   @$test
                   public void shouldUpdate$j() {
                     final Tuple$i$intGenerics tuple = createIntTuple(${(1 to i).gen(j => s"$j")(using ", ")}).update$j(42);
-                    ${(1 to i).gen(k => s"$assertThat(tuple._$k).isEqualTo(${if (j == k) 42 else k});\n")}
+                    ${(1 to i).gen(k => s"$assertThat(tuple._$k()).isEqualTo(${if (j == k) 42 else k});\n")}
                   }
                 """)(using "\n\n")}
 
@@ -4054,13 +3995,6 @@ def generateTestClasses(): Unit = {
                     })(using "\n")}
                 }
               """)}
-
-              @$test
-              public void shouldComputeCorrectHashCode() {
-                  final int actual = createTuple().hashCode();
-                  final int expected = ${im.getType("java.util.Objects")}.${if (i == 1) "hashCode" else "hash"}($nullArgs);
-                  $assertThat(actual).isEqualTo(expected);
-              }
 
               @$test
               public void shouldImplementToString() {

--- a/vavr/src-gen/main/java/io/vavr/API.java
+++ b/vavr/src-gen/main/java/io/vavr/API.java
@@ -10947,7 +10947,7 @@ public final class API {
                     @SuppressWarnings("unchecked")
                     @Override
                     public T1 apply(T obj) {
-                        return (T1) unapply.apply(obj)._1;
+                        return (T1) unapply.apply(obj)._1();
                     }
 
                     @SuppressWarnings("unchecked")
@@ -10956,7 +10956,7 @@ public final class API {
                         if (type.isInstance(obj)) {
                             final Tuple1<U1> u = unapply.apply(obj);
                             return
-                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1);
+                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1());
                         } else {
                             return false;
                         }
@@ -11024,8 +11024,8 @@ public final class API {
                         if (type.isInstance(obj)) {
                             final Tuple2<U1, U2> u = unapply.apply(obj);
                             return
-                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1) &&
-                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2);
+                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1()) &&
+                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2());
                         } else {
                             return false;
                         }
@@ -11097,9 +11097,9 @@ public final class API {
                         if (type.isInstance(obj)) {
                             final Tuple3<U1, U2, U3> u = unapply.apply(obj);
                             return
-                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1) &&
-                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2) &&
-                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3);
+                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1()) &&
+                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2()) &&
+                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3());
                         } else {
                             return false;
                         }
@@ -11175,10 +11175,10 @@ public final class API {
                         if (type.isInstance(obj)) {
                             final Tuple4<U1, U2, U3, U4> u = unapply.apply(obj);
                             return
-                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1) &&
-                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2) &&
-                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3) &&
-                                    ((Pattern<U4, ?>) p4).isDefinedAt(u._4);
+                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1()) &&
+                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2()) &&
+                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3()) &&
+                                    ((Pattern<U4, ?>) p4).isDefinedAt(u._4());
                         } else {
                             return false;
                         }
@@ -11258,11 +11258,11 @@ public final class API {
                         if (type.isInstance(obj)) {
                             final Tuple5<U1, U2, U3, U4, U5> u = unapply.apply(obj);
                             return
-                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1) &&
-                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2) &&
-                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3) &&
-                                    ((Pattern<U4, ?>) p4).isDefinedAt(u._4) &&
-                                    ((Pattern<U5, ?>) p5).isDefinedAt(u._5);
+                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1()) &&
+                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2()) &&
+                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3()) &&
+                                    ((Pattern<U4, ?>) p4).isDefinedAt(u._4()) &&
+                                    ((Pattern<U5, ?>) p5).isDefinedAt(u._5());
                         } else {
                             return false;
                         }
@@ -11346,12 +11346,12 @@ public final class API {
                         if (type.isInstance(obj)) {
                             final Tuple6<U1, U2, U3, U4, U5, U6> u = unapply.apply(obj);
                             return
-                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1) &&
-                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2) &&
-                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3) &&
-                                    ((Pattern<U4, ?>) p4).isDefinedAt(u._4) &&
-                                    ((Pattern<U5, ?>) p5).isDefinedAt(u._5) &&
-                                    ((Pattern<U6, ?>) p6).isDefinedAt(u._6);
+                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1()) &&
+                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2()) &&
+                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3()) &&
+                                    ((Pattern<U4, ?>) p4).isDefinedAt(u._4()) &&
+                                    ((Pattern<U5, ?>) p5).isDefinedAt(u._5()) &&
+                                    ((Pattern<U6, ?>) p6).isDefinedAt(u._6());
                         } else {
                             return false;
                         }
@@ -11439,13 +11439,13 @@ public final class API {
                         if (type.isInstance(obj)) {
                             final Tuple7<U1, U2, U3, U4, U5, U6, U7> u = unapply.apply(obj);
                             return
-                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1) &&
-                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2) &&
-                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3) &&
-                                    ((Pattern<U4, ?>) p4).isDefinedAt(u._4) &&
-                                    ((Pattern<U5, ?>) p5).isDefinedAt(u._5) &&
-                                    ((Pattern<U6, ?>) p6).isDefinedAt(u._6) &&
-                                    ((Pattern<U7, ?>) p7).isDefinedAt(u._7);
+                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1()) &&
+                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2()) &&
+                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3()) &&
+                                    ((Pattern<U4, ?>) p4).isDefinedAt(u._4()) &&
+                                    ((Pattern<U5, ?>) p5).isDefinedAt(u._5()) &&
+                                    ((Pattern<U6, ?>) p6).isDefinedAt(u._6()) &&
+                                    ((Pattern<U7, ?>) p7).isDefinedAt(u._7());
                         } else {
                             return false;
                         }
@@ -11537,14 +11537,14 @@ public final class API {
                         if (type.isInstance(obj)) {
                             final Tuple8<U1, U2, U3, U4, U5, U6, U7, U8> u = unapply.apply(obj);
                             return
-                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1) &&
-                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2) &&
-                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3) &&
-                                    ((Pattern<U4, ?>) p4).isDefinedAt(u._4) &&
-                                    ((Pattern<U5, ?>) p5).isDefinedAt(u._5) &&
-                                    ((Pattern<U6, ?>) p6).isDefinedAt(u._6) &&
-                                    ((Pattern<U7, ?>) p7).isDefinedAt(u._7) &&
-                                    ((Pattern<U8, ?>) p8).isDefinedAt(u._8);
+                                    ((Pattern<U1, ?>) p1).isDefinedAt(u._1()) &&
+                                    ((Pattern<U2, ?>) p2).isDefinedAt(u._2()) &&
+                                    ((Pattern<U3, ?>) p3).isDefinedAt(u._3()) &&
+                                    ((Pattern<U4, ?>) p4).isDefinedAt(u._4()) &&
+                                    ((Pattern<U5, ?>) p5).isDefinedAt(u._5()) &&
+                                    ((Pattern<U6, ?>) p6).isDefinedAt(u._6()) &&
+                                    ((Pattern<U7, ?>) p7).isDefinedAt(u._7()) &&
+                                    ((Pattern<U8, ?>) p8).isDefinedAt(u._8());
                         } else {
                             return false;
                         }

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction1.java
@@ -182,7 +182,7 @@ public interface CheckedFunction1<T1, R> extends Serializable {
      * @return a tupled function equivalent to this.
      */
     default CheckedFunction1<Tuple1<T1>, R> tupled() {
-        return t -> apply(t._1);
+        return t -> apply(t._1());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction2.java
@@ -190,7 +190,7 @@ public interface CheckedFunction2<T1, T2, R> extends Serializable {
      * @return a tupled function equivalent to this.
      */
     default CheckedFunction1<Tuple2<T1, T2>, R> tupled() {
-        return t -> apply(t._1, t._2);
+        return t -> apply(t._1(), t._2());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction3.java
@@ -207,7 +207,7 @@ public interface CheckedFunction3<T1, T2, T3, R> extends Serializable {
      * @return a tupled function equivalent to this.
      */
     default CheckedFunction1<Tuple3<T1, T2, T3>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3);
+        return t -> apply(t._1(), t._2(), t._3());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction4.java
@@ -226,7 +226,7 @@ public interface CheckedFunction4<T1, T2, T3, T4, R> extends Serializable {
      * @return a tupled function equivalent to this.
      */
     default CheckedFunction1<Tuple4<T1, T2, T3, T4>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4);
+        return t -> apply(t._1(), t._2(), t._3(), t._4());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction5.java
@@ -246,7 +246,7 @@ public interface CheckedFunction5<T1, T2, T3, T4, T5, R> extends Serializable {
      * @return a tupled function equivalent to this.
      */
     default CheckedFunction1<Tuple5<T1, T2, T3, T4, T5>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4, t._5);
+        return t -> apply(t._1(), t._2(), t._3(), t._4(), t._5());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction6.java
@@ -267,7 +267,7 @@ public interface CheckedFunction6<T1, T2, T3, T4, T5, T6, R> extends Serializabl
      * @return a tupled function equivalent to this.
      */
     default CheckedFunction1<Tuple6<T1, T2, T3, T4, T5, T6>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4, t._5, t._6);
+        return t -> apply(t._1(), t._2(), t._3(), t._4(), t._5(), t._6());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction7.java
@@ -289,7 +289,7 @@ public interface CheckedFunction7<T1, T2, T3, T4, T5, T6, T7, R> extends Seriali
      * @return a tupled function equivalent to this.
      */
     default CheckedFunction1<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4, t._5, t._6, t._7);
+        return t -> apply(t._1(), t._2(), t._3(), t._4(), t._5(), t._6(), t._7());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
+++ b/vavr/src-gen/main/java/io/vavr/CheckedFunction8.java
@@ -312,7 +312,7 @@ public interface CheckedFunction8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Ser
      * @return a tupled function equivalent to this.
      */
     default CheckedFunction1<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8);
+        return t -> apply(t._1(), t._2(), t._3(), t._4(), t._5(), t._6(), t._7(), t._8());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -181,7 +181,7 @@ public interface Function1<T1, R> extends Serializable, Function<T1, R> {
      * @return a tupled function equivalent to this.
      */
     default Function1<Tuple1<T1>, R> tupled() {
-        return t -> apply(t._1);
+        return t -> apply(t._1());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function2.java
+++ b/vavr/src-gen/main/java/io/vavr/Function2.java
@@ -188,7 +188,7 @@ public interface Function2<T1, T2, R> extends Serializable, BiFunction<T1, T2, R
      * @return a tupled function equivalent to this.
      */
     default Function1<Tuple2<T1, T2>, R> tupled() {
-        return t -> apply(t._1, t._2);
+        return t -> apply(t._1(), t._2());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function3.java
+++ b/vavr/src-gen/main/java/io/vavr/Function3.java
@@ -205,7 +205,7 @@ public interface Function3<T1, T2, T3, R> extends Serializable {
      * @return a tupled function equivalent to this.
      */
     default Function1<Tuple3<T1, T2, T3>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3);
+        return t -> apply(t._1(), t._2(), t._3());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function4.java
+++ b/vavr/src-gen/main/java/io/vavr/Function4.java
@@ -224,7 +224,7 @@ public interface Function4<T1, T2, T3, T4, R> extends Serializable {
      * @return a tupled function equivalent to this.
      */
     default Function1<Tuple4<T1, T2, T3, T4>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4);
+        return t -> apply(t._1(), t._2(), t._3(), t._4());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function5.java
+++ b/vavr/src-gen/main/java/io/vavr/Function5.java
@@ -244,7 +244,7 @@ public interface Function5<T1, T2, T3, T4, T5, R> extends Serializable {
      * @return a tupled function equivalent to this.
      */
     default Function1<Tuple5<T1, T2, T3, T4, T5>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4, t._5);
+        return t -> apply(t._1(), t._2(), t._3(), t._4(), t._5());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function6.java
+++ b/vavr/src-gen/main/java/io/vavr/Function6.java
@@ -265,7 +265,7 @@ public interface Function6<T1, T2, T3, T4, T5, T6, R> extends Serializable {
      * @return a tupled function equivalent to this.
      */
     default Function1<Tuple6<T1, T2, T3, T4, T5, T6>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4, t._5, t._6);
+        return t -> apply(t._1(), t._2(), t._3(), t._4(), t._5(), t._6());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function7.java
+++ b/vavr/src-gen/main/java/io/vavr/Function7.java
@@ -287,7 +287,7 @@ public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> extends Serializable {
      * @return a tupled function equivalent to this.
      */
     default Function1<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4, t._5, t._6, t._7);
+        return t -> apply(t._1(), t._2(), t._3(), t._4(), t._5(), t._6(), t._7());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Function8.java
+++ b/vavr/src-gen/main/java/io/vavr/Function8.java
@@ -310,7 +310,7 @@ public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> extends Serializab
      * @return a tupled function equivalent to this.
      */
     default Function1<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> tupled() {
-        return t -> apply(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8);
+        return t -> apply(t._1(), t._2(), t._3(), t._4(), t._5(), t._6(), t._7(), t._8());
     }
 
     /**

--- a/vavr/src-gen/main/java/io/vavr/Tuple.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple.java
@@ -39,7 +39,7 @@ public interface Tuple extends Serializable {
     long serialVersionUID = 1L;
 
     /**
-     * The maximum arity of an Tuple.
+     * The maximum arity of a Tuple.
      * <p>
      * Note: This value might be changed in a future version of Vavr.
      * So it is recommended to use this constant instead of hardcoding the current maximum arity.

--- a/vavr/src-gen/main/java/io/vavr/Tuple0.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple0.java
@@ -33,25 +33,19 @@ import org.jspecify.annotations.NonNull;
 /**
  * A tuple of no elements which can be seen as cartesian product of no components.
  *
- * @author Daniel Dietrich
+ * @author Daniel Dietrich, Grzegorz Piwowarek
  */
-public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public record Tuple0() implements Tuple, Comparable<Tuple0>, Serializable {
 
     /**
      * The singleton instance of Tuple0.
      */
-    private static final Tuple0 INSTANCE = new Tuple0 ();
+    private static final Tuple0 INSTANCE = new Tuple0();
 
     /**
      * The singleton Tuple0 comparator.
      */
     private static final Comparator<Tuple0> COMPARATOR = (Comparator<Tuple0> & Serializable) (t1, t2) -> 0;
-
-    // hidden constructor, internally called
-    private Tuple0 () {
-    }
 
     /**
      * Returns the singleton instance of Tuple0.
@@ -115,7 +109,7 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
      */
     public <T1> Tuple1<T1> concat(@NonNull Tuple1<T1> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(tuple._1);
+        return Tuple.of(tuple._1());
     }
 
     /**
@@ -129,7 +123,7 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
      */
     public <T1, T2> Tuple2<T1, T2> concat(@NonNull Tuple2<T1, T2> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(tuple._1, tuple._2);
+        return Tuple.of(tuple._1(), tuple._2());
     }
 
     /**
@@ -144,7 +138,7 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
      */
     public <T1, T2, T3> Tuple3<T1, T2, T3> concat(@NonNull Tuple3<T1, T2, T3> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(tuple._1, tuple._2, tuple._3);
+        return Tuple.of(tuple._1(), tuple._2(), tuple._3());
     }
 
     /**
@@ -160,7 +154,7 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
      */
     public <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4> concat(@NonNull Tuple4<T1, T2, T3, T4> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(tuple._1, tuple._2, tuple._3, tuple._4);
+        return Tuple.of(tuple._1(), tuple._2(), tuple._3(), tuple._4());
     }
 
     /**
@@ -177,7 +171,7 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
      */
     public <T1, T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(@NonNull Tuple5<T1, T2, T3, T4, T5> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
+        return Tuple.of(tuple._1(), tuple._2(), tuple._3(), tuple._4(), tuple._5());
     }
 
     /**
@@ -195,7 +189,7 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
      */
     public <T1, T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(@NonNull Tuple6<T1, T2, T3, T4, T5, T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6);
+        return Tuple.of(tuple._1(), tuple._2(), tuple._3(), tuple._4(), tuple._5(), tuple._6());
     }
 
     /**
@@ -214,7 +208,7 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
      */
     public <T1, T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(@NonNull Tuple7<T1, T2, T3, T4, T5, T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6, tuple._7);
+        return Tuple.of(tuple._1(), tuple._2(), tuple._3(), tuple._4(), tuple._5(), tuple._6(), tuple._7());
     }
 
     /**
@@ -234,23 +228,11 @@ public final class Tuple0 implements Tuple, Comparable<Tuple0>, Serializable {
      */
     public <T1, T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(@NonNull Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6, tuple._7, tuple._8);
-    }
-
-    // -- Object
-
-    @Override
-    public boolean equals(Object o) {
-        return o == this;
+        return Tuple.of(tuple._1(), tuple._2(), tuple._3(), tuple._4(), tuple._5(), tuple._6(), tuple._7(), tuple._8());
     }
 
     @Override
-    public int hashCode() {
-        return 1;
-    }
-
-    @Override
-    public String toString() {
+    public @NonNull String toString() {
         return "()";
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple1.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple1.java
@@ -34,36 +34,14 @@ import org.jspecify.annotations.NonNull;
  * A tuple of one element which can be seen as cartesian product of one component.
  *
  * @param <T1> type of the 1st element
- * @author Daniel Dietrich
+ * @author Daniel Dietrich, Grzegorz Piwowarek
  */
-public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * The 1st element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T1 _1;
-
-    /**
-     * Constructs a tuple of one element.
-     *
-     * @param t1 the 1st element
-     */
-    public Tuple1(T1 t1) {
-        this._1 = t1;
-    }
+public record Tuple1<T1>(T1 _1) implements Tuple, Comparable<Tuple1<T1>>, Serializable {
 
     public static <T1> Comparator<Tuple1<T1>> comparator(Comparator<? super T1> t1Comp) {
         return (Comparator<Tuple1<T1>> & Serializable) (t1, t2) -> {
-            final int check1 = t1Comp.compare(t1._1, t2._1);
-            if (check1 != 0) {
-                return check1;
-            }
 
-            // all components are equal
-            return 0;
+            return t1Comp.compare(t1._1, t2._1);
         };
     }
 
@@ -72,13 +50,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
         final Tuple1<U1> t1 = (Tuple1<U1>) o1;
         final Tuple1<U1> t2 = (Tuple1<U1>) o2;
 
-        final int check1 = t1._1.compareTo(t2._1);
-        if (check1 != 0) {
-            return check1;
-        }
-
-        // all components are equal
-        return 0;
+        return t1._1.compareTo(t2._1);
     }
 
     @Override
@@ -89,15 +61,6 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
     @Override
     public int compareTo(Tuple1<T1> that) {
         return Tuple1.compareTo(this, that);
-    }
-
-    /**
-     * Getter of the 1st element of this tuple.
-     *
-     * @return the 1st element of this Tuple.
-     */
-    public T1 _1() {
-        return _1;
     }
 
     /**
@@ -115,7 +78,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      *
      * @param mapper the mapper function
      * @param <U1> new type of the 1st component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if {@code mapper} is null
      */
     public <U1> Tuple1<U1> map(@NonNull Function<? super T1, ? extends U1> mapper) {
@@ -162,7 +125,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      */
     public <T2> Tuple2<T1, T2> concat(@NonNull Tuple1<T2> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, tuple._1);
+        return Tuple.of(_1, tuple._1());
     }
 
     /**
@@ -176,7 +139,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      */
     public <T2, T3> Tuple3<T1, T2, T3> concat(@NonNull Tuple2<T2, T3> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, tuple._1, tuple._2);
+        return Tuple.of(_1, tuple._1(), tuple._2());
     }
 
     /**
@@ -191,7 +154,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      */
     public <T2, T3, T4> Tuple4<T1, T2, T3, T4> concat(@NonNull Tuple3<T2, T3, T4> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, tuple._1, tuple._2, tuple._3);
+        return Tuple.of(_1, tuple._1(), tuple._2(), tuple._3());
     }
 
     /**
@@ -207,7 +170,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      */
     public <T2, T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(@NonNull Tuple4<T2, T3, T4, T5> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4);
+        return Tuple.of(_1, tuple._1(), tuple._2(), tuple._3(), tuple._4());
     }
 
     /**
@@ -224,7 +187,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      */
     public <T2, T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(@NonNull Tuple5<T2, T3, T4, T5, T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
+        return Tuple.of(_1, tuple._1(), tuple._2(), tuple._3(), tuple._4(), tuple._5());
     }
 
     /**
@@ -242,7 +205,7 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      */
     public <T2, T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(@NonNull Tuple6<T2, T3, T4, T5, T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6);
+        return Tuple.of(_1, tuple._1(), tuple._2(), tuple._3(), tuple._4(), tuple._5(), tuple._6());
     }
 
     /**
@@ -261,30 +224,11 @@ public final class Tuple1<T1> implements Tuple, Comparable<Tuple1<T1>>, Serializ
      */
     public <T2, T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(@NonNull Tuple7<T2, T3, T4, T5, T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6, tuple._7);
-    }
-
-    // -- Object
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        } else if (!(o instanceof Tuple1)) {
-            return false;
-        } else {
-            final Tuple1<?> that = (Tuple1<?>) o;
-            return Objects.equals(this._1, that._1);
-        }
+        return Tuple.of(_1, tuple._1(), tuple._2(), tuple._3(), tuple._4(), tuple._5(), tuple._6(), tuple._7());
     }
 
     @Override
-    public int hashCode() {
-        return Tuple.hash(_1);
-    }
-
-    @Override
-    public String toString() {
+    public @NonNull String toString() {
         return "(" + _1 + ")";
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple2.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple2.java
@@ -38,34 +38,9 @@ import org.jspecify.annotations.NonNull;
  *
  * @param <T1> type of the 1st element
  * @param <T2> type of the 2nd element
- * @author Daniel Dietrich
+ * @author Daniel Dietrich, Grzegorz Piwowarek
  */
-public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * The 1st element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T1 _1;
-
-    /**
-     * The 2nd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T2 _2;
-
-    /**
-     * Constructs a tuple of two elements.
-     *
-     * @param t1 the 1st element
-     * @param t2 the 2nd element
-     */
-    public Tuple2(T1 t1, T2 t2) {
-        this._1 = t1;
-        this._2 = t2;
-    }
+public record Tuple2<T1, T2>(T1 _1, T2 _2) implements Tuple, Comparable<Tuple2<T1, T2>>, Serializable {
 
     public static <T1, T2> Comparator<Tuple2<T1, T2>> comparator(Comparator<? super T1> t1Comp, Comparator<? super T2> t2Comp) {
         return (Comparator<Tuple2<T1, T2>> & Serializable) (t1, t2) -> {
@@ -73,14 +48,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
             if (check1 != 0) {
                 return check1;
             }
-
-            final int check2 = t2Comp.compare(t1._2, t2._2);
-            if (check2 != 0) {
-                return check2;
-            }
-
-            // all components are equal
-            return 0;
+            return t2Comp.compare(t1._2, t2._2);
         };
     }
 
@@ -93,14 +61,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
         if (check1 != 0) {
             return check1;
         }
-
-        final int check2 = t1._2.compareTo(t2._2);
-        if (check2 != 0) {
-            return check2;
-        }
-
-        // all components are equal
-        return 0;
+        return t1._2.compareTo(t2._2);
     }
 
     @Override
@@ -114,15 +75,6 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     }
 
     /**
-     * Getter of the 1st element of this tuple.
-     *
-     * @return the 1st element of this Tuple.
-     */
-    public T1 _1() {
-        return _1;
-    }
-
-    /**
      * Sets the 1st element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -130,15 +82,6 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      */
     public Tuple2<T1, T2> update1(T1 value) {
         return new Tuple2<>(value, _2);
-    }
-
-    /**
-     * Getter of the 2nd element of this tuple.
-     *
-     * @return the 2nd element of this Tuple.
-     */
-    public T2 _2() {
-        return _2;
     }
 
     /**
@@ -164,7 +107,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
     /**
      * Converts the tuple to java.util.Map.Entry {@code Tuple}.
      *
-     * @return A  java.util.Map.Entry where the first element is the key and the second
+     * @return A java.util.Map.Entry where the first element is the key and the second
      * element is the value.
      */
     public Map.Entry<T1, T2> toEntry() {
@@ -177,7 +120,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * @param mapper the mapper function
      * @param <U1> new type of the 1st component
      * @param <U2> new type of the 2nd component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if {@code mapper} is null
      */
     public <U1, U2> Tuple2<U1, U2> map(@NonNull BiFunction<? super T1, ? super T2, Tuple2<U1, U2>> mapper) {
@@ -192,7 +135,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * @param f2 the mapper function of the 2nd component
      * @param <U1> new type of the 1st component
      * @param <U2> new type of the 2nd component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if one of the arguments is null
      */
     public <U1, U2> Tuple2<U1, U2> map(@NonNull Function<? super T1, ? extends U1> f1, @NonNull Function<? super T2, ? extends U2> f2) {
@@ -208,10 +151,9 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 1st component
      */
-    public <U> Tuple2<U, T2> map1(Function<? super T1, ? extends U> mapper) {
+    public <U> Tuple2<U, T2> map1(@NonNull Function<? super T1, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_1);
-        return Tuple.of(u, _2);
+        return Tuple.of(mapper.apply(_1), _2);
     }
 
     /**
@@ -221,10 +163,9 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 2nd component
      */
-    public <U> Tuple2<T1, U> map2(Function<? super T2, ? extends U> mapper) {
+    public <U> Tuple2<T1, U> map2(@NonNull Function<? super T2, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_2);
-        return Tuple.of(_1, u);
+        return Tuple.of(_1, mapper.apply(_2));
     }
 
     /**
@@ -266,7 +207,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      */
     public <T3> Tuple3<T1, T2, T3> concat(@NonNull Tuple1<T3> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, tuple._1);
+        return Tuple.of(_1, _2, tuple._1());
     }
 
     /**
@@ -280,7 +221,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      */
     public <T3, T4> Tuple4<T1, T2, T3, T4> concat(@NonNull Tuple2<T3, T4> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, tuple._1, tuple._2);
+        return Tuple.of(_1, _2, tuple._1(), tuple._2());
     }
 
     /**
@@ -295,7 +236,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      */
     public <T3, T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(@NonNull Tuple3<T3, T4, T5> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3);
+        return Tuple.of(_1, _2, tuple._1(), tuple._2(), tuple._3());
     }
 
     /**
@@ -311,7 +252,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      */
     public <T3, T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(@NonNull Tuple4<T3, T4, T5, T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4);
+        return Tuple.of(_1, _2, tuple._1(), tuple._2(), tuple._3(), tuple._4());
     }
 
     /**
@@ -328,7 +269,7 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      */
     public <T3, T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(@NonNull Tuple5<T3, T4, T5, T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
+        return Tuple.of(_1, _2, tuple._1(), tuple._2(), tuple._3(), tuple._4(), tuple._5());
     }
 
     /**
@@ -346,31 +287,11 @@ public final class Tuple2<T1, T2> implements Tuple, Comparable<Tuple2<T1, T2>>, 
      */
     public <T3, T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(@NonNull Tuple6<T3, T4, T5, T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5, tuple._6);
-    }
-
-    // -- Object
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        } else if (!(o instanceof Tuple2)) {
-            return false;
-        } else {
-            final Tuple2<?, ?> that = (Tuple2<?, ?>) o;
-            return Objects.equals(this._1, that._1)
-                  && Objects.equals(this._2, that._2);
-        }
+        return Tuple.of(_1, _2, tuple._1(), tuple._2(), tuple._3(), tuple._4(), tuple._5(), tuple._6());
     }
 
     @Override
-    public int hashCode() {
-        return Tuple.hash(_1, _2);
-    }
-
-    @Override
-    public String toString() {
+    public @NonNull String toString() {
         return "(" + _1 + ", " + _2 + ")";
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple3.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple3.java
@@ -36,42 +36,9 @@ import org.jspecify.annotations.NonNull;
  * @param <T1> type of the 1st element
  * @param <T2> type of the 2nd element
  * @param <T3> type of the 3rd element
- * @author Daniel Dietrich
+ * @author Daniel Dietrich, Grzegorz Piwowarek
  */
-public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2, T3>>, Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * The 1st element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T1 _1;
-
-    /**
-     * The 2nd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T2 _2;
-
-    /**
-     * The 3rd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T3 _3;
-
-    /**
-     * Constructs a tuple of three elements.
-     *
-     * @param t1 the 1st element
-     * @param t2 the 2nd element
-     * @param t3 the 3rd element
-     */
-    public Tuple3(T1 t1, T2 t2, T3 t3) {
-        this._1 = t1;
-        this._2 = t2;
-        this._3 = t3;
-    }
+public record Tuple3<T1, T2, T3>(T1 _1, T2 _2, T3 _3) implements Tuple, Comparable<Tuple3<T1, T2, T3>>, Serializable {
 
     public static <T1, T2, T3> Comparator<Tuple3<T1, T2, T3>> comparator(Comparator<? super T1> t1Comp, Comparator<? super T2> t2Comp, Comparator<? super T3> t3Comp) {
         return (Comparator<Tuple3<T1, T2, T3>> & Serializable) (t1, t2) -> {
@@ -84,14 +51,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
             if (check2 != 0) {
                 return check2;
             }
-
-            final int check3 = t3Comp.compare(t1._3, t2._3);
-            if (check3 != 0) {
-                return check3;
-            }
-
-            // all components are equal
-            return 0;
+            return t3Comp.compare(t1._3, t2._3);
         };
     }
 
@@ -109,14 +69,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
         if (check2 != 0) {
             return check2;
         }
-
-        final int check3 = t1._3.compareTo(t2._3);
-        if (check3 != 0) {
-            return check3;
-        }
-
-        // all components are equal
-        return 0;
+        return t1._3.compareTo(t2._3);
     }
 
     @Override
@@ -130,15 +83,6 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     }
 
     /**
-     * Getter of the 1st element of this tuple.
-     *
-     * @return the 1st element of this Tuple.
-     */
-    public T1 _1() {
-        return _1;
-    }
-
-    /**
      * Sets the 1st element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -149,15 +93,6 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
     }
 
     /**
-     * Getter of the 2nd element of this tuple.
-     *
-     * @return the 2nd element of this Tuple.
-     */
-    public T2 _2() {
-        return _2;
-    }
-
-    /**
      * Sets the 2nd element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -165,15 +100,6 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      */
     public Tuple3<T1, T2, T3> update2(T2 value) {
         return new Tuple3<>(_1, value, _3);
-    }
-
-    /**
-     * Getter of the 3rd element of this tuple.
-     *
-     * @return the 3rd element of this Tuple.
-     */
-    public T3 _3() {
-        return _3;
     }
 
     /**
@@ -193,7 +119,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * @param <U1> new type of the 1st component
      * @param <U2> new type of the 2nd component
      * @param <U3> new type of the 3rd component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if {@code mapper} is null
      */
     public <U1, U2, U3> Tuple3<U1, U2, U3> map(@NonNull Function3<? super T1, ? super T2, ? super T3, Tuple3<U1, U2, U3>> mapper) {
@@ -210,7 +136,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * @param <U1> new type of the 1st component
      * @param <U2> new type of the 2nd component
      * @param <U3> new type of the 3rd component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if one of the arguments is null
      */
     public <U1, U2, U3> Tuple3<U1, U2, U3> map(@NonNull Function<? super T1, ? extends U1> f1, @NonNull Function<? super T2, ? extends U2> f2, @NonNull Function<? super T3, ? extends U3> f3) {
@@ -227,10 +153,9 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 1st component
      */
-    public <U> Tuple3<U, T2, T3> map1(Function<? super T1, ? extends U> mapper) {
+    public <U> Tuple3<U, T2, T3> map1(@NonNull Function<? super T1, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_1);
-        return Tuple.of(u, _2, _3);
+        return Tuple.of(mapper.apply(_1), _2, _3);
     }
 
     /**
@@ -240,10 +165,9 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 2nd component
      */
-    public <U> Tuple3<T1, U, T3> map2(Function<? super T2, ? extends U> mapper) {
+    public <U> Tuple3<T1, U, T3> map2(@NonNull Function<? super T2, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_2);
-        return Tuple.of(_1, u, _3);
+        return Tuple.of(_1, mapper.apply(_2), _3);
     }
 
     /**
@@ -253,10 +177,9 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 3rd component
      */
-    public <U> Tuple3<T1, T2, U> map3(Function<? super T3, ? extends U> mapper) {
+    public <U> Tuple3<T1, T2, U> map3(@NonNull Function<? super T3, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_3);
-        return Tuple.of(_1, _2, u);
+        return Tuple.of(_1, _2, mapper.apply(_3));
     }
 
     /**
@@ -298,7 +221,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      */
     public <T4> Tuple4<T1, T2, T3, T4> concat(@NonNull Tuple1<T4> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, tuple._1);
+        return Tuple.of(_1, _2, _3, tuple._1());
     }
 
     /**
@@ -312,7 +235,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      */
     public <T4, T5> Tuple5<T1, T2, T3, T4, T5> concat(@NonNull Tuple2<T4, T5> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, tuple._1, tuple._2);
+        return Tuple.of(_1, _2, _3, tuple._1(), tuple._2());
     }
 
     /**
@@ -327,7 +250,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      */
     public <T4, T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(@NonNull Tuple3<T4, T5, T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3);
+        return Tuple.of(_1, _2, _3, tuple._1(), tuple._2(), tuple._3());
     }
 
     /**
@@ -343,7 +266,7 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      */
     public <T4, T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(@NonNull Tuple4<T4, T5, T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3, tuple._4);
+        return Tuple.of(_1, _2, _3, tuple._1(), tuple._2(), tuple._3(), tuple._4());
     }
 
     /**
@@ -360,32 +283,11 @@ public final class Tuple3<T1, T2, T3> implements Tuple, Comparable<Tuple3<T1, T2
      */
     public <T4, T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(@NonNull Tuple5<T4, T5, T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, tuple._1, tuple._2, tuple._3, tuple._4, tuple._5);
-    }
-
-    // -- Object
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        } else if (!(o instanceof Tuple3)) {
-            return false;
-        } else {
-            final Tuple3<?, ?, ?> that = (Tuple3<?, ?, ?>) o;
-            return Objects.equals(this._1, that._1)
-                  && Objects.equals(this._2, that._2)
-                  && Objects.equals(this._3, that._3);
-        }
+        return Tuple.of(_1, _2, _3, tuple._1(), tuple._2(), tuple._3(), tuple._4(), tuple._5());
     }
 
     @Override
-    public int hashCode() {
-        return Tuple.hash(_1, _2, _3);
-    }
-
-    @Override
-    public String toString() {
+    public @NonNull String toString() {
         return "(" + _1 + ", " + _2 + ", " + _3 + ")";
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple4.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple4.java
@@ -37,50 +37,9 @@ import org.jspecify.annotations.NonNull;
  * @param <T2> type of the 2nd element
  * @param <T3> type of the 3rd element
  * @param <T4> type of the 4th element
- * @author Daniel Dietrich
+ * @author Daniel Dietrich, Grzegorz Piwowarek
  */
-public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1, T2, T3, T4>>, Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * The 1st element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T1 _1;
-
-    /**
-     * The 2nd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T2 _2;
-
-    /**
-     * The 3rd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T3 _3;
-
-    /**
-     * The 4th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T4 _4;
-
-    /**
-     * Constructs a tuple of 4 elements.
-     *
-     * @param t1 the 1st element
-     * @param t2 the 2nd element
-     * @param t3 the 3rd element
-     * @param t4 the 4th element
-     */
-    public Tuple4(T1 t1, T2 t2, T3 t3, T4 t4) {
-        this._1 = t1;
-        this._2 = t2;
-        this._3 = t3;
-        this._4 = t4;
-    }
+public record Tuple4<T1, T2, T3, T4>(T1 _1, T2 _2, T3 _3, T4 _4) implements Tuple, Comparable<Tuple4<T1, T2, T3, T4>>, Serializable {
 
     public static <T1, T2, T3, T4> Comparator<Tuple4<T1, T2, T3, T4>> comparator(Comparator<? super T1> t1Comp, Comparator<? super T2> t2Comp, Comparator<? super T3> t3Comp, Comparator<? super T4> t4Comp) {
         return (Comparator<Tuple4<T1, T2, T3, T4>> & Serializable) (t1, t2) -> {
@@ -98,14 +57,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
             if (check3 != 0) {
                 return check3;
             }
-
-            final int check4 = t4Comp.compare(t1._4, t2._4);
-            if (check4 != 0) {
-                return check4;
-            }
-
-            // all components are equal
-            return 0;
+            return t4Comp.compare(t1._4, t2._4);
         };
     }
 
@@ -128,14 +80,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
         if (check3 != 0) {
             return check3;
         }
-
-        final int check4 = t1._4.compareTo(t2._4);
-        if (check4 != 0) {
-            return check4;
-        }
-
-        // all components are equal
-        return 0;
+        return t1._4.compareTo(t2._4);
     }
 
     @Override
@@ -149,15 +94,6 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     }
 
     /**
-     * Getter of the 1st element of this tuple.
-     *
-     * @return the 1st element of this Tuple.
-     */
-    public T1 _1() {
-        return _1;
-    }
-
-    /**
      * Sets the 1st element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -165,15 +101,6 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      */
     public Tuple4<T1, T2, T3, T4> update1(T1 value) {
         return new Tuple4<>(value, _2, _3, _4);
-    }
-
-    /**
-     * Getter of the 2nd element of this tuple.
-     *
-     * @return the 2nd element of this Tuple.
-     */
-    public T2 _2() {
-        return _2;
     }
 
     /**
@@ -187,15 +114,6 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
     }
 
     /**
-     * Getter of the 3rd element of this tuple.
-     *
-     * @return the 3rd element of this Tuple.
-     */
-    public T3 _3() {
-        return _3;
-    }
-
-    /**
      * Sets the 3rd element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -203,15 +121,6 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      */
     public Tuple4<T1, T2, T3, T4> update3(T3 value) {
         return new Tuple4<>(_1, _2, value, _4);
-    }
-
-    /**
-     * Getter of the 4th element of this tuple.
-     *
-     * @return the 4th element of this Tuple.
-     */
-    public T4 _4() {
-        return _4;
     }
 
     /**
@@ -232,7 +141,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * @param <U2> new type of the 2nd component
      * @param <U3> new type of the 3rd component
      * @param <U4> new type of the 4th component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if {@code mapper} is null
      */
     public <U1, U2, U3, U4> Tuple4<U1, U2, U3, U4> map(@NonNull Function4<? super T1, ? super T2, ? super T3, ? super T4, Tuple4<U1, U2, U3, U4>> mapper) {
@@ -251,7 +160,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * @param <U2> new type of the 2nd component
      * @param <U3> new type of the 3rd component
      * @param <U4> new type of the 4th component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if one of the arguments is null
      */
     public <U1, U2, U3, U4> Tuple4<U1, U2, U3, U4> map(@NonNull Function<? super T1, ? extends U1> f1, @NonNull Function<? super T2, ? extends U2> f2, @NonNull Function<? super T3, ? extends U3> f3, @NonNull Function<? super T4, ? extends U4> f4) {
@@ -269,10 +178,9 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 1st component
      */
-    public <U> Tuple4<U, T2, T3, T4> map1(Function<? super T1, ? extends U> mapper) {
+    public <U> Tuple4<U, T2, T3, T4> map1(@NonNull Function<? super T1, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_1);
-        return Tuple.of(u, _2, _3, _4);
+        return Tuple.of(mapper.apply(_1), _2, _3, _4);
     }
 
     /**
@@ -282,10 +190,9 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 2nd component
      */
-    public <U> Tuple4<T1, U, T3, T4> map2(Function<? super T2, ? extends U> mapper) {
+    public <U> Tuple4<T1, U, T3, T4> map2(@NonNull Function<? super T2, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_2);
-        return Tuple.of(_1, u, _3, _4);
+        return Tuple.of(_1, mapper.apply(_2), _3, _4);
     }
 
     /**
@@ -295,10 +202,9 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 3rd component
      */
-    public <U> Tuple4<T1, T2, U, T4> map3(Function<? super T3, ? extends U> mapper) {
+    public <U> Tuple4<T1, T2, U, T4> map3(@NonNull Function<? super T3, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_3);
-        return Tuple.of(_1, _2, u, _4);
+        return Tuple.of(_1, _2, mapper.apply(_3), _4);
     }
 
     /**
@@ -308,10 +214,9 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 4th component
      */
-    public <U> Tuple4<T1, T2, T3, U> map4(Function<? super T4, ? extends U> mapper) {
+    public <U> Tuple4<T1, T2, T3, U> map4(@NonNull Function<? super T4, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_4);
-        return Tuple.of(_1, _2, _3, u);
+        return Tuple.of(_1, _2, _3, mapper.apply(_4));
     }
 
     /**
@@ -353,7 +258,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      */
     public <T5> Tuple5<T1, T2, T3, T4, T5> concat(@NonNull Tuple1<T5> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, _4, tuple._1);
+        return Tuple.of(_1, _2, _3, _4, tuple._1());
     }
 
     /**
@@ -367,7 +272,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      */
     public <T5, T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(@NonNull Tuple2<T5, T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2);
+        return Tuple.of(_1, _2, _3, _4, tuple._1(), tuple._2());
     }
 
     /**
@@ -382,7 +287,7 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      */
     public <T5, T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(@NonNull Tuple3<T5, T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2, tuple._3);
+        return Tuple.of(_1, _2, _3, _4, tuple._1(), tuple._2(), tuple._3());
     }
 
     /**
@@ -398,33 +303,11 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple, Comparable<Tuple4<T1
      */
     public <T5, T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(@NonNull Tuple4<T5, T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, _4, tuple._1, tuple._2, tuple._3, tuple._4);
-    }
-
-    // -- Object
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        } else if (!(o instanceof Tuple4)) {
-            return false;
-        } else {
-            final Tuple4<?, ?, ?, ?> that = (Tuple4<?, ?, ?, ?>) o;
-            return Objects.equals(this._1, that._1)
-                  && Objects.equals(this._2, that._2)
-                  && Objects.equals(this._3, that._3)
-                  && Objects.equals(this._4, that._4);
-        }
+        return Tuple.of(_1, _2, _3, _4, tuple._1(), tuple._2(), tuple._3(), tuple._4());
     }
 
     @Override
-    public int hashCode() {
-        return Tuple.hash(_1, _2, _3, _4);
-    }
-
-    @Override
-    public String toString() {
+    public @NonNull String toString() {
         return "(" + _1 + ", " + _2 + ", " + _3 + ", " + _4 + ")";
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple5.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple5.java
@@ -38,58 +38,9 @@ import org.jspecify.annotations.NonNull;
  * @param <T3> type of the 3rd element
  * @param <T4> type of the 4th element
  * @param <T5> type of the 5th element
- * @author Daniel Dietrich
+ * @author Daniel Dietrich, Grzegorz Piwowarek
  */
-public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple5<T1, T2, T3, T4, T5>>, Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * The 1st element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T1 _1;
-
-    /**
-     * The 2nd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T2 _2;
-
-    /**
-     * The 3rd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T3 _3;
-
-    /**
-     * The 4th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T4 _4;
-
-    /**
-     * The 5th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T5 _5;
-
-    /**
-     * Constructs a tuple of 5 elements.
-     *
-     * @param t1 the 1st element
-     * @param t2 the 2nd element
-     * @param t3 the 3rd element
-     * @param t4 the 4th element
-     * @param t5 the 5th element
-     */
-    public Tuple5(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) {
-        this._1 = t1;
-        this._2 = t2;
-        this._3 = t3;
-        this._4 = t4;
-        this._5 = t5;
-    }
+public record Tuple5<T1, T2, T3, T4, T5>(T1 _1, T2 _2, T3 _3, T4 _4, T5 _5) implements Tuple, Comparable<Tuple5<T1, T2, T3, T4, T5>>, Serializable {
 
     public static <T1, T2, T3, T4, T5> Comparator<Tuple5<T1, T2, T3, T4, T5>> comparator(Comparator<? super T1> t1Comp, Comparator<? super T2> t2Comp, Comparator<? super T3> t3Comp, Comparator<? super T4> t4Comp, Comparator<? super T5> t5Comp) {
         return (Comparator<Tuple5<T1, T2, T3, T4, T5>> & Serializable) (t1, t2) -> {
@@ -112,14 +63,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
             if (check4 != 0) {
                 return check4;
             }
-
-            final int check5 = t5Comp.compare(t1._5, t2._5);
-            if (check5 != 0) {
-                return check5;
-            }
-
-            // all components are equal
-            return 0;
+            return t5Comp.compare(t1._5, t2._5);
         };
     }
 
@@ -147,14 +91,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
         if (check4 != 0) {
             return check4;
         }
-
-        final int check5 = t1._5.compareTo(t2._5);
-        if (check5 != 0) {
-            return check5;
-        }
-
-        // all components are equal
-        return 0;
+        return t1._5.compareTo(t2._5);
     }
 
     @Override
@@ -168,15 +105,6 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     }
 
     /**
-     * Getter of the 1st element of this tuple.
-     *
-     * @return the 1st element of this Tuple.
-     */
-    public T1 _1() {
-        return _1;
-    }
-
-    /**
      * Sets the 1st element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -184,15 +112,6 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      */
     public Tuple5<T1, T2, T3, T4, T5> update1(T1 value) {
         return new Tuple5<>(value, _2, _3, _4, _5);
-    }
-
-    /**
-     * Getter of the 2nd element of this tuple.
-     *
-     * @return the 2nd element of this Tuple.
-     */
-    public T2 _2() {
-        return _2;
     }
 
     /**
@@ -206,15 +125,6 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     }
 
     /**
-     * Getter of the 3rd element of this tuple.
-     *
-     * @return the 3rd element of this Tuple.
-     */
-    public T3 _3() {
-        return _3;
-    }
-
-    /**
      * Sets the 3rd element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -225,15 +135,6 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
     }
 
     /**
-     * Getter of the 4th element of this tuple.
-     *
-     * @return the 4th element of this Tuple.
-     */
-    public T4 _4() {
-        return _4;
-    }
-
-    /**
      * Sets the 4th element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -241,15 +142,6 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      */
     public Tuple5<T1, T2, T3, T4, T5> update4(T4 value) {
         return new Tuple5<>(_1, _2, _3, value, _5);
-    }
-
-    /**
-     * Getter of the 5th element of this tuple.
-     *
-     * @return the 5th element of this Tuple.
-     */
-    public T5 _5() {
-        return _5;
     }
 
     /**
@@ -271,7 +163,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * @param <U3> new type of the 3rd component
      * @param <U4> new type of the 4th component
      * @param <U5> new type of the 5th component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if {@code mapper} is null
      */
     public <U1, U2, U3, U4, U5> Tuple5<U1, U2, U3, U4, U5> map(@NonNull Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, Tuple5<U1, U2, U3, U4, U5>> mapper) {
@@ -292,7 +184,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * @param <U3> new type of the 3rd component
      * @param <U4> new type of the 4th component
      * @param <U5> new type of the 5th component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if one of the arguments is null
      */
     public <U1, U2, U3, U4, U5> Tuple5<U1, U2, U3, U4, U5> map(@NonNull Function<? super T1, ? extends U1> f1, @NonNull Function<? super T2, ? extends U2> f2, @NonNull Function<? super T3, ? extends U3> f3, @NonNull Function<? super T4, ? extends U4> f4, @NonNull Function<? super T5, ? extends U5> f5) {
@@ -311,10 +203,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 1st component
      */
-    public <U> Tuple5<U, T2, T3, T4, T5> map1(Function<? super T1, ? extends U> mapper) {
+    public <U> Tuple5<U, T2, T3, T4, T5> map1(@NonNull Function<? super T1, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_1);
-        return Tuple.of(u, _2, _3, _4, _5);
+        return Tuple.of(mapper.apply(_1), _2, _3, _4, _5);
     }
 
     /**
@@ -324,10 +215,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 2nd component
      */
-    public <U> Tuple5<T1, U, T3, T4, T5> map2(Function<? super T2, ? extends U> mapper) {
+    public <U> Tuple5<T1, U, T3, T4, T5> map2(@NonNull Function<? super T2, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_2);
-        return Tuple.of(_1, u, _3, _4, _5);
+        return Tuple.of(_1, mapper.apply(_2), _3, _4, _5);
     }
 
     /**
@@ -337,10 +227,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 3rd component
      */
-    public <U> Tuple5<T1, T2, U, T4, T5> map3(Function<? super T3, ? extends U> mapper) {
+    public <U> Tuple5<T1, T2, U, T4, T5> map3(@NonNull Function<? super T3, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_3);
-        return Tuple.of(_1, _2, u, _4, _5);
+        return Tuple.of(_1, _2, mapper.apply(_3), _4, _5);
     }
 
     /**
@@ -350,10 +239,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 4th component
      */
-    public <U> Tuple5<T1, T2, T3, U, T5> map4(Function<? super T4, ? extends U> mapper) {
+    public <U> Tuple5<T1, T2, T3, U, T5> map4(@NonNull Function<? super T4, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_4);
-        return Tuple.of(_1, _2, _3, u, _5);
+        return Tuple.of(_1, _2, _3, mapper.apply(_4), _5);
     }
 
     /**
@@ -363,10 +251,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 5th component
      */
-    public <U> Tuple5<T1, T2, T3, T4, U> map5(Function<? super T5, ? extends U> mapper) {
+    public <U> Tuple5<T1, T2, T3, T4, U> map5(@NonNull Function<? super T5, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_5);
-        return Tuple.of(_1, _2, _3, _4, u);
+        return Tuple.of(_1, _2, _3, _4, mapper.apply(_5));
     }
 
     /**
@@ -408,7 +295,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      */
     public <T6> Tuple6<T1, T2, T3, T4, T5, T6> concat(@NonNull Tuple1<T6> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, _4, _5, tuple._1);
+        return Tuple.of(_1, _2, _3, _4, _5, tuple._1());
     }
 
     /**
@@ -422,7 +309,7 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      */
     public <T6, T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(@NonNull Tuple2<T6, T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, _4, _5, tuple._1, tuple._2);
+        return Tuple.of(_1, _2, _3, _4, _5, tuple._1(), tuple._2());
     }
 
     /**
@@ -437,34 +324,11 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple, Comparable<Tuple
      */
     public <T6, T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(@NonNull Tuple3<T6, T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, _4, _5, tuple._1, tuple._2, tuple._3);
-    }
-
-    // -- Object
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        } else if (!(o instanceof Tuple5)) {
-            return false;
-        } else {
-            final Tuple5<?, ?, ?, ?, ?> that = (Tuple5<?, ?, ?, ?, ?>) o;
-            return Objects.equals(this._1, that._1)
-                  && Objects.equals(this._2, that._2)
-                  && Objects.equals(this._3, that._3)
-                  && Objects.equals(this._4, that._4)
-                  && Objects.equals(this._5, that._5);
-        }
+        return Tuple.of(_1, _2, _3, _4, _5, tuple._1(), tuple._2(), tuple._3());
     }
 
     @Override
-    public int hashCode() {
-        return Tuple.hash(_1, _2, _3, _4, _5);
-    }
-
-    @Override
-    public String toString() {
+    public @NonNull String toString() {
         return "(" + _1 + ", " + _2 + ", " + _3 + ", " + _4 + ", " + _5 + ")";
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple6.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple6.java
@@ -39,66 +39,9 @@ import org.jspecify.annotations.NonNull;
  * @param <T4> type of the 4th element
  * @param <T5> type of the 5th element
  * @param <T6> type of the 6th element
- * @author Daniel Dietrich
+ * @author Daniel Dietrich, Grzegorz Piwowarek
  */
-public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<Tuple6<T1, T2, T3, T4, T5, T6>>, Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * The 1st element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T1 _1;
-
-    /**
-     * The 2nd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T2 _2;
-
-    /**
-     * The 3rd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T3 _3;
-
-    /**
-     * The 4th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T4 _4;
-
-    /**
-     * The 5th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T5 _5;
-
-    /**
-     * The 6th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T6 _6;
-
-    /**
-     * Constructs a tuple of 6 elements.
-     *
-     * @param t1 the 1st element
-     * @param t2 the 2nd element
-     * @param t3 the 3rd element
-     * @param t4 the 4th element
-     * @param t5 the 5th element
-     * @param t6 the 6th element
-     */
-    public Tuple6(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) {
-        this._1 = t1;
-        this._2 = t2;
-        this._3 = t3;
-        this._4 = t4;
-        this._5 = t5;
-        this._6 = t6;
-    }
+public record Tuple6<T1, T2, T3, T4, T5, T6>(T1 _1, T2 _2, T3 _3, T4 _4, T5 _5, T6 _6) implements Tuple, Comparable<Tuple6<T1, T2, T3, T4, T5, T6>>, Serializable {
 
     public static <T1, T2, T3, T4, T5, T6> Comparator<Tuple6<T1, T2, T3, T4, T5, T6>> comparator(Comparator<? super T1> t1Comp, Comparator<? super T2> t2Comp, Comparator<? super T3> t3Comp, Comparator<? super T4> t4Comp, Comparator<? super T5> t5Comp, Comparator<? super T6> t6Comp) {
         return (Comparator<Tuple6<T1, T2, T3, T4, T5, T6>> & Serializable) (t1, t2) -> {
@@ -126,14 +69,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
             if (check5 != 0) {
                 return check5;
             }
-
-            final int check6 = t6Comp.compare(t1._6, t2._6);
-            if (check6 != 0) {
-                return check6;
-            }
-
-            // all components are equal
-            return 0;
+            return t6Comp.compare(t1._6, t2._6);
         };
     }
 
@@ -166,14 +102,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
         if (check5 != 0) {
             return check5;
         }
-
-        final int check6 = t1._6.compareTo(t2._6);
-        if (check6 != 0) {
-            return check6;
-        }
-
-        // all components are equal
-        return 0;
+        return t1._6.compareTo(t2._6);
     }
 
     @Override
@@ -187,15 +116,6 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
     }
 
     /**
-     * Getter of the 1st element of this tuple.
-     *
-     * @return the 1st element of this Tuple.
-     */
-    public T1 _1() {
-        return _1;
-    }
-
-    /**
      * Sets the 1st element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -203,15 +123,6 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      */
     public Tuple6<T1, T2, T3, T4, T5, T6> update1(T1 value) {
         return new Tuple6<>(value, _2, _3, _4, _5, _6);
-    }
-
-    /**
-     * Getter of the 2nd element of this tuple.
-     *
-     * @return the 2nd element of this Tuple.
-     */
-    public T2 _2() {
-        return _2;
     }
 
     /**
@@ -225,15 +136,6 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
     }
 
     /**
-     * Getter of the 3rd element of this tuple.
-     *
-     * @return the 3rd element of this Tuple.
-     */
-    public T3 _3() {
-        return _3;
-    }
-
-    /**
      * Sets the 3rd element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -241,15 +143,6 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      */
     public Tuple6<T1, T2, T3, T4, T5, T6> update3(T3 value) {
         return new Tuple6<>(_1, _2, value, _4, _5, _6);
-    }
-
-    /**
-     * Getter of the 4th element of this tuple.
-     *
-     * @return the 4th element of this Tuple.
-     */
-    public T4 _4() {
-        return _4;
     }
 
     /**
@@ -263,15 +156,6 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
     }
 
     /**
-     * Getter of the 5th element of this tuple.
-     *
-     * @return the 5th element of this Tuple.
-     */
-    public T5 _5() {
-        return _5;
-    }
-
-    /**
      * Sets the 5th element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -279,15 +163,6 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      */
     public Tuple6<T1, T2, T3, T4, T5, T6> update5(T5 value) {
         return new Tuple6<>(_1, _2, _3, _4, value, _6);
-    }
-
-    /**
-     * Getter of the 6th element of this tuple.
-     *
-     * @return the 6th element of this Tuple.
-     */
-    public T6 _6() {
-        return _6;
     }
 
     /**
@@ -310,7 +185,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * @param <U4> new type of the 4th component
      * @param <U5> new type of the 5th component
      * @param <U6> new type of the 6th component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if {@code mapper} is null
      */
     public <U1, U2, U3, U4, U5, U6> Tuple6<U1, U2, U3, U4, U5, U6> map(@NonNull Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, Tuple6<U1, U2, U3, U4, U5, U6>> mapper) {
@@ -333,7 +208,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * @param <U4> new type of the 4th component
      * @param <U5> new type of the 5th component
      * @param <U6> new type of the 6th component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if one of the arguments is null
      */
     public <U1, U2, U3, U4, U5, U6> Tuple6<U1, U2, U3, U4, U5, U6> map(@NonNull Function<? super T1, ? extends U1> f1, @NonNull Function<? super T2, ? extends U2> f2, @NonNull Function<? super T3, ? extends U3> f3, @NonNull Function<? super T4, ? extends U4> f4, @NonNull Function<? super T5, ? extends U5> f5, @NonNull Function<? super T6, ? extends U6> f6) {
@@ -353,10 +228,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 1st component
      */
-    public <U> Tuple6<U, T2, T3, T4, T5, T6> map1(Function<? super T1, ? extends U> mapper) {
+    public <U> Tuple6<U, T2, T3, T4, T5, T6> map1(@NonNull Function<? super T1, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_1);
-        return Tuple.of(u, _2, _3, _4, _5, _6);
+        return Tuple.of(mapper.apply(_1), _2, _3, _4, _5, _6);
     }
 
     /**
@@ -366,10 +240,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 2nd component
      */
-    public <U> Tuple6<T1, U, T3, T4, T5, T6> map2(Function<? super T2, ? extends U> mapper) {
+    public <U> Tuple6<T1, U, T3, T4, T5, T6> map2(@NonNull Function<? super T2, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_2);
-        return Tuple.of(_1, u, _3, _4, _5, _6);
+        return Tuple.of(_1, mapper.apply(_2), _3, _4, _5, _6);
     }
 
     /**
@@ -379,10 +252,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 3rd component
      */
-    public <U> Tuple6<T1, T2, U, T4, T5, T6> map3(Function<? super T3, ? extends U> mapper) {
+    public <U> Tuple6<T1, T2, U, T4, T5, T6> map3(@NonNull Function<? super T3, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_3);
-        return Tuple.of(_1, _2, u, _4, _5, _6);
+        return Tuple.of(_1, _2, mapper.apply(_3), _4, _5, _6);
     }
 
     /**
@@ -392,10 +264,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 4th component
      */
-    public <U> Tuple6<T1, T2, T3, U, T5, T6> map4(Function<? super T4, ? extends U> mapper) {
+    public <U> Tuple6<T1, T2, T3, U, T5, T6> map4(@NonNull Function<? super T4, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_4);
-        return Tuple.of(_1, _2, _3, u, _5, _6);
+        return Tuple.of(_1, _2, _3, mapper.apply(_4), _5, _6);
     }
 
     /**
@@ -405,10 +276,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 5th component
      */
-    public <U> Tuple6<T1, T2, T3, T4, U, T6> map5(Function<? super T5, ? extends U> mapper) {
+    public <U> Tuple6<T1, T2, T3, T4, U, T6> map5(@NonNull Function<? super T5, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_5);
-        return Tuple.of(_1, _2, _3, _4, u, _6);
+        return Tuple.of(_1, _2, _3, _4, mapper.apply(_5), _6);
     }
 
     /**
@@ -418,10 +288,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 6th component
      */
-    public <U> Tuple6<T1, T2, T3, T4, T5, U> map6(Function<? super T6, ? extends U> mapper) {
+    public <U> Tuple6<T1, T2, T3, T4, T5, U> map6(@NonNull Function<? super T6, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_6);
-        return Tuple.of(_1, _2, _3, _4, _5, u);
+        return Tuple.of(_1, _2, _3, _4, _5, mapper.apply(_6));
     }
 
     /**
@@ -463,7 +332,7 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      */
     public <T7> Tuple7<T1, T2, T3, T4, T5, T6, T7> concat(@NonNull Tuple1<T7> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, _4, _5, _6, tuple._1);
+        return Tuple.of(_1, _2, _3, _4, _5, _6, tuple._1());
     }
 
     /**
@@ -477,35 +346,11 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple, Comparable<T
      */
     public <T7, T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(@NonNull Tuple2<T7, T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, _4, _5, _6, tuple._1, tuple._2);
-    }
-
-    // -- Object
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        } else if (!(o instanceof Tuple6)) {
-            return false;
-        } else {
-            final Tuple6<?, ?, ?, ?, ?, ?> that = (Tuple6<?, ?, ?, ?, ?, ?>) o;
-            return Objects.equals(this._1, that._1)
-                  && Objects.equals(this._2, that._2)
-                  && Objects.equals(this._3, that._3)
-                  && Objects.equals(this._4, that._4)
-                  && Objects.equals(this._5, that._5)
-                  && Objects.equals(this._6, that._6);
-        }
+        return Tuple.of(_1, _2, _3, _4, _5, _6, tuple._1(), tuple._2());
     }
 
     @Override
-    public int hashCode() {
-        return Tuple.hash(_1, _2, _3, _4, _5, _6);
-    }
-
-    @Override
-    public String toString() {
+    public @NonNull String toString() {
         return "(" + _1 + ", " + _2 + ", " + _3 + ", " + _4 + ", " + _5 + ", " + _6 + ")";
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple7.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple7.java
@@ -40,74 +40,9 @@ import org.jspecify.annotations.NonNull;
  * @param <T5> type of the 5th element
  * @param <T6> type of the 6th element
  * @param <T7> type of the 7th element
- * @author Daniel Dietrich
+ * @author Daniel Dietrich, Grzegorz Piwowarek
  */
-public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparable<Tuple7<T1, T2, T3, T4, T5, T6, T7>>, Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * The 1st element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T1 _1;
-
-    /**
-     * The 2nd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T2 _2;
-
-    /**
-     * The 3rd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T3 _3;
-
-    /**
-     * The 4th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T4 _4;
-
-    /**
-     * The 5th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T5 _5;
-
-    /**
-     * The 6th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T6 _6;
-
-    /**
-     * The 7th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T7 _7;
-
-    /**
-     * Constructs a tuple of 7 elements.
-     *
-     * @param t1 the 1st element
-     * @param t2 the 2nd element
-     * @param t3 the 3rd element
-     * @param t4 the 4th element
-     * @param t5 the 5th element
-     * @param t6 the 6th element
-     * @param t7 the 7th element
-     */
-    public Tuple7(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) {
-        this._1 = t1;
-        this._2 = t2;
-        this._3 = t3;
-        this._4 = t4;
-        this._5 = t5;
-        this._6 = t6;
-        this._7 = t7;
-    }
+public record Tuple7<T1, T2, T3, T4, T5, T6, T7>(T1 _1, T2 _2, T3 _3, T4 _4, T5 _5, T6 _6, T7 _7) implements Tuple, Comparable<Tuple7<T1, T2, T3, T4, T5, T6, T7>>, Serializable {
 
     public static <T1, T2, T3, T4, T5, T6, T7> Comparator<Tuple7<T1, T2, T3, T4, T5, T6, T7>> comparator(Comparator<? super T1> t1Comp, Comparator<? super T2> t2Comp, Comparator<? super T3> t3Comp, Comparator<? super T4> t4Comp, Comparator<? super T5> t5Comp, Comparator<? super T6> t6Comp, Comparator<? super T7> t7Comp) {
         return (Comparator<Tuple7<T1, T2, T3, T4, T5, T6, T7>> & Serializable) (t1, t2) -> {
@@ -140,14 +75,7 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
             if (check6 != 0) {
                 return check6;
             }
-
-            final int check7 = t7Comp.compare(t1._7, t2._7);
-            if (check7 != 0) {
-                return check7;
-            }
-
-            // all components are equal
-            return 0;
+            return t7Comp.compare(t1._7, t2._7);
         };
     }
 
@@ -185,14 +113,7 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
         if (check6 != 0) {
             return check6;
         }
-
-        final int check7 = t1._7.compareTo(t2._7);
-        if (check7 != 0) {
-            return check7;
-        }
-
-        // all components are equal
-        return 0;
+        return t1._7.compareTo(t2._7);
     }
 
     @Override
@@ -206,15 +127,6 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
     }
 
     /**
-     * Getter of the 1st element of this tuple.
-     *
-     * @return the 1st element of this Tuple.
-     */
-    public T1 _1() {
-        return _1;
-    }
-
-    /**
      * Sets the 1st element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -222,15 +134,6 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      */
     public Tuple7<T1, T2, T3, T4, T5, T6, T7> update1(T1 value) {
         return new Tuple7<>(value, _2, _3, _4, _5, _6, _7);
-    }
-
-    /**
-     * Getter of the 2nd element of this tuple.
-     *
-     * @return the 2nd element of this Tuple.
-     */
-    public T2 _2() {
-        return _2;
     }
 
     /**
@@ -244,15 +147,6 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
     }
 
     /**
-     * Getter of the 3rd element of this tuple.
-     *
-     * @return the 3rd element of this Tuple.
-     */
-    public T3 _3() {
-        return _3;
-    }
-
-    /**
      * Sets the 3rd element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -260,15 +154,6 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      */
     public Tuple7<T1, T2, T3, T4, T5, T6, T7> update3(T3 value) {
         return new Tuple7<>(_1, _2, value, _4, _5, _6, _7);
-    }
-
-    /**
-     * Getter of the 4th element of this tuple.
-     *
-     * @return the 4th element of this Tuple.
-     */
-    public T4 _4() {
-        return _4;
     }
 
     /**
@@ -282,15 +167,6 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
     }
 
     /**
-     * Getter of the 5th element of this tuple.
-     *
-     * @return the 5th element of this Tuple.
-     */
-    public T5 _5() {
-        return _5;
-    }
-
-    /**
      * Sets the 5th element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -301,15 +177,6 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
     }
 
     /**
-     * Getter of the 6th element of this tuple.
-     *
-     * @return the 6th element of this Tuple.
-     */
-    public T6 _6() {
-        return _6;
-    }
-
-    /**
      * Sets the 6th element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -317,15 +184,6 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      */
     public Tuple7<T1, T2, T3, T4, T5, T6, T7> update6(T6 value) {
         return new Tuple7<>(_1, _2, _3, _4, _5, value, _7);
-    }
-
-    /**
-     * Getter of the 7th element of this tuple.
-     *
-     * @return the 7th element of this Tuple.
-     */
-    public T7 _7() {
-        return _7;
     }
 
     /**
@@ -349,7 +207,7 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * @param <U5> new type of the 5th component
      * @param <U6> new type of the 6th component
      * @param <U7> new type of the 7th component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if {@code mapper} is null
      */
     public <U1, U2, U3, U4, U5, U6, U7> Tuple7<U1, U2, U3, U4, U5, U6, U7> map(@NonNull Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, Tuple7<U1, U2, U3, U4, U5, U6, U7>> mapper) {
@@ -374,7 +232,7 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * @param <U5> new type of the 5th component
      * @param <U6> new type of the 6th component
      * @param <U7> new type of the 7th component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if one of the arguments is null
      */
     public <U1, U2, U3, U4, U5, U6, U7> Tuple7<U1, U2, U3, U4, U5, U6, U7> map(@NonNull Function<? super T1, ? extends U1> f1, @NonNull Function<? super T2, ? extends U2> f2, @NonNull Function<? super T3, ? extends U3> f3, @NonNull Function<? super T4, ? extends U4> f4, @NonNull Function<? super T5, ? extends U5> f5, @NonNull Function<? super T6, ? extends U6> f6, @NonNull Function<? super T7, ? extends U7> f7) {
@@ -395,10 +253,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 1st component
      */
-    public <U> Tuple7<U, T2, T3, T4, T5, T6, T7> map1(Function<? super T1, ? extends U> mapper) {
+    public <U> Tuple7<U, T2, T3, T4, T5, T6, T7> map1(@NonNull Function<? super T1, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_1);
-        return Tuple.of(u, _2, _3, _4, _5, _6, _7);
+        return Tuple.of(mapper.apply(_1), _2, _3, _4, _5, _6, _7);
     }
 
     /**
@@ -408,10 +265,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 2nd component
      */
-    public <U> Tuple7<T1, U, T3, T4, T5, T6, T7> map2(Function<? super T2, ? extends U> mapper) {
+    public <U> Tuple7<T1, U, T3, T4, T5, T6, T7> map2(@NonNull Function<? super T2, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_2);
-        return Tuple.of(_1, u, _3, _4, _5, _6, _7);
+        return Tuple.of(_1, mapper.apply(_2), _3, _4, _5, _6, _7);
     }
 
     /**
@@ -421,10 +277,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 3rd component
      */
-    public <U> Tuple7<T1, T2, U, T4, T5, T6, T7> map3(Function<? super T3, ? extends U> mapper) {
+    public <U> Tuple7<T1, T2, U, T4, T5, T6, T7> map3(@NonNull Function<? super T3, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_3);
-        return Tuple.of(_1, _2, u, _4, _5, _6, _7);
+        return Tuple.of(_1, _2, mapper.apply(_3), _4, _5, _6, _7);
     }
 
     /**
@@ -434,10 +289,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 4th component
      */
-    public <U> Tuple7<T1, T2, T3, U, T5, T6, T7> map4(Function<? super T4, ? extends U> mapper) {
+    public <U> Tuple7<T1, T2, T3, U, T5, T6, T7> map4(@NonNull Function<? super T4, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_4);
-        return Tuple.of(_1, _2, _3, u, _5, _6, _7);
+        return Tuple.of(_1, _2, _3, mapper.apply(_4), _5, _6, _7);
     }
 
     /**
@@ -447,10 +301,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 5th component
      */
-    public <U> Tuple7<T1, T2, T3, T4, U, T6, T7> map5(Function<? super T5, ? extends U> mapper) {
+    public <U> Tuple7<T1, T2, T3, T4, U, T6, T7> map5(@NonNull Function<? super T5, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_5);
-        return Tuple.of(_1, _2, _3, _4, u, _6, _7);
+        return Tuple.of(_1, _2, _3, _4, mapper.apply(_5), _6, _7);
     }
 
     /**
@@ -460,10 +313,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 6th component
      */
-    public <U> Tuple7<T1, T2, T3, T4, T5, U, T7> map6(Function<? super T6, ? extends U> mapper) {
+    public <U> Tuple7<T1, T2, T3, T4, T5, U, T7> map6(@NonNull Function<? super T6, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_6);
-        return Tuple.of(_1, _2, _3, _4, _5, u, _7);
+        return Tuple.of(_1, _2, _3, _4, _5, mapper.apply(_6), _7);
     }
 
     /**
@@ -473,10 +325,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 7th component
      */
-    public <U> Tuple7<T1, T2, T3, T4, T5, T6, U> map7(Function<? super T7, ? extends U> mapper) {
+    public <U> Tuple7<T1, T2, T3, T4, T5, T6, U> map7(@NonNull Function<? super T7, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_7);
-        return Tuple.of(_1, _2, _3, _4, _5, _6, u);
+        return Tuple.of(_1, _2, _3, _4, _5, _6, mapper.apply(_7));
     }
 
     /**
@@ -518,36 +369,11 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple, Comparab
      */
     public <T8> Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> concat(@NonNull Tuple1<T8> tuple) {
         Objects.requireNonNull(tuple, "tuple is null");
-        return Tuple.of(_1, _2, _3, _4, _5, _6, _7, tuple._1);
-    }
-
-    // -- Object
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        } else if (!(o instanceof Tuple7)) {
-            return false;
-        } else {
-            final Tuple7<?, ?, ?, ?, ?, ?, ?> that = (Tuple7<?, ?, ?, ?, ?, ?, ?>) o;
-            return Objects.equals(this._1, that._1)
-                  && Objects.equals(this._2, that._2)
-                  && Objects.equals(this._3, that._3)
-                  && Objects.equals(this._4, that._4)
-                  && Objects.equals(this._5, that._5)
-                  && Objects.equals(this._6, that._6)
-                  && Objects.equals(this._7, that._7);
-        }
+        return Tuple.of(_1, _2, _3, _4, _5, _6, _7, tuple._1());
     }
 
     @Override
-    public int hashCode() {
-        return Tuple.hash(_1, _2, _3, _4, _5, _6, _7);
-    }
-
-    @Override
-    public String toString() {
+    public @NonNull String toString() {
         return "(" + _1 + ", " + _2 + ", " + _3 + ", " + _4 + ", " + _5 + ", " + _6 + ", " + _7 + ")";
     }
 

--- a/vavr/src-gen/main/java/io/vavr/Tuple8.java
+++ b/vavr/src-gen/main/java/io/vavr/Tuple8.java
@@ -41,82 +41,9 @@ import org.jspecify.annotations.NonNull;
  * @param <T6> type of the 6th element
  * @param <T7> type of the 7th element
  * @param <T8> type of the 8th element
- * @author Daniel Dietrich
+ * @author Daniel Dietrich, Grzegorz Piwowarek
  */
-public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comparable<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>, Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * The 1st element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T1 _1;
-
-    /**
-     * The 2nd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T2 _2;
-
-    /**
-     * The 3rd element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T3 _3;
-
-    /**
-     * The 4th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T4 _4;
-
-    /**
-     * The 5th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T5 _5;
-
-    /**
-     * The 6th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T6 _6;
-
-    /**
-     * The 7th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T7 _7;
-
-    /**
-     * The 8th element of this tuple.
-     */
-    @SuppressWarnings("serial") // Conditionally serializable
-    public final T8 _8;
-
-    /**
-     * Constructs a tuple of 8 elements.
-     *
-     * @param t1 the 1st element
-     * @param t2 the 2nd element
-     * @param t3 the 3rd element
-     * @param t4 the 4th element
-     * @param t5 the 5th element
-     * @param t6 the 6th element
-     * @param t7 the 7th element
-     * @param t8 the 8th element
-     */
-    public Tuple8(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) {
-        this._1 = t1;
-        this._2 = t2;
-        this._3 = t3;
-        this._4 = t4;
-        this._5 = t5;
-        this._6 = t6;
-        this._7 = t7;
-        this._8 = t8;
-    }
+public record Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>(T1 _1, T2 _2, T3 _3, T4 _4, T5 _5, T6 _6, T7 _7, T8 _8) implements Tuple, Comparable<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>, Serializable {
 
     public static <T1, T2, T3, T4, T5, T6, T7, T8> Comparator<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> comparator(Comparator<? super T1> t1Comp, Comparator<? super T2> t2Comp, Comparator<? super T3> t3Comp, Comparator<? super T4> t4Comp, Comparator<? super T5> t5Comp, Comparator<? super T6> t6Comp, Comparator<? super T7> t7Comp, Comparator<? super T8> t8Comp) {
         return (Comparator<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> & Serializable) (t1, t2) -> {
@@ -154,14 +81,7 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
             if (check7 != 0) {
                 return check7;
             }
-
-            final int check8 = t8Comp.compare(t1._8, t2._8);
-            if (check8 != 0) {
-                return check8;
-            }
-
-            // all components are equal
-            return 0;
+            return t8Comp.compare(t1._8, t2._8);
         };
     }
 
@@ -204,14 +124,7 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
         if (check7 != 0) {
             return check7;
         }
-
-        final int check8 = t1._8.compareTo(t2._8);
-        if (check8 != 0) {
-            return check8;
-        }
-
-        // all components are equal
-        return 0;
+        return t1._8.compareTo(t2._8);
     }
 
     @Override
@@ -225,15 +138,6 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
     }
 
     /**
-     * Getter of the 1st element of this tuple.
-     *
-     * @return the 1st element of this Tuple.
-     */
-    public T1 _1() {
-        return _1;
-    }
-
-    /**
      * Sets the 1st element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -241,15 +145,6 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      */
     public Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> update1(T1 value) {
         return new Tuple8<>(value, _2, _3, _4, _5, _6, _7, _8);
-    }
-
-    /**
-     * Getter of the 2nd element of this tuple.
-     *
-     * @return the 2nd element of this Tuple.
-     */
-    public T2 _2() {
-        return _2;
     }
 
     /**
@@ -263,15 +158,6 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
     }
 
     /**
-     * Getter of the 3rd element of this tuple.
-     *
-     * @return the 3rd element of this Tuple.
-     */
-    public T3 _3() {
-        return _3;
-    }
-
-    /**
      * Sets the 3rd element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -279,15 +165,6 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      */
     public Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> update3(T3 value) {
         return new Tuple8<>(_1, _2, value, _4, _5, _6, _7, _8);
-    }
-
-    /**
-     * Getter of the 4th element of this tuple.
-     *
-     * @return the 4th element of this Tuple.
-     */
-    public T4 _4() {
-        return _4;
     }
 
     /**
@@ -301,15 +178,6 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
     }
 
     /**
-     * Getter of the 5th element of this tuple.
-     *
-     * @return the 5th element of this Tuple.
-     */
-    public T5 _5() {
-        return _5;
-    }
-
-    /**
      * Sets the 5th element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -317,15 +185,6 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      */
     public Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> update5(T5 value) {
         return new Tuple8<>(_1, _2, _3, _4, value, _6, _7, _8);
-    }
-
-    /**
-     * Getter of the 6th element of this tuple.
-     *
-     * @return the 6th element of this Tuple.
-     */
-    public T6 _6() {
-        return _6;
     }
 
     /**
@@ -339,15 +198,6 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
     }
 
     /**
-     * Getter of the 7th element of this tuple.
-     *
-     * @return the 7th element of this Tuple.
-     */
-    public T7 _7() {
-        return _7;
-    }
-
-    /**
      * Sets the 7th element of this tuple to the given {@code value}.
      *
      * @param value the new value
@@ -355,15 +205,6 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      */
     public Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> update7(T7 value) {
         return new Tuple8<>(_1, _2, _3, _4, _5, _6, value, _8);
-    }
-
-    /**
-     * Getter of the 8th element of this tuple.
-     *
-     * @return the 8th element of this Tuple.
-     */
-    public T8 _8() {
-        return _8;
     }
 
     /**
@@ -388,7 +229,7 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      * @param <U6> new type of the 6th component
      * @param <U7> new type of the 7th component
      * @param <U8> new type of the 8th component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if {@code mapper} is null
      */
     public <U1, U2, U3, U4, U5, U6, U7, U8> Tuple8<U1, U2, U3, U4, U5, U6, U7, U8> map(@NonNull Function8<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, Tuple8<U1, U2, U3, U4, U5, U6, U7, U8>> mapper) {
@@ -415,7 +256,7 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      * @param <U6> new type of the 6th component
      * @param <U7> new type of the 7th component
      * @param <U8> new type of the 8th component
-     * @return A new Tuple of same arity.
+     * @return A new Tuple of the same arity.
      * @throws NullPointerException if one of the arguments is null
      */
     public <U1, U2, U3, U4, U5, U6, U7, U8> Tuple8<U1, U2, U3, U4, U5, U6, U7, U8> map(@NonNull Function<? super T1, ? extends U1> f1, @NonNull Function<? super T2, ? extends U2> f2, @NonNull Function<? super T3, ? extends U3> f3, @NonNull Function<? super T4, ? extends U4> f4, @NonNull Function<? super T5, ? extends U5> f5, @NonNull Function<? super T6, ? extends U6> f6, @NonNull Function<? super T7, ? extends U7> f7, @NonNull Function<? super T8, ? extends U8> f8) {
@@ -437,10 +278,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 1st component
      */
-    public <U> Tuple8<U, T2, T3, T4, T5, T6, T7, T8> map1(Function<? super T1, ? extends U> mapper) {
+    public <U> Tuple8<U, T2, T3, T4, T5, T6, T7, T8> map1(@NonNull Function<? super T1, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_1);
-        return Tuple.of(u, _2, _3, _4, _5, _6, _7, _8);
+        return Tuple.of(mapper.apply(_1), _2, _3, _4, _5, _6, _7, _8);
     }
 
     /**
@@ -450,10 +290,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 2nd component
      */
-    public <U> Tuple8<T1, U, T3, T4, T5, T6, T7, T8> map2(Function<? super T2, ? extends U> mapper) {
+    public <U> Tuple8<T1, U, T3, T4, T5, T6, T7, T8> map2(@NonNull Function<? super T2, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_2);
-        return Tuple.of(_1, u, _3, _4, _5, _6, _7, _8);
+        return Tuple.of(_1, mapper.apply(_2), _3, _4, _5, _6, _7, _8);
     }
 
     /**
@@ -463,10 +302,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 3rd component
      */
-    public <U> Tuple8<T1, T2, U, T4, T5, T6, T7, T8> map3(Function<? super T3, ? extends U> mapper) {
+    public <U> Tuple8<T1, T2, U, T4, T5, T6, T7, T8> map3(@NonNull Function<? super T3, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_3);
-        return Tuple.of(_1, _2, u, _4, _5, _6, _7, _8);
+        return Tuple.of(_1, _2, mapper.apply(_3), _4, _5, _6, _7, _8);
     }
 
     /**
@@ -476,10 +314,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 4th component
      */
-    public <U> Tuple8<T1, T2, T3, U, T5, T6, T7, T8> map4(Function<? super T4, ? extends U> mapper) {
+    public <U> Tuple8<T1, T2, T3, U, T5, T6, T7, T8> map4(@NonNull Function<? super T4, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_4);
-        return Tuple.of(_1, _2, _3, u, _5, _6, _7, _8);
+        return Tuple.of(_1, _2, _3, mapper.apply(_4), _5, _6, _7, _8);
     }
 
     /**
@@ -489,10 +326,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 5th component
      */
-    public <U> Tuple8<T1, T2, T3, T4, U, T6, T7, T8> map5(Function<? super T5, ? extends U> mapper) {
+    public <U> Tuple8<T1, T2, T3, T4, U, T6, T7, T8> map5(@NonNull Function<? super T5, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_5);
-        return Tuple.of(_1, _2, _3, _4, u, _6, _7, _8);
+        return Tuple.of(_1, _2, _3, _4, mapper.apply(_5), _6, _7, _8);
     }
 
     /**
@@ -502,10 +338,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 6th component
      */
-    public <U> Tuple8<T1, T2, T3, T4, T5, U, T7, T8> map6(Function<? super T6, ? extends U> mapper) {
+    public <U> Tuple8<T1, T2, T3, T4, T5, U, T7, T8> map6(@NonNull Function<? super T6, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_6);
-        return Tuple.of(_1, _2, _3, _4, _5, u, _7, _8);
+        return Tuple.of(_1, _2, _3, _4, _5, mapper.apply(_6), _7, _8);
     }
 
     /**
@@ -515,10 +350,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 7th component
      */
-    public <U> Tuple8<T1, T2, T3, T4, T5, T6, U, T8> map7(Function<? super T7, ? extends U> mapper) {
+    public <U> Tuple8<T1, T2, T3, T4, T5, T6, U, T8> map7(@NonNull Function<? super T7, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_7);
-        return Tuple.of(_1, _2, _3, _4, _5, _6, u, _8);
+        return Tuple.of(_1, _2, _3, _4, _5, _6, mapper.apply(_7), _8);
     }
 
     /**
@@ -528,10 +362,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
      * @param mapper A mapping function
      * @return a new tuple based on this tuple and substituted 8th component
      */
-    public <U> Tuple8<T1, T2, T3, T4, T5, T6, T7, U> map8(Function<? super T8, ? extends U> mapper) {
+    public <U> Tuple8<T1, T2, T3, T4, T5, T6, T7, U> map8(@NonNull Function<? super T8, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        final U u = mapper.apply(_8);
-        return Tuple.of(_1, _2, _3, _4, _5, _6, _7, u);
+        return Tuple.of(_1, _2, _3, _4, _5, _6, _7, mapper.apply(_8));
     }
 
     /**
@@ -552,34 +385,8 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple, Comp
         return List.of(_1, _2, _3, _4, _5, _6, _7, _8);
     }
 
-    // -- Object
-
     @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        } else if (!(o instanceof Tuple8)) {
-            return false;
-        } else {
-            final Tuple8<?, ?, ?, ?, ?, ?, ?, ?> that = (Tuple8<?, ?, ?, ?, ?, ?, ?, ?>) o;
-            return Objects.equals(this._1, that._1)
-                  && Objects.equals(this._2, that._2)
-                  && Objects.equals(this._3, that._3)
-                  && Objects.equals(this._4, that._4)
-                  && Objects.equals(this._5, that._5)
-                  && Objects.equals(this._6, that._6)
-                  && Objects.equals(this._7, that._7)
-                  && Objects.equals(this._8, that._8);
-        }
-    }
-
-    @Override
-    public int hashCode() {
-        return Tuple.hash(_1, _2, _3, _4, _5, _6, _7, _8);
-    }
-
-    @Override
-    public String toString() {
+    public @NonNull String toString() {
         return "(" + _1 + ", " + _2 + ", " + _3 + ", " + _4 + ", " + _5 + ", " + _6 + ", " + _7 + ", " + _8 + ")";
     }
 

--- a/vavr/src-gen/test/java/io/vavr/Tuple0Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple0Test.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import java.util.Comparator;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 public class Tuple0Test {
@@ -140,13 +139,6 @@ public class Tuple0Test {
         final Tuple0 tuple = createTuple();
         final Object other = new Object();
         assertThat(tuple).isNotEqualTo(other);
-    }
-
-    @Test
-    public void shouldComputeCorrectHashCode() {
-        final int actual = createTuple().hashCode();
-        final int expected = Objects.hash();
-        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Tuple1Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple1Test.java
@@ -29,7 +29,6 @@ import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
 import java.util.Comparator;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 public class Tuple1Test {
@@ -49,13 +48,13 @@ public class Tuple1Test {
     @Test
     public void shouldReturnElements() {
         final Tuple1<Integer> tuple = createIntTuple(1);
-        assertThat(tuple._1).isEqualTo(1);
+        assertThat(tuple._1()).isEqualTo(1);
     }
 
     @Test
     public void shouldUpdate1() {
       final Tuple1<Integer> tuple = createIntTuple(1).update1(42);
-      assertThat(tuple._1).isEqualTo(42);
+      assertThat(tuple._1()).isEqualTo(42);
     }
 
     @Test
@@ -184,13 +183,6 @@ public class Tuple1Test {
     public void shouldRecognizeNonEqualityPerComponent() {
         final Tuple1<String> tuple = Tuple.of("1");
         assertThat(tuple.equals(Tuple.of("X"))).isFalse();
-    }
-
-    @Test
-    public void shouldComputeCorrectHashCode() {
-        final int actual = createTuple().hashCode();
-        final int expected = Objects.hashCode(null);
-        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Tuple2Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple2Test.java
@@ -31,7 +31,6 @@ import io.vavr.collection.Stream;
 import java.util.AbstractMap;
 import java.util.Comparator;
 import java.util.Map;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 public class Tuple2Test {
@@ -51,22 +50,22 @@ public class Tuple2Test {
     @Test
     public void shouldReturnElements() {
         final Tuple2<Integer, Integer> tuple = createIntTuple(1, 2);
-        assertThat(tuple._1).isEqualTo(1);
-        assertThat(tuple._2).isEqualTo(2);
+        assertThat(tuple._1()).isEqualTo(1);
+        assertThat(tuple._2()).isEqualTo(2);
     }
 
     @Test
     public void shouldUpdate1() {
       final Tuple2<Integer, Integer> tuple = createIntTuple(1, 2).update1(42);
-      assertThat(tuple._1).isEqualTo(42);
-      assertThat(tuple._2).isEqualTo(2);
+      assertThat(tuple._1()).isEqualTo(42);
+      assertThat(tuple._2()).isEqualTo(2);
     }
 
     @Test
     public void shouldUpdate2() {
       final Tuple2<Integer, Integer> tuple = createIntTuple(1, 2).update2(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(42);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(42);
     }
 
     @Test
@@ -233,13 +232,6 @@ public class Tuple2Test {
         final Tuple2<String, String> tuple = Tuple.of("1", "2");
         assertThat(tuple.equals(Tuple.of("X", "2"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "X"))).isFalse();
-    }
-
-    @Test
-    public void shouldComputeCorrectHashCode() {
-        final int actual = createTuple().hashCode();
-        final int expected = Objects.hash(null, null);
-        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Tuple3Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple3Test.java
@@ -29,7 +29,6 @@ import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
 import java.util.Comparator;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 public class Tuple3Test {
@@ -49,33 +48,33 @@ public class Tuple3Test {
     @Test
     public void shouldReturnElements() {
         final Tuple3<Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3);
-        assertThat(tuple._1).isEqualTo(1);
-        assertThat(tuple._2).isEqualTo(2);
-        assertThat(tuple._3).isEqualTo(3);
+        assertThat(tuple._1()).isEqualTo(1);
+        assertThat(tuple._2()).isEqualTo(2);
+        assertThat(tuple._3()).isEqualTo(3);
     }
 
     @Test
     public void shouldUpdate1() {
       final Tuple3<Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3).update1(42);
-      assertThat(tuple._1).isEqualTo(42);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
+      assertThat(tuple._1()).isEqualTo(42);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
     }
 
     @Test
     public void shouldUpdate2() {
       final Tuple3<Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3).update2(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(42);
-      assertThat(tuple._3).isEqualTo(3);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(42);
+      assertThat(tuple._3()).isEqualTo(3);
     }
 
     @Test
     public void shouldUpdate3() {
       final Tuple3<Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3).update3(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(42);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(42);
     }
 
     @Test
@@ -242,13 +241,6 @@ public class Tuple3Test {
         assertThat(tuple.equals(Tuple.of("X", "2", "3"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "X", "3"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "X"))).isFalse();
-    }
-
-    @Test
-    public void shouldComputeCorrectHashCode() {
-        final int actual = createTuple().hashCode();
-        final int expected = Objects.hash(null, null, null);
-        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Tuple4Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple4Test.java
@@ -29,7 +29,6 @@ import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
 import java.util.Comparator;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 public class Tuple4Test {
@@ -49,46 +48,46 @@ public class Tuple4Test {
     @Test
     public void shouldReturnElements() {
         final Tuple4<Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4);
-        assertThat(tuple._1).isEqualTo(1);
-        assertThat(tuple._2).isEqualTo(2);
-        assertThat(tuple._3).isEqualTo(3);
-        assertThat(tuple._4).isEqualTo(4);
+        assertThat(tuple._1()).isEqualTo(1);
+        assertThat(tuple._2()).isEqualTo(2);
+        assertThat(tuple._3()).isEqualTo(3);
+        assertThat(tuple._4()).isEqualTo(4);
     }
 
     @Test
     public void shouldUpdate1() {
       final Tuple4<Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4).update1(42);
-      assertThat(tuple._1).isEqualTo(42);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
+      assertThat(tuple._1()).isEqualTo(42);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
     }
 
     @Test
     public void shouldUpdate2() {
       final Tuple4<Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4).update2(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(42);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(42);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
     }
 
     @Test
     public void shouldUpdate3() {
       final Tuple4<Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4).update3(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(42);
-      assertThat(tuple._4).isEqualTo(4);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(42);
+      assertThat(tuple._4()).isEqualTo(4);
     }
 
     @Test
     public void shouldUpdate4() {
       final Tuple4<Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4).update4(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(42);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(42);
     }
 
     @Test
@@ -267,13 +266,6 @@ public class Tuple4Test {
         assertThat(tuple.equals(Tuple.of("1", "X", "3", "4"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "X", "4"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "X"))).isFalse();
-    }
-
-    @Test
-    public void shouldComputeCorrectHashCode() {
-        final int actual = createTuple().hashCode();
-        final int expected = Objects.hash(null, null, null, null);
-        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Tuple5Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple5Test.java
@@ -29,7 +29,6 @@ import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
 import java.util.Comparator;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 public class Tuple5Test {
@@ -49,61 +48,61 @@ public class Tuple5Test {
     @Test
     public void shouldReturnElements() {
         final Tuple5<Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5);
-        assertThat(tuple._1).isEqualTo(1);
-        assertThat(tuple._2).isEqualTo(2);
-        assertThat(tuple._3).isEqualTo(3);
-        assertThat(tuple._4).isEqualTo(4);
-        assertThat(tuple._5).isEqualTo(5);
+        assertThat(tuple._1()).isEqualTo(1);
+        assertThat(tuple._2()).isEqualTo(2);
+        assertThat(tuple._3()).isEqualTo(3);
+        assertThat(tuple._4()).isEqualTo(4);
+        assertThat(tuple._5()).isEqualTo(5);
     }
 
     @Test
     public void shouldUpdate1() {
       final Tuple5<Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5).update1(42);
-      assertThat(tuple._1).isEqualTo(42);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
+      assertThat(tuple._1()).isEqualTo(42);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
     }
 
     @Test
     public void shouldUpdate2() {
       final Tuple5<Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5).update2(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(42);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(42);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
     }
 
     @Test
     public void shouldUpdate3() {
       final Tuple5<Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5).update3(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(42);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(42);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
     }
 
     @Test
     public void shouldUpdate4() {
       final Tuple5<Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5).update4(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(42);
-      assertThat(tuple._5).isEqualTo(5);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(42);
+      assertThat(tuple._5()).isEqualTo(5);
     }
 
     @Test
     public void shouldUpdate5() {
       final Tuple5<Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5).update5(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(42);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(42);
     }
 
     @Test
@@ -294,13 +293,6 @@ public class Tuple5Test {
         assertThat(tuple.equals(Tuple.of("1", "2", "X", "4", "5"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "X", "5"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "4", "X"))).isFalse();
-    }
-
-    @Test
-    public void shouldComputeCorrectHashCode() {
-        final int actual = createTuple().hashCode();
-        final int expected = Objects.hash(null, null, null, null, null);
-        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Tuple6Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple6Test.java
@@ -29,7 +29,6 @@ import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
 import java.util.Comparator;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 public class Tuple6Test {
@@ -49,78 +48,78 @@ public class Tuple6Test {
     @Test
     public void shouldReturnElements() {
         final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6);
-        assertThat(tuple._1).isEqualTo(1);
-        assertThat(tuple._2).isEqualTo(2);
-        assertThat(tuple._3).isEqualTo(3);
-        assertThat(tuple._4).isEqualTo(4);
-        assertThat(tuple._5).isEqualTo(5);
-        assertThat(tuple._6).isEqualTo(6);
+        assertThat(tuple._1()).isEqualTo(1);
+        assertThat(tuple._2()).isEqualTo(2);
+        assertThat(tuple._3()).isEqualTo(3);
+        assertThat(tuple._4()).isEqualTo(4);
+        assertThat(tuple._5()).isEqualTo(5);
+        assertThat(tuple._6()).isEqualTo(6);
     }
 
     @Test
     public void shouldUpdate1() {
       final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6).update1(42);
-      assertThat(tuple._1).isEqualTo(42);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
+      assertThat(tuple._1()).isEqualTo(42);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
     }
 
     @Test
     public void shouldUpdate2() {
       final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6).update2(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(42);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(42);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
     }
 
     @Test
     public void shouldUpdate3() {
       final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6).update3(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(42);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(42);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
     }
 
     @Test
     public void shouldUpdate4() {
       final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6).update4(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(42);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(42);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
     }
 
     @Test
     public void shouldUpdate5() {
       final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6).update5(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(42);
-      assertThat(tuple._6).isEqualTo(6);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(42);
+      assertThat(tuple._6()).isEqualTo(6);
     }
 
     @Test
     public void shouldUpdate6() {
       final Tuple6<Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6).update6(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(42);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(42);
     }
 
     @Test
@@ -323,13 +322,6 @@ public class Tuple6Test {
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "X", "5", "6"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "4", "X", "6"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "4", "5", "X"))).isFalse();
-    }
-
-    @Test
-    public void shouldComputeCorrectHashCode() {
-        final int actual = createTuple().hashCode();
-        final int expected = Objects.hash(null, null, null, null, null, null);
-        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Tuple7Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple7Test.java
@@ -29,7 +29,6 @@ import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
 import java.util.Comparator;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 public class Tuple7Test {
@@ -49,97 +48,97 @@ public class Tuple7Test {
     @Test
     public void shouldReturnElements() {
         final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7);
-        assertThat(tuple._1).isEqualTo(1);
-        assertThat(tuple._2).isEqualTo(2);
-        assertThat(tuple._3).isEqualTo(3);
-        assertThat(tuple._4).isEqualTo(4);
-        assertThat(tuple._5).isEqualTo(5);
-        assertThat(tuple._6).isEqualTo(6);
-        assertThat(tuple._7).isEqualTo(7);
+        assertThat(tuple._1()).isEqualTo(1);
+        assertThat(tuple._2()).isEqualTo(2);
+        assertThat(tuple._3()).isEqualTo(3);
+        assertThat(tuple._4()).isEqualTo(4);
+        assertThat(tuple._5()).isEqualTo(5);
+        assertThat(tuple._6()).isEqualTo(6);
+        assertThat(tuple._7()).isEqualTo(7);
     }
 
     @Test
     public void shouldUpdate1() {
       final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7).update1(42);
-      assertThat(tuple._1).isEqualTo(42);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
+      assertThat(tuple._1()).isEqualTo(42);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
     }
 
     @Test
     public void shouldUpdate2() {
       final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7).update2(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(42);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(42);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
     }
 
     @Test
     public void shouldUpdate3() {
       final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7).update3(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(42);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(42);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
     }
 
     @Test
     public void shouldUpdate4() {
       final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7).update4(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(42);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(42);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
     }
 
     @Test
     public void shouldUpdate5() {
       final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7).update5(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(42);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(42);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
     }
 
     @Test
     public void shouldUpdate6() {
       final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7).update6(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(42);
-      assertThat(tuple._7).isEqualTo(7);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(42);
+      assertThat(tuple._7()).isEqualTo(7);
     }
 
     @Test
     public void shouldUpdate7() {
       final Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7).update7(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(42);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(42);
     }
 
     @Test
@@ -354,13 +353,6 @@ public class Tuple7Test {
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "4", "X", "6", "7"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "4", "5", "X", "7"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "4", "5", "6", "X"))).isFalse();
-    }
-
-    @Test
-    public void shouldComputeCorrectHashCode() {
-        final int actual = createTuple().hashCode();
-        final int expected = Objects.hash(null, null, null, null, null, null, null);
-        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/vavr/src-gen/test/java/io/vavr/Tuple8Test.java
+++ b/vavr/src-gen/test/java/io/vavr/Tuple8Test.java
@@ -29,7 +29,6 @@ import io.vavr.collection.List;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Stream;
 import java.util.Comparator;
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 public class Tuple8Test {
@@ -49,118 +48,118 @@ public class Tuple8Test {
     @Test
     public void shouldReturnElements() {
         final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7, 8);
-        assertThat(tuple._1).isEqualTo(1);
-        assertThat(tuple._2).isEqualTo(2);
-        assertThat(tuple._3).isEqualTo(3);
-        assertThat(tuple._4).isEqualTo(4);
-        assertThat(tuple._5).isEqualTo(5);
-        assertThat(tuple._6).isEqualTo(6);
-        assertThat(tuple._7).isEqualTo(7);
-        assertThat(tuple._8).isEqualTo(8);
+        assertThat(tuple._1()).isEqualTo(1);
+        assertThat(tuple._2()).isEqualTo(2);
+        assertThat(tuple._3()).isEqualTo(3);
+        assertThat(tuple._4()).isEqualTo(4);
+        assertThat(tuple._5()).isEqualTo(5);
+        assertThat(tuple._6()).isEqualTo(6);
+        assertThat(tuple._7()).isEqualTo(7);
+        assertThat(tuple._8()).isEqualTo(8);
     }
 
     @Test
     public void shouldUpdate1() {
       final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7, 8).update1(42);
-      assertThat(tuple._1).isEqualTo(42);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
-      assertThat(tuple._8).isEqualTo(8);
+      assertThat(tuple._1()).isEqualTo(42);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
+      assertThat(tuple._8()).isEqualTo(8);
     }
 
     @Test
     public void shouldUpdate2() {
       final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7, 8).update2(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(42);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
-      assertThat(tuple._8).isEqualTo(8);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(42);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
+      assertThat(tuple._8()).isEqualTo(8);
     }
 
     @Test
     public void shouldUpdate3() {
       final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7, 8).update3(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(42);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
-      assertThat(tuple._8).isEqualTo(8);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(42);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
+      assertThat(tuple._8()).isEqualTo(8);
     }
 
     @Test
     public void shouldUpdate4() {
       final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7, 8).update4(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(42);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
-      assertThat(tuple._8).isEqualTo(8);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(42);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
+      assertThat(tuple._8()).isEqualTo(8);
     }
 
     @Test
     public void shouldUpdate5() {
       final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7, 8).update5(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(42);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
-      assertThat(tuple._8).isEqualTo(8);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(42);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
+      assertThat(tuple._8()).isEqualTo(8);
     }
 
     @Test
     public void shouldUpdate6() {
       final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7, 8).update6(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(42);
-      assertThat(tuple._7).isEqualTo(7);
-      assertThat(tuple._8).isEqualTo(8);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(42);
+      assertThat(tuple._7()).isEqualTo(7);
+      assertThat(tuple._8()).isEqualTo(8);
     }
 
     @Test
     public void shouldUpdate7() {
       final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7, 8).update7(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(42);
-      assertThat(tuple._8).isEqualTo(8);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(42);
+      assertThat(tuple._8()).isEqualTo(8);
     }
 
     @Test
     public void shouldUpdate8() {
       final Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer> tuple = createIntTuple(1, 2, 3, 4, 5, 6, 7, 8).update8(42);
-      assertThat(tuple._1).isEqualTo(1);
-      assertThat(tuple._2).isEqualTo(2);
-      assertThat(tuple._3).isEqualTo(3);
-      assertThat(tuple._4).isEqualTo(4);
-      assertThat(tuple._5).isEqualTo(5);
-      assertThat(tuple._6).isEqualTo(6);
-      assertThat(tuple._7).isEqualTo(7);
-      assertThat(tuple._8).isEqualTo(42);
+      assertThat(tuple._1()).isEqualTo(1);
+      assertThat(tuple._2()).isEqualTo(2);
+      assertThat(tuple._3()).isEqualTo(3);
+      assertThat(tuple._4()).isEqualTo(4);
+      assertThat(tuple._5()).isEqualTo(5);
+      assertThat(tuple._6()).isEqualTo(6);
+      assertThat(tuple._7()).isEqualTo(7);
+      assertThat(tuple._8()).isEqualTo(42);
     }
 
     @Test
@@ -380,13 +379,6 @@ public class Tuple8Test {
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "4", "5", "X", "7", "8"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "4", "5", "6", "X", "8"))).isFalse();
         assertThat(tuple.equals(Tuple.of("1", "2", "3", "4", "5", "6", "7", "X"))).isFalse();
-    }
-
-    @Test
-    public void shouldComputeCorrectHashCode() {
-        final int actual = createTuple().hashCode();
-        final int expected = Objects.hash(null, null, null, null, null, null, null, null);
-        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/vavr/src/main/java/io/vavr/Value.java
+++ b/vavr/src/main/java/io/vavr/Value.java
@@ -819,11 +819,11 @@ public interface Value<T> extends Iterable<T> {
         if (!isEmpty()) {
             if (isSingleValued()) {
                 final Tuple2<? extends K, ? extends V> entry = f.apply(get());
-                map.put(entry._1, entry._2);
+                map.put(entry._1(), entry._2());
             } else {
                 for (T a : this) {
                     final Tuple2<? extends K, ? extends V> entry = f.apply(a);
-                    map.put(entry._1, entry._2);
+                    map.put(entry._1(), entry._2());
                 }
             }
         }

--- a/vavr/src/main/java/io/vavr/collection/Array.java
+++ b/vavr/src/main/java/io/vavr/collection/Array.java
@@ -1565,8 +1565,8 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
             final Object[] ys = new Object[delegate.length];
             for (int i = 0; i < delegate.length; i++) {
                 final Tuple2<? extends T1, ? extends T2> t = unzipper.apply(get(i));
-                xs[i] = t._1;
-                ys[i] = t._2;
+                xs[i] = t._1();
+                ys[i] = t._2();
             }
             return Tuple.of(wrap(xs), wrap(ys));
         }
@@ -1583,9 +1583,9 @@ public final class Array<T> implements IndexedSeq<T>, Serializable {
             final Object[] zs = new Object[delegate.length];
             for (int i = 0; i < delegate.length; i++) {
                 final Tuple3<? extends T1, ? extends T2, ? extends T3> t = unzipper.apply(get(i));
-                xs[i] = t._1;
-                ys[i] = t._2;
-                zs[i] = t._3;
+                xs[i] = t._1();
+                ys[i] = t._2();
+                zs[i] = t._3();
             }
             return Tuple.of(wrap(xs), wrap(ys), wrap(zs));
         }
@@ -1676,7 +1676,7 @@ interface ArrayModule {
                 return Array.of(Array.empty());
             } else {
                 return elements.zipWithIndex().flatMap(
-                        t -> apply(elements.drop(t._2 + 1), (k - 1)).map(c -> c.prepend(t._1))
+                        t -> apply(elements.drop(t._2() + 1), (k - 1)).map(c -> c.prepend(t._1()))
                 );
             }
         }

--- a/vavr/src/main/java/io/vavr/collection/BitSet.java
+++ b/vavr/src/main/java/io/vavr/collection/BitSet.java
@@ -836,7 +836,7 @@ public interface BitSet<T> extends SortedSet<T> {
     @Override
     default TreeSet<Tuple2<T, Integer>> zipWithIndex() {
         final Comparator<? super T> component1Comparator = comparator();
-        final Comparator<Tuple2<T, Integer>> tuple2Comparator = (t1, t2) -> component1Comparator.compare(t1._1, t2._1);
+        final Comparator<Tuple2<T, Integer>> tuple2Comparator = (t1, t2) -> component1Comparator.compare(t1._1(), t2._1());
         return TreeSet.ofAll(tuple2Comparator, iterator().zipWithIndex());
     }
 

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -1172,8 +1172,8 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
         IndexedSeq<T2> ys = Vector.empty();
         for (int i = 0; i < length(); i++) {
             final Tuple2<? extends T1, ? extends T2> t = unzipper.apply(get(i));
-            xs = xs.append(t._1);
-            ys = ys.append(t._2);
+            xs = xs.append(t._1());
+            ys = ys.append(t._2());
         }
         return Tuple.of(xs, ys);
     }
@@ -1186,9 +1186,9 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
         IndexedSeq<T3> zs = Vector.empty();
         for (int i = 0; i < length(); i++) {
             final Tuple3<? extends T1, ? extends T2, ? extends T3> t = unzipper.apply(get(i));
-            xs = xs.append(t._1);
-            ys = ys.append(t._2);
-            zs = zs.append(t._3);
+            xs = xs.append(t._1());
+            ys = ys.append(t._2());
+            zs = zs.append(t._3());
         }
         return Tuple.of(xs, ys, zs);
     }
@@ -3519,7 +3519,7 @@ interface CharSeqModule {
                 return Vector.of(CharSeq.empty());
             } else {
                 return elements.zipWithIndex().flatMap(
-                        t -> apply(elements.drop(t._2 + 1), (k - 1)).map((CharSeq c) -> c.prepend(t._1))
+                        t -> apply(elements.drop(t._2() + 1), (k - 1)).map((CharSeq c) -> c.prepend(t._1()))
                 );
             }
         }

--- a/vavr/src/main/java/io/vavr/collection/Collections.java
+++ b/vavr/src/main/java/io/vavr/collection/Collections.java
@@ -274,8 +274,8 @@ final class Collections {
         Objects.requireNonNull(keyMapper, "keyMapper is null");
         Objects.requireNonNull(valueMerge, "valueMerge is null");
         return source.foldLeft(zero, (acc, entry) -> {
-            final K2 k2 = keyMapper.apply(entry._1);
-            final V v2 = entry._2;
+            final K2 k2 = keyMapper.apply(entry._1());
+            final V v2 = entry._2();
             final Option<V> v1 = acc.get(k2);
             final V v = v1.isDefined() ? valueMerge.apply(v1.get(), v2) : v2;
             return (U) acc.put(k2, v);

--- a/vavr/src/main/java/io/vavr/collection/HashArrayMappedTrie.java
+++ b/vavr/src/main/java/io/vavr/collection/HashArrayMappedTrie.java
@@ -259,7 +259,7 @@ interface HashArrayMappedTrieModule {
 
         @Override
         public final String toString() {
-            return iterator().map(t -> t._1 + " -> " + t._2).mkString("HashArrayMappedTrie(", ", ", ")");
+            return iterator().map(t -> t._1() + " -> " + t._2()).mkString("HashArrayMappedTrie(", ", ", ")");
         }
     }
 

--- a/vavr/src/main/java/io/vavr/collection/HashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMap.java
@@ -45,6 +45,7 @@ import org.jspecify.annotations.NonNull;
  */
 public final class HashMap<K, V> implements Map<K, V>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final HashMap<?, ?> EMPTY = new HashMap<>(HashArrayMappedTrie.empty());
@@ -151,7 +152,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
      * @return A new Map containing the given entry
      */
     public static <K, V> HashMap<K, V> of(@NonNull Tuple2<? extends K, ? extends V> entry) {
-        return new HashMap<>(HashArrayMappedTrie.<K, V> empty().put(entry._1, entry._2));
+        return new HashMap<>(HashArrayMappedTrie.<K, V> empty().put(entry._1(), entry._2()));
     }
 
     /**
@@ -487,7 +488,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
         Objects.requireNonNull(entries, "entries is null");
         HashArrayMappedTrie<K, V> trie = HashArrayMappedTrie.empty();
         for (Tuple2<? extends K, ? extends V> entry : entries) {
-            trie = trie.put(entry._1, entry._2);
+            trie = trie.put(entry._1(), entry._2());
         }
         return wrap(trie);
     }
@@ -508,7 +509,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
         } else {
             HashArrayMappedTrie<K, V> trie = HashArrayMappedTrie.empty();
             for (Tuple2<? extends K, ? extends V> entry : entries) {
-                trie = trie.put(entry._1, entry._2);
+                trie = trie.put(entry._1(), entry._2());
             }
             return trie.isEmpty() ? empty() : wrap(trie);
         }
@@ -518,7 +519,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     public <K2, V2> HashMap<K2, V2> bimap(@NonNull Function<? super K, ? extends K2> keyMapper, @NonNull Function<? super V, ? extends V2> valueMapper) {
         Objects.requireNonNull(keyMapper, "keyMapper is null");
         Objects.requireNonNull(valueMapper, "valueMapper is null");
-        final Iterator<Tuple2<K2, V2>> entries = iterator().map(entry -> Tuple.of(keyMapper.apply(entry._1), valueMapper.apply(entry._2)));
+        final Iterator<Tuple2<K2, V2>> entries = iterator().map(entry -> Tuple.of(keyMapper.apply(entry._1()), valueMapper.apply(entry._2())));
         return HashMap.ofEntries(entries);
     }
 
@@ -616,7 +617,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     public <K2, V2> HashMap<K2, V2> flatMap(@NonNull BiFunction<? super K, ? super V, ? extends Iterable<Tuple2<K2, V2>>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return foldLeft(HashMap.<K2, V2> empty(), (acc, entry) -> {
-            for (Tuple2<? extends K2, ? extends V2> mappedEntry : mapper.apply(entry._1, entry._2)) {
+            for (Tuple2<? extends K2, ? extends V2> mappedEntry : mapper.apply(entry._1(), entry._2())) {
                 acc = acc.put(mappedEntry);
             }
             return acc;
@@ -657,7 +658,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
         if (trie.isEmpty()) {
             throw new UnsupportedOperationException("init of empty HashMap");
         } else {
-            return remove(last()._1);
+            return remove(last()._1());
         }
     }
 
@@ -861,7 +862,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
         HashArrayMappedTrie<K, V> tree = HashArrayMappedTrie.empty();
         for (Tuple2<K, V> entry : elements) {
             if (contains(entry)) {
-                tree = tree.put(entry._1, entry._2);
+                tree = tree.put(entry._1(), entry._2());
             }
         }
         return wrap(tree);
@@ -904,7 +905,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
         if (trie.isEmpty()) {
             throw new UnsupportedOperationException("tail of empty HashMap");
         } else {
-            return remove(head()._1);
+            return remove(head()._1());
         }
     }
 
@@ -1005,8 +1006,8 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
             s.defaultWriteObject();
             s.writeInt(trie.size());
             for (Tuple2<K, V> e : trie) {
-                s.writeObject(e._1);
-                s.writeObject(e._2);
+                s.writeObject(e._1());
+                s.writeObject(e._2());
             }
         }
 

--- a/vavr/src/main/java/io/vavr/collection/HashMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMultimap.java
@@ -125,7 +125,7 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
             Objects.requireNonNull(entries, "entries is null");
             HashMultimap<K, V2> result = empty();
             for (Tuple2<? extends K, ? extends V2> entry : entries) {
-                result = result.put(entry._1, entry._2);
+                result = result.put(entry._1(), entry._2());
             }
             return result;
         }
@@ -143,7 +143,7 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
             Objects.requireNonNull(entries, "entries is null");
             HashMultimap<K, V2> result = empty();
             for (Tuple2<? extends K, ? extends V2> entry : entries) {
-                result = result.put(entry._1, entry._2);
+                result = result.put(entry._1(), entry._2());
             }
             return result;
         }
@@ -250,7 +250,7 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
          * @param <V2>    The value type
          * @param n       The number of elements in the HashMultimap
          * @param element The element
-         * @return A HashMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2}.
+         * @return A HashMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2()}.
          */
         @SuppressWarnings("unchecked")
         public <K, V2 extends V> HashMultimap<K, V2> fill(int n, @NonNull Tuple2<? extends K, ? extends V2> element) {
@@ -489,7 +489,7 @@ public final class HashMultimap<K, V> extends AbstractMultimap<K, V, HashMultima
          */
         public <K, V2 extends V> HashMultimap<K, V2> of(@NonNull Tuple2<? extends K, ? extends V2> entry) {
             final HashMultimap<K, V2> e = empty();
-            return e.put(entry._1, entry._2);
+            return e.put(entry._1(), entry._2());
         }
 
         /**

--- a/vavr/src/main/java/io/vavr/collection/HashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/HashSet.java
@@ -943,7 +943,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
     public Tuple2<HashSet<T>, HashSet<T>> span(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         final Tuple2<Iterator<T>, Iterator<T>> t = iterator().span(predicate);
-        return Tuple.of(HashSet.ofAll(t._1), HashSet.ofAll(t._2));
+        return Tuple.of(HashSet.ofAll(t._1()), HashSet.ofAll(t._2()));
     }
 
     @Override
@@ -1037,7 +1037,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
       @NonNull Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         final Tuple2<Iterator<T1>, Iterator<T2>> t = iterator().unzip(unzipper);
-        return Tuple.of(HashSet.ofAll(t._1), HashSet.ofAll(t._2));
+        return Tuple.of(HashSet.ofAll(t._1()), HashSet.ofAll(t._2()));
     }
 
     @Override
@@ -1045,7 +1045,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
       @NonNull Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         final Tuple3<Iterator<T1>, Iterator<T2>, Iterator<T3>> t = iterator().unzip3(unzipper);
-        return Tuple.of(HashSet.ofAll(t._1), HashSet.ofAll(t._2), HashSet.ofAll(t._3));
+        return Tuple.of(HashSet.ofAll(t._1()), HashSet.ofAll(t._2()), HashSet.ofAll(t._3()));
     }
 
     @Override
@@ -1175,7 +1175,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
             s.defaultWriteObject();
             s.writeInt(tree.size());
             for (Tuple2<T, T> e : tree) {
-                s.writeObject(e._1);
+                s.writeObject(e._1());
             }
         }
 

--- a/vavr/src/main/java/io/vavr/collection/Iterator.java
+++ b/vavr/src/main/java/io/vavr/collection/Iterator.java
@@ -1318,7 +1318,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
             return Tuple.of(empty(), empty());
         } else {
             final Stream<Tuple2<? extends T1, ? extends T2>> source = Stream.ofAll(this.map(unzipper));
-            return Tuple.of(source.map(t -> (T1) t._1).iterator(), source.map(t -> (T2) t._2).iterator());
+            return Tuple.of(source.map(t -> (T1) t._1()).iterator(), source.map(t -> (T2) t._2()).iterator());
         }
     }
 
@@ -1330,7 +1330,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
             return Tuple.of(empty(), empty(), empty());
         } else {
             final Stream<Tuple3<? extends T1, ? extends T2, ? extends T3>> source = Stream.ofAll(this.map(unzipper));
-            return Tuple.of(source.map(t -> (T1) t._1).iterator(), source.map(t -> (T2) t._2).iterator(), source.map(t -> (T3) t._3).iterator());
+            return Tuple.of(source.map(t -> (T1) t._1()).iterator(), source.map(t -> (T2) t._2()).iterator(), source.map(t -> (T3) t._3()).iterator());
         }
     }
 
@@ -1386,7 +1386,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
     static <T, U> Iterator<U> unfoldLeft(T seed, Function<? super T, Option<Tuple2<? extends T, ? extends U>>> f) {
         Objects.requireNonNull(f, "f is null");
         return Stream.<U> ofAll(
-                unfoldRight(seed, f.andThen(tupleOpt -> tupleOpt.map(t -> Tuple.of(t._2, t._1)))))
+                unfoldRight(seed, f.andThen(tupleOpt -> tupleOpt.map(t -> Tuple.of(t._2(), t._1())))))
                 .reverse().iterator();
     }
 
@@ -1427,8 +1427,8 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
             @Override
             public U getNext() {
                 Tuple2<? extends U, ? extends T> tuple = nextVal.get().get();
-                final U result = tuple._1;
-                nextVal = Lazy.of(() -> f.apply(tuple._2));
+                final U result = tuple._1();
+                nextVal = Lazy.of(() -> f.apply(tuple._2()));
                 return result;
             }
         };
@@ -1580,8 +1580,8 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
                 @Override
                 public T getNext() {
                     final Tuple2<T, io.vavr.collection.Queue<T>> t = queue.append(that.next()).dequeue();
-                    queue = t._2;
-                    return t._1;
+                    queue = t._2();
+                    return t._1();
                 }
             };
         }
@@ -1854,7 +1854,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
             return Tuple.of(empty(), empty());
         } else {
             final Tuple2<Iterator<T>, Iterator<T>> dup = IteratorModule.duplicate(this);
-            return Tuple.of(dup._1.filter(predicate), dup._2.filter(predicate.negate()));
+            return Tuple.of(dup._1().filter(predicate), dup._2().filter(predicate.negate()));
         }
     }
 
@@ -2136,7 +2136,7 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
                     while (that.hasNext()) {
                         queue = queue.enqueue(that.next());
                         if (queue.length() > n) {
-                            queue = queue.dequeue()._2;
+                            queue = queue.dequeue()._2();
                         }
                     }
                     return !queue.isEmpty();
@@ -2145,8 +2145,8 @@ public interface Iterator<T> extends java.util.Iterator<T>, Traversable<T> {
                 @Override
                 public T getNext() {
                     final Tuple2<T, io.vavr.collection.Queue<T>> t = queue.dequeue();
-                    queue = t._2;
-                    return t._1;
+                    queue = t._2();
+                    return t._1();
                 }
             };
         }

--- a/vavr/src/main/java/io/vavr/collection/LinearSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/LinearSeq.java
@@ -467,10 +467,10 @@ interface LinearSeqModule {
                 if (r == null) {
                     return result;
                 }
-                if (index + r._2 <= end) {
-                    result = index + r._2;
-                    index += r._2 + 1;
-                    source = r._1.tail();
+                if (index + r._2() <= end) {
+                    result = index + r._2();
+                    index += r._2() + 1;
+                    source = r._1().tail();
                 } else {
                     return result;
                 }

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -530,7 +530,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public <K2, V2> LinkedHashMap<K2, V2> bimap(@NonNull Function<? super K, ? extends K2> keyMapper, @NonNull Function<? super V, ? extends V2> valueMapper) {
         Objects.requireNonNull(keyMapper, "keyMapper is null");
         Objects.requireNonNull(valueMapper, "valueMapper is null");
-        final Iterator<Tuple2<K2, V2>> entries = iterator().map(entry -> Tuple.of(keyMapper.apply(entry._1), valueMapper.apply(entry._2)));
+        final Iterator<Tuple2<K2, V2>> entries = iterator().map(entry -> Tuple.of(keyMapper.apply(entry._1()), valueMapper.apply(entry._2())));
         return LinkedHashMap.ofEntries(entries);
     }
 
@@ -628,7 +628,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public <K2, V2> LinkedHashMap<K2, V2> flatMap(@NonNull BiFunction<? super K, ? super V, ? extends Iterable<Tuple2<K2, V2>>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return foldLeft(LinkedHashMap.<K2, V2> empty(), (acc, entry) -> {
-            for (Tuple2<? extends K2, ? extends V2> mappedEntry : mapper.apply(entry._1, entry._2)) {
+            for (Tuple2<? extends K2, ? extends V2> mappedEntry : mapper.apply(entry._1(), entry._2())) {
                 acc = acc.put(mappedEntry);
             }
             return acc;
@@ -817,7 +817,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @Override
     public LinkedHashMap<K, V> remove(K key) {
         if (containsKey(key)) {
-            final Queue<Tuple2<K, V>> newList = list.removeFirst(t -> Objects.equals(t._1, key));
+            final Queue<Tuple2<K, V>> newList = list.removeFirst(t -> Objects.equals(t._1(), key));
             final HashMap<K, V> newMap = map.remove(key);
             return wrap(newList, newMap);
         } else {
@@ -836,8 +836,8 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public LinkedHashMap<K, V> removeAll(@NonNull Iterable<? extends K> keys) {
         Objects.requireNonNull(keys, "keys is null");
         final HashSet<K> toRemove = HashSet.ofAll(keys);
-        final Queue<Tuple2<K, V>> newList = list.filter(t -> !toRemove.contains(t._1));
-        final HashMap<K, V> newMap = map.filter(t -> !toRemove.contains(t._1));
+        final Queue<Tuple2<K, V>> newList = list.filter(t -> !toRemove.contains(t._1()));
+        final HashMap<K, V> newMap = map.filter(t -> !toRemove.contains(t._1()));
         return newList.size() == size() ? this : wrap(newList, newMap);
     }
 
@@ -866,8 +866,8 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
             Queue<Tuple2<K, V>> newList = list;
             HashMap<K, V> newMap = map;
 
-            final K currentKey = currentElement._1;
-            final K newKey = newElement._1;
+            final K currentKey = currentElement._1();
+            final K newKey = newElement._1();
 
             // If current key and new key are equal, the element will be automatically replaced,
             // otherwise we need to remove the pair (newKey, ?) from the list manually.
@@ -914,7 +914,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         LinkedHashMap<K, V> result = empty();
         for (Tuple2<K, V> entry : elements) {
             if (contains(entry)) {
-                result = result.put(entry._1, entry._2);
+                result = result.put(entry._1(), entry._2());
             }
         }
         return result;
@@ -993,7 +993,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public Seq<V> values() {
-        return map(t -> t._2);
+        return map(Tuple2::_2);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMultimap.java
@@ -90,7 +90,7 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
             Objects.requireNonNull(entries, "entries is null");
             LinkedHashMultimap<K, V2> result = empty();
             for (Tuple2<? extends K, ? extends V2> entry : entries) {
-                result = result.put(entry._1, entry._2);
+                result = result.put(entry._1(), entry._2());
             }
             return result;
         }
@@ -108,7 +108,7 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
             Objects.requireNonNull(entries, "entries is null");
             LinkedHashMultimap<K, V2> result = empty();
             for (Tuple2<? extends K, ? extends V2> entry : entries) {
-                result = result.put(entry._1, entry._2);
+                result = result.put(entry._1(), entry._2());
             }
             return result;
         }
@@ -215,7 +215,7 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
          * @param <V2>    The value type
          * @param n       The number of elements in the LinkedHashMultimap
          * @param element The element
-         * @return A LinkedHashMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2}.
+         * @return A LinkedHashMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2()}.
          */
         @SuppressWarnings("unchecked")
         public <K, V2 extends V> LinkedHashMultimap<K, V2> fill(int n, @NonNull Tuple2<? extends K, ? extends V2> element) {
@@ -454,7 +454,7 @@ public final class LinkedHashMultimap<K, V> extends AbstractMultimap<K, V, Linke
          */
         public <K, V2 extends V> LinkedHashMultimap<K, V2> of(Tuple2<? extends K, ? extends V2> entry) {
             final LinkedHashMultimap<K, V2> e = empty();
-            return e.put(entry._1, entry._2);
+            return e.put(entry._1(), entry._2());
         }
 
         /**

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -834,12 +834,12 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
 
     @Override
     public @NonNull Iterator<T> iterator() {
-        return map.iterator().map(t -> t._1);
+        return map.iterator().map(Tuple2::_1);
     }
 
     @Override
     public T last() {
-        return map.last()._1;
+        return map.last()._1();
     }
 
     @Override
@@ -967,7 +967,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
     public Tuple2<LinkedHashSet<T>, LinkedHashSet<T>> span(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         final Tuple2<Iterator<T>, Iterator<T>> t = iterator().span(predicate);
-        return Tuple.of(LinkedHashSet.ofAll(t._1), LinkedHashSet.ofAll(t._2));
+        return Tuple.of(LinkedHashSet.ofAll(t._1()), LinkedHashSet.ofAll(t._2()));
     }
 
     @Override
@@ -1067,7 +1067,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
       @NonNull Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         final Tuple2<Iterator<T1>, Iterator<T2>> t = iterator().unzip(unzipper);
-        return Tuple.of(LinkedHashSet.ofAll(t._1), LinkedHashSet.ofAll(t._2));
+        return Tuple.of(LinkedHashSet.ofAll(t._1()), LinkedHashSet.ofAll(t._2()));
     }
 
     @Override
@@ -1075,7 +1075,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
       @NonNull Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         final Tuple3<Iterator<T1>, Iterator<T2>, Iterator<T3>> t = iterator().unzip3(unzipper);
-        return Tuple.of(LinkedHashSet.ofAll(t._1), LinkedHashSet.ofAll(t._2), LinkedHashSet.ofAll(t._3));
+        return Tuple.of(LinkedHashSet.ofAll(t._1()), LinkedHashSet.ofAll(t._2()), LinkedHashSet.ofAll(t._3()));
     }
 
     @Override
@@ -1205,7 +1205,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
             s.defaultWriteObject();
             s.writeInt(map.size());
             for (Tuple2<T, Object> e : map) {
-                s.writeObject(e._1);
+                s.writeObject(e._1());
             }
         }
 

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -1612,7 +1612,7 @@ public interface List<T> extends LinearSeq<T> {
     default Tuple2<List<T>, List<T>> span(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         final Tuple2<Iterator<T>, Iterator<T>> itt = iterator().span(predicate);
-        return Tuple.of(ofAll(itt._1), ofAll(itt._2));
+        return Tuple.of(ofAll(itt._1()), ofAll(itt._2()));
     }
 
     @Override
@@ -1637,10 +1637,10 @@ public interface List<T> extends LinearSeq<T> {
             return Tuple.of(empty(), empty());
         } else {
             final Tuple2<List<T>, List<T>> t = SplitAt.splitByPredicateReversed(this, predicate);
-            if (t._2.isEmpty()) {
+            if (t._2().isEmpty()) {
                 return Tuple.of(this, empty());
             } else {
-                return Tuple.of(t._1.reverse(), t._2);
+                return Tuple.of(t._1().reverse(), t._2());
             }
         }
     }
@@ -1651,10 +1651,10 @@ public interface List<T> extends LinearSeq<T> {
             return Tuple.of(empty(), empty());
         } else {
             final Tuple2<List<T>, List<T>> t = SplitAt.splitByPredicateReversed(this, predicate);
-            if (t._2.isEmpty() || t._2.tail().isEmpty()) {
+            if (t._2().isEmpty() || t._2().tail().isEmpty()) {
                 return Tuple.of(this, empty());
             } else {
-                return Tuple.of(t._1.prepend(t._2.head()).reverse(), t._2.tail());
+                return Tuple.of(t._1().prepend(t._2().head()).reverse(), t._2().tail());
             }
         }
     }
@@ -1776,8 +1776,8 @@ public interface List<T> extends LinearSeq<T> {
         List<T2> ys = Nil.instance();
         for (T element : this) {
             final Tuple2<? extends T1, ? extends T2> t = unzipper.apply(element);
-            xs = xs.prepend(t._1);
-            ys = ys.prepend(t._2);
+            xs = xs.prepend(t._1());
+            ys = ys.prepend(t._2());
         }
         return Tuple.of(xs.reverse(), ys.reverse());
     }
@@ -1791,9 +1791,9 @@ public interface List<T> extends LinearSeq<T> {
         List<T3> zs = Nil.instance();
         for (T element : this) {
             final Tuple3<? extends T1, ? extends T2, ? extends T3> t = unzipper.apply(element);
-            xs = xs.prepend(t._1);
-            ys = ys.prepend(t._2);
-            zs = zs.prepend(t._3);
+            xs = xs.prepend(t._1());
+            ys = ys.prepend(t._2());
+            zs = zs.prepend(t._3());
         }
         return Tuple.of(xs.reverse(), ys.reverse(), zs.reverse());
     }
@@ -2116,7 +2116,7 @@ interface ListModule {
                 return List.of(List.empty());
             } else {
                 return elements.zipWithIndex().flatMap(
-                        t -> apply(elements.drop(t._2 + 1), (k - 1)).map(c -> c.prepend(t._1))
+                        t -> apply(elements.drop(t._2() + 1), (k - 1)).map(c -> c.prepend(t._1()))
                 );
             }
         }

--- a/vavr/src/main/java/io/vavr/collection/Map.java
+++ b/vavr/src/main/java/io/vavr/collection/Map.java
@@ -132,7 +132,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
 
     @Override
     default boolean contains(@NonNull Tuple2<K, V> element) {
-        return get(element._1).map(v -> Objects.equals(v, element._2)).getOrElse(false);
+        return get(element._1()).map(v -> Objects.equals(v, element._2())).getOrElse(false);
     }
 
     /**
@@ -273,7 +273,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
     default void forEach(@NonNull BiConsumer<K, V> action) {
         Objects.requireNonNull(action, "action is null");
         for (Tuple2<K, V> t : this) {
-            action.accept(t._1, t._2);
+            action.accept(t._1(), t._2());
         }
     }
 
@@ -320,7 +320,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
      */
     default <U> Iterator<U> iterator(@NonNull BiFunction<K, V, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return iterator().map(t -> mapper.apply(t._1, t._2));
+        return iterator().map(t -> mapper.apply(t._1(), t._2()));
     }
 
     /**
@@ -466,7 +466,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
     Map<K, V> put(K key, V value);
 
     /**
-     * Convenience method for {@code put(entry._1, entry._2)}.
+     * Convenience method for {@code put(entry._1(), entry._2())}.
      *
      * @param entry A Tuple2 containing the key and value
      * @return A new Map containing these elements and that entry.
@@ -488,7 +488,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
     <U extends V> Map<K, V> put(K key, U value, @NonNull BiFunction<? super V, ? super U, ? extends V> merge);
 
     /**
-     * Convenience method for {@code put(entry._1, entry._2, merge)}.
+     * Convenience method for {@code put(entry._1(), entry._2(), merge)}.
      *
      * @param <U>   the value type
      * @param entry A Tuple2 containing the key and value
@@ -605,7 +605,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
      */
     default <T1, T2> Tuple2<Seq<T1>, Seq<T2>> unzip(@NonNull BiFunction<? super K, ? super V, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
-        return unzip(entry -> unzipper.apply(entry._1, entry._2));
+        return unzip(entry -> unzipper.apply(entry._1(), entry._2()));
     }
 
     @Override
@@ -630,7 +630,7 @@ public interface Map<K, V> extends Traversable<Tuple2<K, V>>, PartialFunction<K,
      */
     default <T1, T2, T3> Tuple3<Seq<T1>, Seq<T2>, Seq<T3>> unzip3(@NonNull BiFunction<? super K, ? super V, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
-        return unzip3(entry -> unzipper.apply(entry._1, entry._2));
+        return unzip3(entry -> unzipper.apply(entry._1(), entry._2()));
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/Maps.java
+++ b/vavr/src/main/java/io/vavr/collection/Maps.java
@@ -114,7 +114,7 @@ final class Maps {
     static <K, V, M extends Map<K, V>> M filter(M map, OfEntries<K, V, M> ofEntries,
             BiPredicate<? super K, ? super V> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return filter(map, ofEntries, t -> predicate.test(t._1, t._2));
+        return filter(map, ofEntries, t -> predicate.test(t._1(), t._2()));
     }
 
     static <K, V, M extends Map<K, V>> M filter(M map, OfEntries<K, V, M> ofEntries,
@@ -126,13 +126,13 @@ final class Maps {
     static <K, V, M extends Map<K, V>> M filterKeys(M map, OfEntries<K, V, M> ofEntries,
             Predicate<? super K> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return filter(map, ofEntries, t -> predicate.test(t._1));
+        return filter(map, ofEntries, t -> predicate.test(t._1()));
     }
 
     static <K, V, M extends Map<K, V>> M filterValues(M map, OfEntries<K, V, M> ofEntries,
             Predicate<? super V> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return filter(map, ofEntries, t -> predicate.test(t._2));
+        return filter(map, ofEntries, t -> predicate.test(t._2()));
     }
 
     static <K, V, C, M extends Map<K, V>> Map<C, M> groupBy(M map, OfEntries<K, V, M> ofEntries,
@@ -157,7 +157,7 @@ final class Maps {
         } else if (that.isEmpty()) {
             return map;
         } else {
-            return that.foldLeft(map, (result, entry) -> !result.containsKey(entry._1) ? put(result, entry) : result);
+            return that.foldLeft(map, (result, entry) -> !result.containsKey(entry._1()) ? put(result, entry) : result);
         }
     }
 
@@ -173,8 +173,8 @@ final class Maps {
             return map;
         } else {
             return that.foldLeft(map, (result, entry) -> {
-                final K key = entry._1;
-                final U value = entry._2;
+                final K key = entry._1();
+                final U value = entry._2();
                 final V newValue = result.get(key).map(v -> (V) collisionResolution.apply(v, value)).getOrElse(value);
                 return (M) result.put(key, newValue);
             });
@@ -233,13 +233,13 @@ final class Maps {
     @SuppressWarnings("unchecked")
     static <K, V, M extends Map<K, V>> M put(M map, Tuple2<? extends K, ? extends V> entry) {
         Objects.requireNonNull(entry, "entry is null");
-        return (M) map.put(entry._1, entry._2);
+        return (M) map.put(entry._1(), entry._2());
     }
 
     static <K, V, U extends V, M extends Map<K, V>> M put(M map, Tuple2<? extends K, U> entry,
             BiFunction<? super V, ? super U, ? extends V> merge) {
         Objects.requireNonNull(merge, "the merge function is null");
-        final Option<V> currentValue = map.get(entry._1);
+        final Option<V> currentValue = map.get(entry._1());
         if (currentValue.isEmpty()) {
             return put(map, entry);
         } else {
@@ -280,7 +280,7 @@ final class Maps {
     static <K, V, M extends Map<K, V>> M replace(M map, Tuple2<K, V> currentElement, Tuple2<K, V> newElement) {
         Objects.requireNonNull(currentElement, "currentElement is null");
         Objects.requireNonNull(newElement, "newElement is null");
-        return (M) (map.containsKey(currentElement._1) ? map.remove(currentElement._1).put(newElement) : map);
+        return (M) (map.containsKey(currentElement._1()) ? map.remove(currentElement._1()).put(newElement) : map);
     }
 
     @SuppressWarnings("unchecked")
@@ -321,7 +321,7 @@ final class Maps {
             Predicate<? super Tuple2<K, V>> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
         final Tuple2<Iterator<Tuple2<K, V>>, Iterator<Tuple2<K, V>>> t = map.iterator().span(predicate);
-        return Tuple.of(ofEntries.apply(t._1), ofEntries.apply(t._2));
+        return Tuple.of(ofEntries.apply(t._1()), ofEntries.apply(t._2()));
     }
 
     @SuppressWarnings("unchecked")

--- a/vavr/src/main/java/io/vavr/collection/Multimap.java
+++ b/vavr/src/main/java/io/vavr/collection/Multimap.java
@@ -223,7 +223,7 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
 
     @Override
     default boolean contains(@NonNull Tuple2<K, V> element) {
-        return get(element._1).map(v -> v.contains(element._2)).getOrElse(false);
+        return get(element._1()).map(v -> v.contains(element._2())).getOrElse(false);
     }
 
     /**
@@ -320,7 +320,7 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
     default void forEach(@NonNull BiConsumer<K, V> action) {
         Objects.requireNonNull(action, "action is null");
         for (Tuple2<K, V> t : this) {
-            action.accept(t._1, t._2);
+            action.accept(t._1(), t._2());
         }
     }
 
@@ -385,7 +385,7 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
      */
     default <U> Iterator<U> iterator(@NonNull BiFunction<K, V, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return iterator().map(t -> mapper.apply(t._1, t._2));
+        return iterator().map(t -> mapper.apply(t._1(), t._2()));
     }
 
     /**
@@ -487,7 +487,7 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
     Multimap<K, V> put(K key, V value);
 
     /**
-     * Convenience method for {@code put(entry._1, entry._2)}.
+     * Convenience method for {@code put(entry._1(), entry._2())}.
      *
      * @param entry A Tuple2 containing the key and value
      * @return A new Multimap containing these elements and that entry.
@@ -601,7 +601,7 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
      */
     default <T1, T2> Tuple2<Seq<T1>, Seq<T2>> unzip(@NonNull BiFunction<? super K, ? super V, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
-        return unzip(entry -> unzipper.apply(entry._1, entry._2));
+        return unzip(entry -> unzipper.apply(entry._1(), entry._2()));
     }
 
     @Override
@@ -623,7 +623,7 @@ public interface Multimap<K, V> extends Traversable<Tuple2<K, V>>, PartialFuncti
      */
     default <T1, T2, T3> Tuple3<Seq<T1>, Seq<T2>, Seq<T3>> unzip3(@NonNull BiFunction<? super K, ? super V, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
-        return unzip3(entry -> unzipper.apply(entry._1, entry._2));
+        return unzip3(entry -> unzipper.apply(entry._1(), entry._2()));
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
+++ b/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
@@ -108,7 +108,7 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
         if (isEmpty()) {
             throw new UnsupportedOperationException("tail of empty " + stringPrefix());
         } else {
-            return dequeue()._2;
+            return dequeue()._2();
         }
     }
 
@@ -118,7 +118,7 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
             throw new NoSuchElementException("dequeue of empty " + stringPrefix());
         } else {
             final Tuple2<T, Seq<Node<T>>> dequeue = deleteMin(comparator, this.forest);
-            return Tuple.of(dequeue._1, with(dequeue._2, this.size - 1));
+            return Tuple.of(dequeue._1(), with(dequeue._2(), this.size - 1));
         }
     }
 
@@ -376,8 +376,8 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
         io.vavr.collection.List<T> results = io.vavr.collection.List.empty();
         for (PriorityQueue<T> queue = this; !queue.isEmpty(); ) {
             final Tuple2<T, PriorityQueue<T>> dequeue = queue.dequeue();
-            results = results.prepend(dequeue._1);
-            queue = dequeue._2;
+            results = results.prepend(dequeue._1());
+            queue = dequeue._2();
         }
         return results.reverse();
     }
@@ -697,14 +697,14 @@ public final class PriorityQueue<T> extends io.vavr.collection.AbstractQueue<T, 
     public <T1, T2> Tuple2<? extends PriorityQueue<T1>, ? extends PriorityQueue<T2>> unzip(@NonNull Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         final Tuple2<io.vavr.collection.Iterator<T1>, io.vavr.collection.Iterator<T2>> unzip = iterator().unzip(unzipper);
-        return Tuple.of(ofAll(Comparators.naturalComparator(), unzip._1), ofAll(Comparators.naturalComparator(), unzip._2));
+        return Tuple.of(ofAll(Comparators.naturalComparator(), unzip._1()), ofAll(Comparators.naturalComparator(), unzip._2()));
     }
 
     @Override
     public <T1, T2, T3> Tuple3<? extends PriorityQueue<T1>, ? extends PriorityQueue<T2>, ? extends PriorityQueue<T3>> unzip3(@NonNull Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         final Tuple3<io.vavr.collection.Iterator<T1>, io.vavr.collection.Iterator<T2>, io.vavr.collection.Iterator<T3>> unzip3 = iterator().unzip3(unzipper);
-        return Tuple.of(ofAll(Comparators.naturalComparator(), unzip3._1), ofAll(Comparators.naturalComparator(), unzip3._2), ofAll(Comparators.naturalComparator(), unzip3._3));
+        return Tuple.of(ofAll(Comparators.naturalComparator(), unzip3._1()), ofAll(Comparators.naturalComparator(), unzip3._2()), ofAll(Comparators.naturalComparator(), unzip3._3()));
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/RedBlackTree.java
+++ b/vavr/src/main/java/io/vavr/collection/RedBlackTree.java
@@ -127,7 +127,7 @@ interface RedBlackTree<T> extends Iterable<T>, Serializable {
      * @return A new RedBlackTree if the value is present, otherwise this.
      */
     default RedBlackTree<T> delete(T value) {
-        final RedBlackTree<T> tree = Node.delete(this, value)._1;
+        final RedBlackTree<T> tree = Node.delete(this, value)._1();
         return Node.color(tree, BLACK);
     }
 
@@ -138,7 +138,7 @@ interface RedBlackTree<T> extends Iterable<T>, Serializable {
         } else {
             final Node<T> that = (Node<T>) tree;
             final Tuple2<RedBlackTree<T>, RedBlackTree<T>> split = Node.split(this, that.value);
-            return Node.merge(split._1.difference(that.left), split._2.difference(that.right));
+            return Node.merge(split._1().difference(that.left), split._2().difference(that.right));
         }
     }
 
@@ -171,9 +171,9 @@ interface RedBlackTree<T> extends Iterable<T>, Serializable {
             final Node<T> that = (Node<T>) tree;
             final Tuple2<RedBlackTree<T>, RedBlackTree<T>> split = Node.split(this, that.value);
             if (contains(that.value)) {
-                return Node.join(split._1.intersection(that.left), that.value, split._2.intersection(that.right));
+                return Node.join(split._1().intersection(that.left), that.value, split._2().intersection(that.right));
             } else {
-                return Node.merge(split._1.intersection(that.left), split._2.intersection(that.right));
+                return Node.merge(split._1().intersection(that.left), split._2().intersection(that.right));
             }
         }
     }
@@ -242,7 +242,7 @@ interface RedBlackTree<T> extends Iterable<T>, Serializable {
                 return that.color(BLACK);
             } else {
                 final Tuple2<RedBlackTree<T>, RedBlackTree<T>> split = Node.split(this, that.value);
-                return Node.join(split._1.union(that.left), that.value, split._2.union(that.right));
+                return Node.join(split._1().union(that.left), that.value, split._2().union(that.right));
             }
         }
     }
@@ -292,9 +292,9 @@ interface RedBlackTree<T> extends Iterable<T>, Serializable {
                 @Override
                 public T getNext() {
                     final Tuple2<Node<T>, ? extends List<Node<T>>> result = stack.pop2();
-                    final Node<T> node = result._1;
-                    stack = node.right.isEmpty() ? result._2 : pushLeftChildren(result._2, (Node<T>) node.right);
-                    return result._1.value;
+                    final Node<T> node = result._1();
+                    stack = node.right.isEmpty() ? result._2() : pushLeftChildren(result._2(), (Node<T>) node.right);
+                    return result._1().value;
                 }
 
                 private List<Node<T>> pushLeftChildren(List<Node<T>> initialStack, Node<T> that) {
@@ -536,8 +536,8 @@ interface RedBlackTreeModule {
                 final int comparison = node.comparator().compare(value, node.value);
                 if (comparison < 0) {
                     final Tuple2<? extends RedBlackTree<T>, Boolean> deleted = delete(node.left, value);
-                    final RedBlackTree<T> l = deleted._1;
-                    final boolean d = deleted._2;
+                    final RedBlackTree<T> l = deleted._1();
+                    final boolean d = deleted._2();
                     if (d) {
                         return Node.unbalancedRight(node.color, node.blackHeight - 1, l, node.value, node.right,
                                 node.empty);
@@ -548,8 +548,8 @@ interface RedBlackTreeModule {
                     }
                 } else if (comparison > 0) {
                     final Tuple2<? extends RedBlackTree<T>, Boolean> deleted = delete(node.right, value);
-                    final RedBlackTree<T> r = deleted._1;
-                    final boolean d = deleted._2;
+                    final RedBlackTree<T> r = deleted._1();
+                    final boolean d = deleted._2();
                     if (d) {
                         return Node.unbalancedLeft(node.color, node.blackHeight - 1, node.left, node.value, r,
                                 node.empty);
@@ -568,9 +568,9 @@ interface RedBlackTreeModule {
                     } else {
                         final Node<T> nodeRight = (Node<T>) node.right;
                         final Tuple3<? extends RedBlackTree<T>, Boolean, T> newRight = deleteMin(nodeRight);
-                        final RedBlackTree<T> r = newRight._1;
-                        final boolean d = newRight._2;
-                        final T m = newRight._3;
+                        final RedBlackTree<T> r = newRight._1();
+                        final boolean d = newRight._2();
+                        final T m = newRight._3();
                         if (d) {
                             return Node.unbalancedLeft(node.color, node.blackHeight - 1, node.left, m, r, node.empty);
                         } else {
@@ -593,13 +593,13 @@ interface RedBlackTreeModule {
             } else{
                 final Node<T> nodeLeft = (Node<T>) node.left;
                 final Tuple3<? extends RedBlackTree<T>, Boolean, T> newNode = deleteMin(nodeLeft);
-                final RedBlackTree<T> l = newNode._1;
-                final boolean deleted = newNode._2;
-                final T m = newNode._3;
+                final RedBlackTree<T> l = newNode._1();
+                final boolean deleted = newNode._2();
+                final T m = newNode._3();
                 if (deleted) {
                     final Tuple2<Node<T>, Boolean> tD = Node.unbalancedRight(node.color, node.blackHeight - 1, l,
                             node.value, node.right, node.empty);
-                    return Tuple.of(tD._1, tD._2, m);
+                    return Tuple.of(tD._1(), tD._2(), m);
                 } else {
                     final Node<T> tD = new Node<>(node.color, node.blackHeight, l, node.value, node.right, node.empty);
                     return Tuple.of(tD, false, m);
@@ -699,7 +699,7 @@ interface RedBlackTreeModule {
 
         private static <T> Node<T> mergeEQ(Node<T> n1, Node<T> n2) {
             final T m = Node.minimum(n2);
-            final RedBlackTree<T> t2 = Node.deleteMin(n2)._1;
+            final RedBlackTree<T> t2 = Node.deleteMin(n2)._1();
             final int h2 = t2.isEmpty() ? 0 : ((Node<T>) t2).blackHeight;
             if (n1.blackHeight == h2) {
                 return new Node<>(RED, n1.blackHeight + 1, n1, m, t2, n1.empty);
@@ -760,10 +760,10 @@ interface RedBlackTreeModule {
                 final int comparison = node.comparator().compare(value, node.value);
                 if (comparison < 0) {
                     final Tuple2<RedBlackTree<T>, RedBlackTree<T>> split = Node.split(node.left, value);
-                    return Tuple.of(split._1, Node.join(split._2, node.value, Node.color(node.right, BLACK)));
+                    return Tuple.of(split._1(), Node.join(split._2(), node.value, Node.color(node.right, BLACK)));
                 } else if (comparison > 0) {
                     final Tuple2<RedBlackTree<T>, RedBlackTree<T>> split = Node.split(node.right, value);
-                    return Tuple.of(Node.join(Node.color(node.left, BLACK), node.value, split._1), split._2);
+                    return Tuple.of(Node.join(Node.color(node.left, BLACK), node.value, split._1()), split._2());
                 } else {
                     return Tuple.of(Node.color(node.left, BLACK), Node.color(node.right, BLACK));
                 }

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -926,13 +926,13 @@ public interface Stream<T> extends LinearSeq<T> {
      * Well known Scala code for Fibonacci infinite sequence
      * <pre>
      * {@code
-     * val fibs:Stream[Int] = 0 #:: 1 #:: (fibs zip fibs.tail).map{ t => t._1 + t._2 }
+     * val fibs:Stream[Int] = 0 #:: 1 #:: (fibs zip fibs.tail).map{ t => t._1() + t._2() }
      * }
      * </pre>
      * can be transformed to
      * <pre>
      * {@code
-     * Stream.of(0, 1).appendSelf(self -> self.zip(self.tail()).map(t -> t._1 + t._2));
+     * Stream.of(0, 1).appendSelf(self -> self.zip(self.tail()).map(t -> t._1() + t._2()));
      * }
      * </pre>
      *
@@ -1612,10 +1612,10 @@ public interface Stream<T> extends LinearSeq<T> {
     @Override
     default Tuple2<Stream<T>, Stream<T>> splitAtInclusive(@NonNull Predicate<? super T> predicate) {
         final Tuple2<Stream<T>, Stream<T>> split = splitAt(predicate);
-        if (split._2.isEmpty()) {
+        if (split._2().isEmpty()) {
             return split;
         } else {
-            return Tuple.of(split._1.append(split._2.head()), split._2.tail());
+            return Tuple.of(split._1().append(split._2().head()), split._2().tail());
         }
     }
 
@@ -1738,8 +1738,8 @@ public interface Stream<T> extends LinearSeq<T> {
       @NonNull Function<? super T, Tuple2<? extends T1, ? extends T2>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         final Stream<Tuple2<? extends T1, ? extends T2>> stream = map(unzipper);
-        final Stream<T1> stream1 = stream.map(t -> t._1);
-        final Stream<T2> stream2 = stream.map(t -> t._2);
+        final Stream<T1> stream1 = stream.map(Tuple2::_1);
+        final Stream<T2> stream2 = stream.map(Tuple2::_2);
         return Tuple.of(stream1, stream2);
     }
 
@@ -1748,9 +1748,9 @@ public interface Stream<T> extends LinearSeq<T> {
       @NonNull Function<? super T, Tuple3<? extends T1, ? extends T2, ? extends T3>> unzipper) {
         Objects.requireNonNull(unzipper, "unzipper is null");
         final Stream<Tuple3<? extends T1, ? extends T2, ? extends T3>> stream = map(unzipper);
-        final Stream<T1> stream1 = stream.map(t -> t._1);
-        final Stream<T2> stream2 = stream.map(t -> t._2);
-        final Stream<T3> stream3 = stream.map(t -> t._3);
+        final Stream<T1> stream1 = stream.map(Tuple3::_1);
+        final Stream<T2> stream2 = stream.map(Tuple3::_2);
+        final Stream<T3> stream3 = stream.map(Tuple3::_3);
         return Tuple.of(stream1, stream2, stream3);
     }
 
@@ -2199,7 +2199,7 @@ interface StreamModule {
                 return Stream.of(Stream.empty());
             } else {
                 return elements.zipWithIndex().flatMap(
-                        t -> apply(elements.drop(t._2 + 1), (k - 1)).map((Stream<T> c) -> c.prepend(t._1))
+                        t -> apply(elements.drop(t._2() + 1), (k - 1)).map((Stream<T> c) -> c.prepend(t._1()))
                 );
             }
         }

--- a/vavr/src/main/java/io/vavr/collection/Traversable.java
+++ b/vavr/src/main/java/io/vavr/collection/Traversable.java
@@ -81,7 +81,7 @@ public interface Traversable<T> extends Foldable<T>, Value<T> {
     default <K> Option<Map<K, T>> arrangeBy(@NonNull Function<? super T, ? extends K> getKey) {
         Objects.requireNonNull(getKey, "getKey is null");
         return Option.of(groupBy(getKey).mapValues(Traversable<T>::singleOption))
-          .filter(map -> !map.exists(kv -> kv._2.isEmpty()))
+          .filter(map -> !map.exists(kv -> kv._2().isEmpty()))
           .map(map -> Map.narrow(map.mapValues(Option::get)));
     }
 

--- a/vavr/src/main/java/io/vavr/collection/Tree.java
+++ b/vavr/src/main/java/io/vavr/collection/Tree.java
@@ -1309,8 +1309,8 @@ interface TreeModule {
         final io.vavr.collection.List<Tuple2<Node<T1>, Node<T2>>> children = node
                 .getChildren()
                 .map(child -> unzip(child, unzipper));
-        final Node<T1> node1 = new Node<>(value._1, children.map(t -> t._1));
-        final Node<T2> node2 = new Node<>(value._2, children.map(t -> t._2));
+        final Node<T1> node1 = new Node<>(value._1(), children.map(Tuple2::_1));
+        final Node<T2> node2 = new Node<>(value._2(), children.map(Tuple2::_2));
         return Tuple.of(node1, node2);
     }
 
@@ -1319,9 +1319,9 @@ interface TreeModule {
         final Tuple3<? extends T1, ? extends T2, ? extends T3> value = unzipper.apply(node.getValue());
         final io.vavr.collection.List<Tuple3<Node<T1>, Node<T2>, Node<T3>>> children = node.getChildren()
                 .map(child -> unzip3(child, unzipper));
-        final Node<T1> node1 = new Node<>(value._1, children.map(t -> t._1));
-        final Node<T2> node2 = new Node<>(value._2, children.map(t -> t._2));
-        final Node<T3> node3 = new Node<>(value._3, children.map(t -> t._3));
+        final Node<T1> node1 = new Node<>(value._1(), children.map(Tuple3::_1));
+        final Node<T2> node2 = new Node<>(value._2(), children.map(Tuple3::_2));
+        final Node<T3> node3 = new Node<>(value._3(), children.map(Tuple3::_3));
         return Tuple.of(node1, node2, node3);
     }
 

--- a/vavr/src/main/java/io/vavr/collection/TreeMap.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeMap.java
@@ -1422,7 +1422,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
     private static <K, V, K2, V2> TreeMap<K2, V2> flatMap(@NonNull TreeMap<K, V> map, @NonNull EntryComparator<K2, V2> entryComparator,
             BiFunction<? super K, ? super V, ? extends Iterable<Tuple2<K2, V2>>> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return createTreeMap(entryComparator, map.entries.iterator().flatMap(entry -> mapper.apply(entry._1, entry._2)));
+        return createTreeMap(entryComparator, map.entries.iterator().flatMap(entry -> mapper.apply(entry._1(), entry._2())));
     }
 
     private static <K, K2, V, V2> TreeMap<K2, V2> map(@NonNull TreeMap<K, V> map, @NonNull EntryComparator<K2, V2> entryComparator,
@@ -1573,7 +1573,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
 
             @Override
             public int compare(Tuple2<K, V> e1, Tuple2<K, V> e2) {
-                return keyComparator.compare(e1._1, e2._1);
+                return keyComparator.compare(e1._1(), e2._1());
             }
 
             @Override
@@ -1600,8 +1600,8 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
             @SuppressWarnings("unchecked")
             @Override
             public int compare(Tuple2<K, V> e1, Tuple2<K, V> e2) {
-                final K key1 = e1._1;
-                final K key2 = e2._1;
+                final K key1 = e1._1();
+                final K key2 = e2._1();
                 return ((Comparable<K>) key1).compareTo(key2);
             }
 

--- a/vavr/src/main/java/io/vavr/collection/TreeMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeMultimap.java
@@ -154,7 +154,7 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
             Objects.requireNonNull(entries, "entries is null");
             TreeMultimap<K, V2> result = empty(keyComparator);
             for (Tuple2<? extends K, ? extends V2> entry : entries) {
-                result = result.put(entry._1, entry._2);
+                result = result.put(entry._1(), entry._2());
             }
             return result;
         }
@@ -190,7 +190,7 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
             Objects.requireNonNull(entries, "entries is null");
             TreeMultimap<K, V2> result = empty(keyComparator);
             for (Tuple2<? extends K, ? extends V2> entry : entries) {
-                result = result.put(entry._1, entry._2);
+                result = result.put(entry._1(), entry._2());
             }
             return result;
         }
@@ -402,7 +402,7 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
          * @param <V2>    The value type
          * @param n       The number of elements in the TreeMultimap
          * @param element The element
-         * @return A TreeMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2}.
+         * @return A TreeMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2()}.
          */
         @SuppressWarnings("unchecked")
         public <K extends Comparable<? super K>, V2 extends V> TreeMultimap<K, V2> fill(int n, @NonNull Tuple2<? extends K, ? extends V2> element) {
@@ -417,7 +417,7 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
          * @param keyComparator The comparator used to sort the entries by their key
          * @param n             The number of elements in the TreeMultimap
          * @param element       The element
-         * @return A TreeMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2}.
+         * @return A TreeMultimap of size {@code 1}, where each element contains {@code n} values of {@code element._2()}.
          */
         @SuppressWarnings("unchecked")
         public <K, V2 extends V> TreeMultimap<K, V2> fill(Comparator<? super K> keyComparator, int n, @NonNull Tuple2<? extends K, ? extends V2> element) {
@@ -899,7 +899,7 @@ public final class TreeMultimap<K, V> extends AbstractMultimap<K, V, TreeMultima
          */
         public <K, V2 extends V> TreeMultimap<K, V2> of(@NonNull Comparator<? super K> keyComparator, Tuple2<? extends K, ? extends V2> entry) {
             final TreeMultimap<K, V2> e = empty(keyComparator);
-            return e.put(entry._1, entry._2);
+            return e.put(entry._1(), entry._2());
         }
 
         /**

--- a/vavr/src/main/java/io/vavr/collection/TreeSet.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeSet.java
@@ -1137,7 +1137,7 @@ public final class TreeSet<T> implements SortedSet<T>, Serializable {
     @Override
     public TreeSet<Tuple2<T, Integer>> zipWithIndex() {
         final Comparator<? super T> component1Comparator = tree.comparator();
-        final Comparator<Tuple2<T, Integer>> tuple2Comparator = (t1, t2) -> component1Comparator.compare(t1._1, t2._1);
+        final Comparator<Tuple2<T, Integer>> tuple2Comparator = (t1, t2) -> component1Comparator.compare(t1._1(), t2._1());
         return TreeSet.ofAll(tuple2Comparator, iterator().zipWithIndex());
     }
 

--- a/vavr/src/main/java/io/vavr/collection/Vector.java
+++ b/vavr/src/main/java/io/vavr/collection/Vector.java
@@ -1372,8 +1372,8 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
         Vector<T2> ys = empty();
         for (int i = 0; i < length(); i++) {
             final Tuple2<? extends T1, ? extends T2> t = unzipper.apply(get(i));
-            xs = xs.append(t._1);
-            ys = ys.append(t._2);
+            xs = xs.append(t._1());
+            ys = ys.append(t._2());
         }
         return Tuple.of(xs, ys);
     }
@@ -1386,9 +1386,9 @@ public final class Vector<T> implements IndexedSeq<T>, Serializable {
         Vector<T3> zs = empty();
         for (int i = 0; i < length(); i++) {
             final Tuple3<? extends T1, ? extends T2, ? extends T3> t = unzipper.apply(get(i));
-            xs = xs.append(t._1);
-            ys = ys.append(t._2);
-            zs = zs.append(t._3);
+            xs = xs.append(t._1());
+            ys = ys.append(t._2());
+            zs = zs.append(t._3());
         }
         return Tuple.of(xs, ys, zs);
     }
@@ -1462,7 +1462,7 @@ interface VectorModule {
             return (k == 0)
                    ? Vector.of(Vector.empty())
                    : elements.zipWithIndex().flatMap(
-                    t -> apply(elements.drop(t._2 + 1), (k - 1)).map((Vector<T> c) -> c.prepend(t._1)));
+                    t -> apply(elements.drop(t._2() + 1), (k - 1)).map((Vector<T> c) -> c.prepend(t._1())));
         }
     }
 }

--- a/vavr/src/test/java/io/vavr/LazyTest.java
+++ b/vavr/src/test/java/io/vavr/LazyTest.java
@@ -287,7 +287,7 @@ public class LazyTest extends AbstractValueTest {
                 return Tuple.of(lazy, expected);
             }).flatMap(t -> range(0, 5).map(j -> runAsync(() -> {
                         while (!canProceed.get()) { /* busy wait */ }
-                        assertThat(t._1.get()).isEqualTo(t._2);
+                        assertThat(t._1().get()).isEqualTo(t._2());
                     }))
             );
 

--- a/vavr/src/test/java/io/vavr/TupleTest.java
+++ b/vavr/src/test/java/io/vavr/TupleTest.java
@@ -21,7 +21,6 @@ package io.vavr;
 import io.vavr.collection.List;
 import java.math.BigDecimal;
 import java.util.AbstractMap;
-import java.util.Objects;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -34,11 +33,6 @@ public class TupleTest {
     @Test
     public void shouldCreateEmptyTuple() {
         assertThat(Tuple.empty().toString()).isEqualTo("()");
-    }
-
-    @Test
-    public void shouldHashTuple0() {
-        assertThat(tuple0().hashCode()).isEqualTo(Objects.hash());
     }
 
     @Test
@@ -104,12 +98,6 @@ public class TupleTest {
     }
 
     @Test
-    public void shouldHashTuple1() {
-        final Tuple1<?> t = tuple1();
-        assertThat(t.hashCode()).isEqualTo(Tuple.hash(t._1));
-    }
-
-    @Test
     public void shouldReturnCorrectArityOfTuple1() {
         assertThat(tuple1().arity()).isEqualTo(1);
     }
@@ -155,12 +143,6 @@ public class TupleTest {
     public void shouldCreateTuple2FromEntry() {
         final Tuple2<Integer, Integer> tuple2FromEntry = Tuple.fromEntry(new AbstractMap.SimpleEntry<>(1, 2));
         assertThat(tuple2FromEntry.toString()).isEqualTo("(1, 2)");
-    }
-
-    @Test
-    public void shouldHashTuple2() {
-        final Tuple2<?, ?> t = tuple2();
-        assertThat(t.hashCode()).isEqualTo(Objects.hash(t._1, t._2));
     }
 
     @Test
@@ -216,12 +198,6 @@ public class TupleTest {
     }
 
     @Test
-    public void shouldHashTuple3() {
-        final Tuple3<?, ?, ?> t = tuple3();
-        assertThat(t.hashCode()).isEqualTo(Objects.hash(t._1, t._2, t._3));
-    }
-
-    @Test
     public void shouldReturnCorrectArityOfTuple3() {
         assertThat(tuple3().arity()).isEqualTo(3);
     }
@@ -263,12 +239,6 @@ public class TupleTest {
     @Test
     public void shouldCreateQuadruple() {
         assertThat(tuple4().toString()).isEqualTo("(1, 2, 3, 4)");
-    }
-
-    @Test
-    public void shouldHashTuple4() {
-        final Tuple4<?, ?, ?, ?> t = tuple4();
-        assertThat(t.hashCode()).isEqualTo(Objects.hash(t._1, t._2, t._3, t._4));
     }
 
     @Test
@@ -317,12 +287,6 @@ public class TupleTest {
     }
 
     @Test
-    public void shouldHashTuple5() {
-        final Tuple5<?, ?, ?, ?, ?> t = tuple5();
-        assertThat(t.hashCode()).isEqualTo(Objects.hash(t._1, t._2, t._3, t._4, t._5));
-    }
-
-    @Test
     public void shouldReturnCorrectArityOfTuple5() {
         assertThat(tuple5().arity()).isEqualTo(5);
     }
@@ -366,12 +330,6 @@ public class TupleTest {
     @Test
     public void shouldCreateSextuple() {
         assertThat(tuple6().toString()).isEqualTo("(1, 2, 3, 4, 5, 6)");
-    }
-
-    @Test
-    public void shouldHashTuple6() {
-        final Tuple6<?, ?, ?, ?, ?, ?> t = tuple6();
-        assertThat(t.hashCode()).isEqualTo(Objects.hash(t._1, t._2, t._3, t._4, t._5, t._6));
     }
 
     @Test
@@ -422,12 +380,6 @@ public class TupleTest {
     }
 
     @Test
-    public void shouldHashTuple7() {
-        final Tuple7<?, ?, ?, ?, ?, ?, ?> t = tuple7();
-        assertThat(t.hashCode()).isEqualTo(Objects.hash(t._1, t._2, t._3, t._4, t._5, t._6, t._7));
-    }
-
-    @Test
     public void shouldReturnCorrectArityOfTuple7() {
         assertThat(tuple7().arity()).isEqualTo(7);
     }
@@ -473,12 +425,6 @@ public class TupleTest {
     @Test
     public void shouldCreateTuple8() {
         assertThat(tuple8().toString()).isEqualTo("(1, 2, 3, 4, 5, 6, 7, 8)");
-    }
-
-    @Test
-    public void shouldHashTuple8() {
-        final Tuple8<?, ?, ?, ?, ?, ?, ?, ?> t = tuple8();
-        assertThat(t.hashCode()).isEqualTo(Objects.hash(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8));
     }
 
     @Test

--- a/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
@@ -101,7 +101,7 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
                 final ArrayList<Tuple2<Integer, T>> result = new ArrayList<>();
                 Stream.ofAll(list)
                         .zipWithIndex()
-                        .map(tu -> Tuple.of(tu._2, tu._1))
+                        .map(tu -> Tuple.of(tu._2(), tu._1()))
                         .forEach(result::add);
                 return result;
             }
@@ -109,7 +109,7 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
             private ArrayList<T> fromTuples(java.util.List<Tuple2<Integer, T>> list) {
                 final ArrayList<T> result = new ArrayList<>();
                 Stream.ofAll(list)
-                        .map(tu -> tu._2)
+                        .map(tu -> tu._2())
                         .forEach(result::add);
                 return result;
             }
@@ -906,7 +906,7 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
     @Test
     public void shouldUnzipNonNil() {
         final Map<Integer, Integer> map = emptyIntInt().put(0, 0).put(1, 1);
-        final Tuple actual = map.unzip(entry -> Tuple.of(entry._1, entry._2 + 1));
+        final Tuple actual = map.unzip(entry -> Tuple.of(entry._1(), entry._2() + 1));
         final Tuple expected = Tuple.of(Stream.of(0, 1), Stream.of(1, 2));
         assertThat(actual).isEqualTo(expected);
     }
@@ -921,7 +921,7 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
     @Test
     public void shouldUnzip3NonNil() {
         final Map<Integer, Integer> map = emptyIntInt().put(0, 0).put(1, 1);
-        final Tuple actual = map.unzip3(entry -> Tuple.of(entry._1, entry._2 + 1, entry._2 + 5));
+        final Tuple actual = map.unzip3(entry -> Tuple.of(entry._1(), entry._2() + 1, entry._2() + 5));
         final Tuple expected = Tuple.of(Stream.of(0, 1), Stream.of(1, 2), Stream.of(5, 6));
         assertThat(actual).isEqualTo(expected);
     }
@@ -1134,7 +1134,7 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         final Map<Integer, Integer> map = mapOf(1, 2).put(3, 4);
         final int[] result = { 0 };
         map.forEach(t -> {
-            result[0] += t._1 + t._2;
+            result[0] += t._1() + t._2();
         });
         assertThat(result[0]).isEqualTo(10);
     }
@@ -1449,8 +1449,8 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
             count.incrementAndGet();
             return true;
         });
-        assertThat(results._1).isEqualTo(mapOf("1", 1, "2", 2, "3", 3));
-        assertThat(results._2).isEmpty();
+        assertThat(results._1()).isEqualTo(mapOf("1", 1, "2", 2, "3", 3));
+        assertThat(results._2()).isEmpty();
         assertThat(count.get()).isEqualTo(3);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/AbstractMultimapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractMultimapTest.java
@@ -143,7 +143,7 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
                 final ArrayList<Tuple2<Integer, T>> result = new ArrayList<>();
                 Stream.ofAll(list)
                   .zipWithIndex()
-                  .map(tu -> Tuple.of(tu._2, tu._1))
+                  .map(tu -> Tuple.of(tu._2(), tu._1()))
                   .forEach(result::add);
                 return result;
             }
@@ -151,7 +151,7 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
             private ArrayList<T> fromTuples(java.util.List<Tuple2<Integer, T>> list) {
                 final ArrayList<T> result = new ArrayList<>();
                 Stream.ofAll(list)
-                  .map(tu -> tu._2)
+                  .map(tu -> tu._2())
                   .forEach(result::add);
                 return result;
             }
@@ -590,7 +590,7 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
     public void forEachByTuple() {
         final Multimap<Integer, Integer> map = mapOf(1, 2).put(3, 4);
         final int[] result = {0};
-        map.forEach(t -> result[0] += t._1 + t._2);
+        map.forEach(t -> result[0] += t._1() + t._2());
         assertThat(result[0]).isEqualTo(10);
     }
 
@@ -846,8 +846,8 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
             count.incrementAndGet();
             return true;
         });
-        assertThat(results._1).isEqualTo(mapOfTuples(Tuple.of("1", 1), Tuple.of("2", 2), Tuple.of("3", 3)));
-        assertThat(results._2).isEmpty();
+        assertThat(results._1()).isEqualTo(mapOfTuples(Tuple.of("1", 1), Tuple.of("2", 2), Tuple.of("3", 3)));
+        assertThat(results._2()).isEmpty();
         assertThat(count.get()).isEqualTo(3);
     }
 
@@ -1106,7 +1106,7 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
     @TestTemplate
     public void shouldUnzipNonNil() {
         final Multimap<Integer, Integer> map = emptyIntInt().put(0, 0).put(1, 1);
-        final Tuple actual = map.unzip(entry -> Tuple.of(entry._1, entry._2 + 1));
+        final Tuple actual = map.unzip(entry -> Tuple.of(entry._1(), entry._2() + 1));
         final Tuple expected = Tuple.of(Stream.of(0, 1), Stream.of(1, 2));
         assertThat(actual).isEqualTo(expected);
     }
@@ -1121,7 +1121,7 @@ public abstract class AbstractMultimapTest extends AbstractTraversableTest {
     @TestTemplate
     public void shouldUnzip3NonNil() {
         final Multimap<Integer, Integer> map = emptyIntInt().put(0, 0).put(1, 1);
-        final Tuple actual = map.unzip3(entry -> Tuple.of(entry._1, entry._2 + 1, entry._2 + 5));
+        final Tuple actual = map.unzip3(entry -> Tuple.of(entry._1(), entry._2() + 1, entry._2() + 5));
         final Tuple expected = Tuple.of(Stream.of(0, 1), Stream.of(1, 2), Stream.of(5, 6));
         assertThat(actual).isEqualTo(expected);
     }

--- a/vavr/src/test/java/io/vavr/collection/AbstractSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSetTest.java
@@ -199,8 +199,8 @@ public abstract class AbstractSetTest extends AbstractTraversableRangeTest {
             count.incrementAndGet();
             return true;
         });
-        assertThat(results._1).isEqualTo(of(1, 2, 3));
-        assertThat(results._2).isEqualTo(of());
+        assertThat(results._1()).isEqualTo(of(1, 2, 3));
+        assertThat(results._2()).isEqualTo(of());
         assertThat(count.get()).isEqualTo(3);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/ArrayTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ArrayTest.java
@@ -254,8 +254,8 @@ public class ArrayTest extends AbstractIndexedSeqTest {
             count.incrementAndGet();
             return true;
         });
-        assertThat(results._1).isEqualTo(of(1, 2, 3));
-        assertThat(results._2).isEqualTo(of());
+        assertThat(results._1()).isEqualTo(of(1, 2, 3));
+        assertThat(results._2()).isEqualTo(of());
         assertThat(count.get()).isEqualTo(3);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/BitSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/BitSetTest.java
@@ -66,25 +66,26 @@ public class BitSetTest extends AbstractSortedSetTest {
 
     @Override
     protected <T> ObjectAssert<T> assertThat(T actual) {
-        return new ObjectAssert<T>(actual) {
+        return new ObjectAssert<>(actual) {
+            
             @Override
             public ObjectAssert<T> isEqualTo(Object expected) {
-                if (actual instanceof Tuple2) {
-                    final Tuple2<?, ?> t1 = (Tuple2<?, ?>) actual;
-                    final Tuple2<?, ?> t2 = (Tuple2<?, ?>) expected;
-                    assertThat((Iterable<?>) t1._1).isEqualTo(t2._1);
-                    assertThat((Iterable<?>) t1._2).isEqualTo(t2._2);
-                    return this;
-                } else if (actual instanceof Tuple3) {
-                    final Tuple3<?, ?, ?> t1 = (Tuple3<?, ?, ?>) actual;
-                    final Tuple3<?, ?, ?> t2 = (Tuple3<?, ?, ?>) expected;
-                    assertThat((Iterable<?>) t1._1).isEqualTo(t2._1);
-                    assertThat((Iterable<?>) t1._2).isEqualTo(t2._2);
-                    assertThat((Iterable<?>) t1._3).isEqualTo(t2._3);
-                    return this;
-                } else {
-                    return super.isEqualTo(expected);
-                }
+                return switch (actual) {
+                    case Tuple2<?, ?> t1 -> {
+                        final Tuple2<?, ?> t2 = (Tuple2<?, ?>) expected;
+                        assertThat((Iterable<?>) t1._1()).isEqualTo(t2._1());
+                        assertThat((Iterable<?>) t1._2()).isEqualTo(t2._2());
+                        yield this;
+                    }
+                    case Tuple3<?, ?, ?> t1 -> {
+                        final Tuple3<?, ?, ?> t2 = (Tuple3<?, ?, ?>) expected;
+                        assertThat((Iterable<?>) t1._1()).isEqualTo(t2._1());
+                        assertThat((Iterable<?>) t1._2()).isEqualTo(t2._2());
+                        assertThat((Iterable<?>) t1._3()).isEqualTo(t2._3());
+                        yield this;
+                    }
+                    case null, default -> super.isEqualTo(expected);
+                };
             }
         };
     }

--- a/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/CharSeqTest.java
@@ -301,8 +301,8 @@ public class CharSeqTest {
             count.incrementAndGet();
             return true;
         });
-        assertThat(results._1).isEqualTo(CharSeq.of('1', '2', '3'));
-        assertThat(results._2).isEqualTo(CharSeq.of());
+        assertThat(results._1()).isEqualTo(CharSeq.of('1', '2', '3'));
+        assertThat(results._2()).isEqualTo(CharSeq.of());
         assertThat(count.get()).isEqualTo(3);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/HashArrayMappedTrieTest.java
+++ b/vavr/src/test/java/io/vavr/collection/HashArrayMappedTrieTest.java
@@ -112,7 +112,7 @@ public class HashArrayMappedTrieTest {
 
     @Test
     public void testBigDataWeakHashCode() {
-        testBigData(5000, t -> Tuple.of(new WeakInteger(t._1), t._2));
+        testBigData(5000, t -> Tuple.of(new WeakInteger(t._1()), t._2()));
     }
 
     private <K extends Comparable<? super K>, V> void testBigData(int count, Function<Tuple2<Integer, Integer>, Tuple2<K, V>> mapper) {
@@ -195,7 +195,7 @@ public class HashArrayMappedTrieTest {
 
         void test() {
             assertThat(hamt.size()).isEqualTo(classic.size());
-            hamt.iterator().forEachRemaining(e -> assertThat(classic.get(e._1)).isEqualTo(e._2));
+            hamt.iterator().forEachRemaining(e -> assertThat(classic.get(e._1())).isEqualTo(e._2()));
             classic.forEach((k, v) -> {
                 assertThat(hamt.get(k).get()).isEqualTo(v);
                 assertThat(hamt.getOrElse(k, null)).isEqualTo(v);
@@ -218,7 +218,7 @@ public class HashArrayMappedTrieTest {
         final java.util.HashMap<K, V> mp = new java.util.HashMap<>();
         for (int i = 0; i < count; i++) {
             final Tuple2<K, V> entry = mapper.apply(Tuple.of(r.nextInt(), r.nextInt()));
-            mp.put(entry._1, entry._2);
+            mp.put(entry._1(), entry._2());
         }
         return mp;
     }

--- a/vavr/src/test/java/io/vavr/collection/IntMap.java
+++ b/vavr/src/test/java/io/vavr/collection/IntMap.java
@@ -96,11 +96,11 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
             private static final long serialVersionUID = 1L;
             @Override
             public R apply(Tuple2<Integer, T> entry) {
-                return partialFunction.apply(entry._2);
+                return partialFunction.apply(entry._2());
             }
             @Override
             public boolean isDefinedAt(Tuple2<Integer, T> entry) {
-                return partialFunction.isDefinedAt(entry._2);
+                return partialFunction.isDefinedAt(entry._2());
             }
         };
         return original.collect(pf);
@@ -113,12 +113,12 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
 
     @Override
     public IntMap<T> distinctBy(@NonNull Comparator<? super T> comparator) {
-        return unit(original.distinctBy((o1, o2) -> comparator.compare(o1._2, o2._2)));
+        return unit(original.distinctBy((o1, o2) -> comparator.compare(o1._2(), o2._2())));
     }
 
     @Override
     public <U> IntMap<T> distinctBy(@NonNull Function<? super T, ? extends U> keyExtractor) {
-        return unit(original.distinctBy(f -> keyExtractor.apply(f._2)));
+        return unit(original.distinctBy(f -> keyExtractor.apply(f._2())));
     }
 
     @Override
@@ -135,38 +135,38 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
 
     @Override
     public IntMap<T> dropUntil(@NonNull Predicate<? super T> predicate) {
-        return unit(original.dropUntil(p -> predicate.test(p._2)));
+        return unit(original.dropUntil(p -> predicate.test(p._2())));
     }
 
     @Override
     public IntMap<T> dropWhile(@NonNull Predicate<? super T> predicate) {
-        return unit(original.dropWhile(p -> predicate.test(p._2)));
+        return unit(original.dropWhile(p -> predicate.test(p._2())));
     }
 
     @Override
     public IntMap<T> filter(@NonNull Predicate<? super T> predicate) {
-        return unit(original.filter(p -> predicate.test(p._2)));
+        return unit(original.filter(p -> predicate.test(p._2())));
     }
 
     @Override
     public IntMap<T> reject(@NonNull Predicate<? super T> predicate) {
-        return unit(original.reject(p -> predicate.test(p._2)));
+        return unit(original.reject(p -> predicate.test(p._2())));
     }
 
     @Override
     public <U> Seq<U> flatMap(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        return original.flatMap(e -> mapper.apply(e._2));
+        return original.flatMap(e -> mapper.apply(e._2()));
     }
 
     @Override
     public <U> U foldRight(U zero, @NonNull BiFunction<? super T, ? super U, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
-        return original.foldRight(zero, (e, u) -> f.apply(e._2, u));
+        return original.foldRight(zero, (e, u) -> f.apply(e._2(), u));
     }
 
     @Override
     public <C> Map<C, ? extends IntMap<T>> groupBy(@NonNull Function<? super T, ? extends C> classifier) {
-        return original.groupBy(e -> classifier.apply(e._2)).map((k, v) -> Tuple.of(k, IntMap.of(v)));
+        return original.groupBy(e -> classifier.apply(e._2())).map((k, v) -> Tuple.of(k, IntMap.of(v)));
     }
 
     @Override
@@ -181,12 +181,12 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
 
     @Override
     public T head() {
-        return original.head()._2;
+        return original.head()._2();
     }
 
     @Override
     public Option<T> headOption() {
-        return original.headOption().map(o -> o._2);
+        return original.headOption().map(o -> o._2());
     }
 
     @Override
@@ -211,7 +211,7 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
 
     @Override
     public T last() {
-        return original.last()._2;
+        return original.last()._2();
     }
 
     @Override
@@ -221,7 +221,7 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
 
     @Override
     public <U> Seq<U> map(@NonNull Function<? super T, ? extends U> mapper) {
-        return original.map(e -> mapper.apply(e._2));
+        return original.map(e -> mapper.apply(e._2()));
     }
 
     @Override
@@ -236,30 +236,30 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
 
     @Override
     public IntMap<T> orElse(Iterable<? extends T> other) {
-        return unit(original.orElse(List.ofAll(other).zipWithIndex().map(t -> Tuple.of(t._2, t._1))));
+        return unit(original.orElse(List.ofAll(other).zipWithIndex().map(t -> Tuple.of(t._2(), t._1()))));
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public IntMap<T> orElse(@NonNull Supplier<? extends Iterable<? extends T>> supplier) {
-        return unit(original.orElse(() -> (Iterable<? extends Tuple2<Integer, T>>) List.ofAll(supplier.get()).zipWithIndex().map(t -> Tuple.of(t._2, t._1))));
+        return unit(original.orElse(() -> (Iterable<? extends Tuple2<Integer, T>>) List.ofAll(supplier.get()).zipWithIndex().map(t -> Tuple.of(t._2(), t._1()))));
     }
 
     @Override
     public Tuple2<IntMap<T>, IntMap<T>> partition(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return original.partition(p -> predicate.test(p._2)).map(IntMap::of, IntMap::of);
+        return original.partition(p -> predicate.test(p._2())).map(IntMap::of, IntMap::of);
     }
 
     @Override
     public IntMap<T> peek(@NonNull Consumer<? super T> action) {
-        original.peek(e -> action.accept(e._2));
+        original.peek(e -> action.accept(e._2()));
         return this;
     }
 
     @Override
     public IntMap<T> replace(T currentElement, T newElement) {
-        final Option<Tuple2<Integer, T>> currentEntryOpt = original.find(e -> e._2.equals(currentElement));
+        final Option<Tuple2<Integer, T>> currentEntryOpt = original.find(e -> e._2().equals(currentElement));
         if (currentEntryOpt.isDefined()) {
             final Tuple2<Integer, T> currentEntry = currentEntryOpt.get();
             return unit(original.replace(currentEntry, Tuple.of(original.size() + 1, newElement)));
@@ -271,8 +271,8 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
     @Override
     public IntMap<T> replaceAll(T currentElement, T newElement) {
         Map<Integer, T> result = original;
-        for (Tuple2<Integer, T> entry : original.filter(e -> e._2.equals(currentElement))) {
-            result = result.replaceAll(entry, Tuple.of(entry._1, newElement));
+        for (Tuple2<Integer, T> entry : original.filter(e -> e._2().equals(currentElement))) {
+            result = result.replaceAll(entry, Tuple.of(entry._1(), newElement));
         }
         return unit(result);
     }
@@ -280,28 +280,28 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
     @Override
     public IntMap<T> retainAll(@NonNull Iterable<? extends T> elements) {
         final Set<T> elementsSet = HashSet.ofAll(elements);
-        return unit(original.retainAll(original.filter(e -> elementsSet.contains(e._2))));
+        return unit(original.retainAll(original.filter(e -> elementsSet.contains(e._2()))));
     }
 
     @Override
     public Traversable<T> scan(T zero, @NonNull BiFunction<? super T, ? super T, ? extends T> operation) {
         final int[] index = new int[] { 0 };
-        return original.scan(Tuple.of(-1, zero), (i, t) -> Tuple.of(index[0]++, operation.apply(i._2, t._2))).values();
+        return original.scan(Tuple.of(-1, zero), (i, t) -> Tuple.of(index[0]++, operation.apply(i._2(), t._2()))).values();
     }
 
     @Override
     public <U> Traversable<U> scanLeft(U zero, @NonNull BiFunction<? super U, ? super T, ? extends U> operation) {
-        return original.scanLeft(zero, (i, t) -> operation.apply(i, t._2));
+        return original.scanLeft(zero, (i, t) -> operation.apply(i, t._2()));
     }
 
     @Override
     public <U> Traversable<U> scanRight(U zero, @NonNull BiFunction<? super T, ? super U, ? extends U> operation) {
-        return original.scanRight(zero, (t, i) -> operation.apply(t._2, i));
+        return original.scanRight(zero, (t, i) -> operation.apply(t._2(), i));
     }
 
     @Override
     public Iterator<IntMap<T>> slideBy(@NonNull Function<? super T, ?> classifier) {
-        return original.slideBy(e -> classifier.apply(e._2)).map(IntMap::of);
+        return original.slideBy(e -> classifier.apply(e._2())).map(IntMap::of);
     }
 
     @Override
@@ -316,7 +316,7 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
 
     @Override
     public Tuple2<? extends IntMap<T>, ? extends IntMap<T>> span(@NonNull Predicate<? super T> predicate) {
-        return original.span(p -> predicate.test(p._2)).map(IntMap::of, IntMap::of);
+        return original.span(p -> predicate.test(p._2())).map(IntMap::of, IntMap::of);
     }
 
     public Spliterator<T> spliterator() {
@@ -329,7 +329,7 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
 
             @Override
             public boolean tryAdvance(Consumer<? super T> action) {
-                return spliterator.tryAdvance(a -> action.accept(a._2));
+                return spliterator.tryAdvance(a -> action.accept(a._2()));
             }
 
             @Override
@@ -380,12 +380,12 @@ public final class IntMap<T> implements Traversable<T>, Serializable {
 
     @Override
     public Traversable<T> takeUntil(@NonNull Predicate<? super T> predicate) {
-        return unit(original.takeUntil(p -> predicate.test(p._2)));
+        return unit(original.takeUntil(p -> predicate.test(p._2())));
     }
 
     @Override
     public IntMap<T> takeWhile(@NonNull Predicate<? super T> predicate) {
-        return unit(original.takeWhile(p -> predicate.test(p._2)));
+        return unit(original.takeWhile(p -> predicate.test(p._2())));
     }
 
     @Override

--- a/vavr/src/test/java/io/vavr/collection/IntMultimap.java
+++ b/vavr/src/test/java/io/vavr/collection/IntMultimap.java
@@ -97,11 +97,11 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
             private static final long serialVersionUID = 1L;
             @Override
             public R apply(Tuple2<Integer, T> entry) {
-                return partialFunction.apply(entry._2);
+                return partialFunction.apply(entry._2());
             }
             @Override
             public boolean isDefinedAt(Tuple2<Integer, T> entry) {
-                return partialFunction.isDefinedAt(entry._2);
+                return partialFunction.isDefinedAt(entry._2());
             }
         };
         return original.collect(pf);
@@ -114,12 +114,12 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
 
     @Override
     public IntMultimap<T> distinctBy(@NonNull Comparator<? super T> comparator) {
-        return unit(original.distinctBy((o1, o2) -> comparator.compare(o1._2, o2._2)));
+        return unit(original.distinctBy((o1, o2) -> comparator.compare(o1._2(), o2._2())));
     }
 
     @Override
     public <U> IntMultimap<T> distinctBy(@NonNull Function<? super T, ? extends U> keyExtractor) {
-        return unit(original.distinctBy(f -> keyExtractor.apply(f._2)));
+        return unit(original.distinctBy(f -> keyExtractor.apply(f._2())));
     }
 
     @Override
@@ -136,38 +136,38 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
 
     @Override
     public IntMultimap<T> dropUntil(@NonNull Predicate<? super T> predicate) {
-        return unit(original.dropUntil(p -> predicate.test(p._2)));
+        return unit(original.dropUntil(p -> predicate.test(p._2())));
     }
 
     @Override
     public IntMultimap<T> dropWhile(@NonNull Predicate<? super T> predicate) {
-        return unit(original.dropWhile(p -> predicate.test(p._2)));
+        return unit(original.dropWhile(p -> predicate.test(p._2())));
     }
 
     @Override
     public IntMultimap<T> filter(@NonNull Predicate<? super T> predicate) {
-        return unit(original.filter(p -> predicate.test(p._2)));
+        return unit(original.filter(p -> predicate.test(p._2())));
     }
 
     @Override
     public IntMultimap<T> reject(@NonNull Predicate<? super T> predicate) {
-        return unit(original.reject(p -> predicate.test(p._2)));
+        return unit(original.reject(p -> predicate.test(p._2())));
     }
 
     @Override
     public <U> Seq<U> flatMap(@NonNull Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        return original.flatMap(e -> mapper.apply(e._2));
+        return original.flatMap(e -> mapper.apply(e._2()));
     }
 
     @Override
     public <U> U foldRight(U zero, @NonNull BiFunction<? super T, ? super U, ? extends U> f) {
         Objects.requireNonNull(f, "f is null");
-        return original.foldRight(zero, (e, u) -> f.apply(e._2, u));
+        return original.foldRight(zero, (e, u) -> f.apply(e._2(), u));
     }
 
     @Override
     public <C> Map<C, ? extends IntMultimap<T>> groupBy(@NonNull Function<? super T, ? extends C> classifier) {
-        return original.groupBy(e -> classifier.apply(e._2)).map((k, v) -> Tuple.of(k, IntMultimap.of(v)));
+        return original.groupBy(e -> classifier.apply(e._2())).map((k, v) -> Tuple.of(k, IntMultimap.of(v)));
     }
 
     @Override
@@ -182,12 +182,12 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
 
     @Override
     public T head() {
-        return original.head()._2;
+        return original.head()._2();
     }
 
     @Override
     public Option<T> headOption() {
-        return original.headOption().map(o -> o._2);
+        return original.headOption().map(o -> o._2());
     }
 
     @Override
@@ -212,7 +212,7 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
 
     @Override
     public T last() {
-        return original.last()._2;
+        return original.last()._2();
     }
 
     @Override
@@ -222,7 +222,7 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
 
     @Override
     public <U> Seq<U> map(@NonNull Function<? super T, ? extends U> mapper) {
-        return original.map(e -> mapper.apply(e._2));
+        return original.map(e -> mapper.apply(e._2()));
     }
 
     @Override
@@ -237,30 +237,30 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
 
     @Override
     public IntMultimap<T> orElse(Iterable<? extends T> other) {
-        return unit(original.orElse(List.ofAll(other).zipWithIndex().map(t -> Tuple.of(t._2, t._1))));
+        return unit(original.orElse(List.ofAll(other).zipWithIndex().map(t -> Tuple.of(t._2(), t._1()))));
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public IntMultimap<T> orElse(@NonNull Supplier<? extends Iterable<? extends T>> supplier) {
-        return unit(original.orElse(() -> (Iterable<? extends Tuple2<Integer, T>>) List.ofAll(supplier.get()).zipWithIndex().map(t -> Tuple.of(t._2, t._1))));
+        return unit(original.orElse(() -> (Iterable<? extends Tuple2<Integer, T>>) List.ofAll(supplier.get()).zipWithIndex().map(t -> Tuple.of(t._2(), t._1()))));
     }
 
     @Override
     public Tuple2<IntMultimap<T>, IntMultimap<T>> partition(@NonNull Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate, "predicate is null");
-        return original.partition(p -> predicate.test(p._2)).map(IntMultimap::of, IntMultimap::of);
+        return original.partition(p -> predicate.test(p._2())).map(IntMultimap::of, IntMultimap::of);
     }
 
     @Override
     public IntMultimap<T> peek(@NonNull Consumer<? super T> action) {
-        original.peek(e -> action.accept(e._2));
+        original.peek(e -> action.accept(e._2()));
         return this;
     }
 
     @Override
     public IntMultimap<T> replace(T currentElement, T newElement) {
-        final Option<Tuple2<Integer, T>> currentEntryOpt = original.find(e -> e._2.equals(currentElement));
+        final Option<Tuple2<Integer, T>> currentEntryOpt = original.find(e -> e._2().equals(currentElement));
         if (currentEntryOpt.isDefined()) {
             final Tuple2<Integer, T> currentEntry = currentEntryOpt.get();
             return unit(original.replace(currentEntry, Tuple.of(original.size() + 1, newElement)));
@@ -272,8 +272,8 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
     @Override
     public IntMultimap<T> replaceAll(T currentElement, T newElement) {
         Multimap<Integer, T> result = original;
-        for (Tuple2<Integer, T> entry : original.filter(e -> e._2.equals(currentElement))) {
-            result = result.replaceAll(entry, Tuple.of(entry._1, newElement));
+        for (Tuple2<Integer, T> entry : original.filter(e -> e._2().equals(currentElement))) {
+            result = result.replaceAll(entry, Tuple.of(entry._1(), newElement));
         }
         return unit(result);
     }
@@ -281,28 +281,28 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
     @Override
     public IntMultimap<T> retainAll(@NonNull Iterable<? extends T> elements) {
         final Set<T> elementsSet = HashSet.ofAll(elements);
-        return unit(original.retainAll(original.filter(e -> elementsSet.contains(e._2))));
+        return unit(original.retainAll(original.filter(e -> elementsSet.contains(e._2()))));
     }
 
     @Override
     public Traversable<T> scan(T zero, @NonNull BiFunction<? super T, ? super T, ? extends T> operation) {
         final int[] index = new int[] { 0 };
-        return original.scan(Tuple.of(-1, zero), (i, t) -> Tuple.of(index[0]++, operation.apply(i._2, t._2))).values();
+        return original.scan(Tuple.of(-1, zero), (i, t) -> Tuple.of(index[0]++, operation.apply(i._2(), t._2()))).values();
     }
 
     @Override
     public <U> Traversable<U> scanLeft(U zero, @NonNull BiFunction<? super U, ? super T, ? extends U> operation) {
-        return original.scanLeft(zero, (i, t) -> operation.apply(i, t._2));
+        return original.scanLeft(zero, (i, t) -> operation.apply(i, t._2()));
     }
 
     @Override
     public <U> Traversable<U> scanRight(U zero, @NonNull BiFunction<? super T, ? super U, ? extends U> operation) {
-        return original.scanRight(zero, (t, i) -> operation.apply(t._2, i));
+        return original.scanRight(zero, (t, i) -> operation.apply(t._2(), i));
     }
 
     @Override
     public Iterator<IntMultimap<T>> slideBy(@NonNull Function<? super T, ?> classifier) {
-        return original.slideBy(e -> classifier.apply(e._2)).map(IntMultimap::of);
+        return original.slideBy(e -> classifier.apply(e._2())).map(IntMultimap::of);
     }
 
     @Override
@@ -317,7 +317,7 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
 
     @Override
     public Tuple2<? extends IntMultimap<T>, ? extends IntMultimap<T>> span(@NonNull Predicate<? super T> predicate) {
-        return original.span(p -> predicate.test(p._2)).map(IntMultimap::of, IntMultimap::of);
+        return original.span(p -> predicate.test(p._2())).map(IntMultimap::of, IntMultimap::of);
     }
 
     public Spliterator<T> spliterator() {
@@ -330,7 +330,7 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
 
             @Override
             public boolean tryAdvance(Consumer<? super T> action) {
-                return spliterator.tryAdvance(a -> action.accept(a._2));
+                return spliterator.tryAdvance(a -> action.accept(a._2()));
             }
 
             @Override
@@ -381,12 +381,12 @@ public final class IntMultimap<T> implements Traversable<T>, Serializable {
 
     @Override
     public Traversable<T> takeUntil(@NonNull Predicate<? super T> predicate) {
-        return unit(original.takeUntil(p -> predicate.test(p._2)));
+        return unit(original.takeUntil(p -> predicate.test(p._2())));
     }
 
     @Override
     public IntMultimap<T> takeWhile(@NonNull Predicate<? super T> predicate) {
-        return unit(original.takeWhile(p -> predicate.test(p._2)));
+        return unit(original.takeWhile(p -> predicate.test(p._2())));
     }
 
     @Override

--- a/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
@@ -127,7 +127,7 @@ public class LinkedHashMapTest extends AbstractMapTest {
 
     @Test
     public void shouldKeepOrder() {
-        final List<Character> actual = LinkedHashMap.<Integer, Character> empty().put(3, 'a').put(2, 'b').put(1, 'c').foldLeft(List.empty(), (s, t) -> s.append(t._2));
+        final List<Character> actual = LinkedHashMap.<Integer, Character> empty().put(3, 'a').put(2, 'b').put(1, 'c').foldLeft(List.empty(), (s, t) -> s.append(t._2()));
         Assertions.assertThat(actual).isEqualTo(List.of('a', 'b', 'c'));
     }
 
@@ -252,7 +252,7 @@ public class LinkedHashMapTest extends AbstractMapTest {
                 .put(Tuple.of(2, "b"))
                 .put(Tuple.of(3, "c"))
                 .put(Tuple.of(4, "d"));
-        final Map<Integer, String> result = map.scan(Tuple.of(0, "x"), (t1, t2) -> Tuple.of(t1._1 + t2._1, t1._2 + t2._2));
+        final Map<Integer, String> result = map.scan(Tuple.of(0, "x"), (t1, t2) -> Tuple.of(t1._1() + t2._1(), t1._2() + t2._2()));
         assertThat(result).isEqualTo(LinkedHashMap.empty()
                 .put(0, "x")
                 .put(1, "xa")
@@ -268,7 +268,7 @@ public class LinkedHashMapTest extends AbstractMapTest {
                 .put(Tuple.of(2, "b"))
                 .put(Tuple.of(3, "c"))
                 .put(Tuple.of(4, "d"));
-        final Seq<Tuple2<Integer, String>> result = map.scanLeft(Tuple.of(0, "x"), (t1, t2) -> Tuple.of(t1._1 + t2._1, t1._2 + t2._2));
+        final Seq<Tuple2<Integer, String>> result = map.scanLeft(Tuple.of(0, "x"), (t1, t2) -> Tuple.of(t1._1() + t2._1(), t1._2() + t2._2()));
         assertThat(result).isEqualTo(List.of(
                 Tuple.of(0, "x"),
                 Tuple.of(1, "xa"),
@@ -284,7 +284,7 @@ public class LinkedHashMapTest extends AbstractMapTest {
                 .put(Tuple.of(2, "b"))
                 .put(Tuple.of(3, "c"))
                 .put(Tuple.of(4, "d"));
-        final Seq<Tuple2<Integer, String>> result = map.scanRight(Tuple.of(0, "x"), (t1, t2) -> Tuple.of(t1._1 + t2._1, t1._2 + t2._2));
+        final Seq<Tuple2<Integer, String>> result = map.scanRight(Tuple.of(0, "x"), (t1, t2) -> Tuple.of(t1._1() + t2._1(), t1._2() + t2._2()));
         assertThat(result).isEqualTo(List.of(
                 Tuple.of(10, "abcdx"),
                 Tuple.of(9, "bcdx"),

--- a/vavr/src/test/java/io/vavr/collection/ListTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ListTest.java
@@ -253,8 +253,8 @@ public class ListTest extends AbstractLinearSeqTest {
             count.incrementAndGet();
             return true;
         });
-        assertThat(results._1).isEqualTo(of(1, 2, 3));
-        assertThat(results._2).isEqualTo(of());
+        assertThat(results._1()).isEqualTo(of(1, 2, 3));
+        assertThat(results._2()).isEqualTo(of());
         assertThat(count.get()).isEqualTo(3);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/QueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/QueueTest.java
@@ -249,8 +249,8 @@ public class QueueTest extends AbstractLinearSeqTest {
             count.incrementAndGet();
             return true;
         });
-        assertThat(results._1).isEqualTo(of(1, 2, 3));
-        assertThat(results._2).isEqualTo(of());
+        assertThat(results._1()).isEqualTo(of(1, 2, 3));
+        assertThat(results._2()).isEqualTo(of());
         assertThat(count.get()).isEqualTo(3);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -480,8 +480,8 @@ public class StreamTest extends AbstractLinearSeqTest {
             count.incrementAndGet();
             return true;
         });
-        assertThat(results._1).isEqualTo(of(1, 2, 3));
-        assertThat(results._2).isEqualTo(of());
+        assertThat(results._1()).isEqualTo(of(1, 2, 3));
+        assertThat(results._2()).isEqualTo(of());
         assertThat(count.get()).isEqualTo(6);
     }
 
@@ -497,10 +497,10 @@ public class StreamTest extends AbstractLinearSeqTest {
             return i % 2 == 0;
         });
         assertThat(itemsCalled).containsExactly(0, 1);
-        assertThat(results._1.head()).isEqualTo(0);
-        assertThat(results._2.head()).isEqualTo(1);
-        assertThat(results._1.take(3)).isEqualTo(of(0, 2, 4));
-        assertThat(results._2.take(3)).isEqualTo(of(1, 3, 5));
+        assertThat(results._1().head()).isEqualTo(0);
+        assertThat(results._2().head()).isEqualTo(1);
+        assertThat(results._1().take(3)).isEqualTo(of(0, 2, 4));
+        assertThat(results._2().take(3)).isEqualTo(of(1, 3, 5));
         assertThat(itemsCalled).containsExactly(0, 1, 2, 3, 4, 5);
     }
 
@@ -528,7 +528,7 @@ public class StreamTest extends AbstractLinearSeqTest {
 
     @Test
     public void shouldRecurrentlyCalculateFibonacci() {
-        assertThat(Stream.of(1, 1).appendSelf(self -> self.zip(self.tail()).map(t -> t._1 + t._2)).take(10))
+        assertThat(Stream.of(1, 1).appendSelf(self -> self.zip(self.tail()).map(t -> t._1() + t._2())).take(10))
                 .isEqualTo(Stream.of(1, 1, 2, 3, 5, 8, 13, 21, 34, 55));
     }
 

--- a/vavr/src/test/java/io/vavr/collection/TreeMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/TreeMapTest.java
@@ -306,21 +306,21 @@ public class TreeMapTest extends AbstractSortedMapTest {
     @Test
     public void shouldScan() {
         final TreeMap<String, Integer> tm = TreeMap.ofEntries(Tuple.of("one", 1), Tuple.of("two", 2));
-        final TreeMap<String, Integer> result = tm.scan(Tuple.of("z", 0), (t1, t2) -> Tuple.of(t1._1 + t2._1, t1._2 + t2._2));
+        final TreeMap<String, Integer> result = tm.scan(Tuple.of("z", 0), (t1, t2) -> Tuple.of(t1._1() + t2._1(), t1._2() + t2._2()));
         assertThat(result).isEqualTo(TreeMap.ofEntries(Tuple.of("z", 0), Tuple.of("zone", 1), Tuple.of("zonetwo", 3)));
     }
 
     @Test
     public void shouldScanLeft() {
         final TreeMap<String, Integer> tm = TreeMap.ofEntries(Tuple.of("one", 1), Tuple.of("two", 2));
-        final Seq<Tuple2<String, Integer>> result = tm.scanLeft(Tuple.of("z", 0), (t1, t2) -> Tuple.of(t1._1 + t2._1, t1._2 + t2._2));
+        final Seq<Tuple2<String, Integer>> result = tm.scanLeft(Tuple.of("z", 0), (t1, t2) -> Tuple.of(t1._1() + t2._1(), t1._2() + t2._2()));
         assertThat(result).isEqualTo(List.of(Tuple.of("z", 0), Tuple.of("zone", 1), Tuple.of("zonetwo", 3)));
     }
 
     @Test
     public void shouldScanRight() {
         final TreeMap<String, Integer> tm = TreeMap.ofEntries(Tuple.of("one", 1), Tuple.of("two", 2));
-        final Seq<String> result = tm.scanRight("z", (t1, acc) -> acc + CharSeq.of(t1._1).reverse());
+        final Seq<String> result = tm.scanRight("z", (t1, acc) -> acc + CharSeq.of(t1._1()).reverse());
         assertThat(result).isEqualTo(List.of("zowteno", "zowt", "z"));
     }
 

--- a/vavr/src/test/java/io/vavr/collection/TreeTest.java
+++ b/vavr/src/test/java/io/vavr/collection/TreeTest.java
@@ -92,18 +92,18 @@ public class TreeTest extends AbstractTraversableTest {
 
     @Override
     protected <T> ObjectAssert<T> assertThat(T actual) {
-        return new ObjectAssert<T>(actual) {
+        return new ObjectAssert<>(actual) {
             @Override
             public ObjectAssert<T> isEqualTo(Object expected) {
-                if (actual instanceof Tuple2) {
-                    final Tuple2<?, ?> t1 = (Tuple2<?, ?>) actual;
-                    final Tuple2<?, ?> t2 = (Tuple2<?, ?>) expected;
-                    assertThat((Iterable<?>) t1._1).isEqualTo(t2._1);
-                    assertThat((Iterable<?>) t1._2).isEqualTo(t2._2);
-                    return this;
-                } else {
-                    return super.isEqualTo(expected);
-                }
+                return switch (actual) {
+                    case Tuple2<?, ?> t1 -> {
+                        Tuple2<?, ?> t2 = (Tuple2<?, ?>) expected;
+                        assertThat((Iterable<?>) t1._1()).isEqualTo(t2._1());
+                        assertThat((Iterable<?>) t1._2()).isEqualTo(t2._2());
+                        yield this;
+                    }
+                    case null, default -> super.isEqualTo(expected);
+                };
             }
         };
     }
@@ -591,7 +591,7 @@ public class TreeTest extends AbstractTraversableTest {
         final int length = List
                 .of(1, 2, 4, 7, 5, 3, 6, 8, 9)
                 .zip(tree)
-                .filter(t -> Objects.equals(t._1, t._2))
+                .filter(t -> Objects.equals(t._1(), t._2()))
                 .length();
         assertThat(length).isEqualTo(9);
     }

--- a/vavr/src/test/java/io/vavr/collection/VectorPropertyTest.java
+++ b/vavr/src/test/java/io/vavr/collection/VectorPropertyTest.java
@@ -346,7 +346,7 @@ public class VectorPropertyTest {
                     }
                 }
 
-                history.forEach(t -> assertAreEqual(t._1, t._2)); // test that the modifications are persistent
+                history.forEach(t -> assertAreEqual(t._1(), t._2())); // test that the modifications are persistent
             }
         }
     }

--- a/vavr/src/test/java/io/vavr/collection/VectorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/VectorTest.java
@@ -249,8 +249,8 @@ public class VectorTest extends AbstractIndexedSeqTest {
             count.incrementAndGet();
             return true;
         });
-        assertThat(results._1).isEqualTo(ofAll(1, 2, 3));
-        assertThat(results._2).isEmpty();
+        assertThat(results._1()).isEqualTo(ofAll(1, 2, 3));
+        assertThat(results._2()).isEmpty();
         assertThat(count.get()).isEqualTo(3);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler04Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler04Test.java
@@ -44,8 +44,8 @@ public class Euler04Test {
     private static int largestPalindromeOfProductsFromFactorsInRange(final int min, final int max) {
         return List.rangeClosed(min, max)
                 .crossProduct()
-                .filter(t -> t._1 <= t._2)
-                .map(t -> t._1 * t._2)
+                .filter(t -> t._1() <= t._2())
+                .map(t -> t._1() * t._2())
                 .filter(Utils::isPalindrome)
                 .max().get();
     }

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler05Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler05Test.java
@@ -46,7 +46,7 @@ public class Euler05Test {
         return Stream.rangeClosed(2, max)
                 .map(PrimeNumbers::factorization)
                 .reduce((m1, m2) -> m1.merge(m2, Math::max))
-                .foldLeft(1L, (xs, x) -> xs * pow(x._1, x._2));
+                .foldLeft(1L, (xs, x) -> xs * pow(x._1(), x._2()));
     }
 
     private static long pow(long a, long p) {

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler09Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler09Test.java
@@ -47,10 +47,10 @@ public class Euler09Test {
     public int abc(int sum) {
         return List.rangeClosed(1, sum)
                 .crossProduct()
-                .filter(t -> t._1 + t._2 < sum)
-                .map(t -> Tuple.of(t._1, t._2, sum - t._1 - t._2))
-                .filter(t -> t._1 * t._1 + t._2 * t._2 == t._3 * t._3)
-                .map(t -> t._1 * t._2 * t._3)
+                .filter(t -> t._1() + t._2() < sum)
+                .map(t -> Tuple.of(t._1(), t._2(), sum - t._1() - t._2()))
+                .filter(t -> t._1() * t._1() + t._2() * t._2() == t._3() * t._3())
+                .map(t -> t._1() * t._2() * t._3())
                 .head();
     }
 }

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler11Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler11Test.java
@@ -91,11 +91,11 @@ public class Euler11Test {
 
     private static int maxProduct() {
         return List.of(Tuple.of(0, 1), Tuple.of(1, 1), Tuple.of(1, 0), Tuple.of(1, -1))
-                .map(d -> maxProduct(d._1, d._2)).max().get();
+                .map(d -> maxProduct(d._1(), d._2())).max().get();
     }
 
     private static int maxProduct(int dr, int dc) {
-        return range(dr).crossProduct(range(dc)).map(rc -> product(rc._1, rc._2, dr, dc)).max().get();
+        return range(dr).crossProduct(range(dc)).map(rc -> product(rc._1(), rc._2(), dr, dc)).max().get();
     }
 
     private static List<Integer> range(int d) {

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler17Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler17Test.java
@@ -58,8 +58,8 @@ public class Euler17Test {
         List.of("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen", "twenty", "twentyone")
                 .zipWithIndex()
                 .forEach(t -> {
-                    final int number = t._2 + 1;
-                    final String numberAsString = t._1;
+                    final int number = t._2() + 1;
+                    final String numberAsString = t._1();
                     assertThat(numberAsString).hasSize(solution.letterCount(number));
                 });
 
@@ -150,12 +150,12 @@ public class Euler17Test {
 
         private static String asText(int number) {
             return LENGTHS.foldRight(Tuple.of(Vector.<String> empty(), number), (magnitudeAndText, lengthsAndRemainder) -> {
-                final int magnitude = magnitudeAndText._1;
-                final int remainder = lengthsAndRemainder._2;
+                final int magnitude = magnitudeAndText._1();
+                final int remainder = lengthsAndRemainder._2();
 
-                return ((remainder >= magnitude) && (remainder > 0)) ? asText(magnitude, magnitudeAndText._2, lengthsAndRemainder._1, remainder)
+                return ((remainder >= magnitude) && (remainder > 0)) ? asText(magnitude, magnitudeAndText._2(), lengthsAndRemainder._1(), remainder)
                                                                      : lengthsAndRemainder;
-            })._1.mkString();
+            })._1().mkString();
         }
 
         private static Tuple2<Vector<String>, Integer> asText(int magnitude, String text, Vector<String> chunks, int remainder) {

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler19Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler19Test.java
@@ -60,7 +60,7 @@ public class Euler19Test {
     private static int findNumberOfFirstMonthDaysOnSunday(int startYear, int endYear) {
         return For(List.rangeClosed(startYear, endYear), List.of(Month.values()))
                 .yield(Tuple::of)
-                .filter(t -> isFirstDayOfMonthSunday(t._1, t._2))
+                .filter(t -> isFirstDayOfMonthSunday(t._1(), t._2()))
                 .length();
     }
 

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler21Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler21Test.java
@@ -48,8 +48,8 @@ public class Euler21Test {
     private static int sumOfDivisors(int n) {
         return 1 + Stream.rangeClosed(2, (int) Math.sqrt(n))
                 .map(d -> Tuple.of(d, n / d))
-                .filter(t -> t._1 * t._2 == n && !Objects.equals(t._1, t._2))
-                .map(t -> t._1 + t._2)
+                .filter(t -> t._1() * t._2() == n && !Objects.equals(t._1(), t._2()))
+                .map(t -> t._1() + t._2())
                 .foldLeft(0, (sum, x) -> sum + x);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler22Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler22Test.java
@@ -64,7 +64,7 @@ public class Euler22Test {
                 .flatMap(l -> Stream.of(l.split(",")))
                 .sorted()
                 .zipWithIndex()
-                .map(t -> nameScore(t._1, t._2 + 1))
+                .map(t -> nameScore(t._1(), t._2() + 1))
                 .sum().longValue();
     }
 }

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler24Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler24Test.java
@@ -50,8 +50,8 @@ public class Euler24Test {
     public void shouldSolveProblem24() {
         List.of("012", "021", "102", "120", "201", "210").zipWithIndex()
                 .forEach(p -> {
-                    assertThat(lexicographicPermutationNaive(List.of("1", "0", "2"), p._2 + 1)).isEqualTo(p._1);
-                    assertThat(lexicographicPermutation(List.of("1", "0", "2"), p._2 + 1)).isEqualTo(p._1);
+                    assertThat(lexicographicPermutationNaive(List.of("1", "0", "2"), p._2() + 1)).isEqualTo(p._1());
+                    assertThat(lexicographicPermutation(List.of("1", "0", "2"), p._2() + 1)).isEqualTo(p._1());
                 });
 
         assertThat(lexicographicPermutation(List.of("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"), 1_000_000)).isEqualTo("2783915460");

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler25Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler25Test.java
@@ -62,7 +62,7 @@ public class Euler25Test {
     private static int firstFibonacciTermContaining(int digits) {
         return fibonacci()
                 .zipWithIndex()
-                .find(t -> t._1.toString().length() == digits)
-                .get()._2;
+                .find(t -> t._1().toString().length() == digits)
+                .get()._2();
     }
 }

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler26Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler26Test.java
@@ -59,15 +59,15 @@ public class Euler26Test {
 
     @Test
     public void shouldSolveProblem26() {
-        assertThat(recurringCycleLengthForDivisionOf1(2)._2).isEqualTo(0);
-        assertThat(recurringCycleLengthForDivisionOf1(3)._2).isEqualTo(1);
-        assertThat(recurringCycleLengthForDivisionOf1(4)._2).isEqualTo(0);
-        assertThat(recurringCycleLengthForDivisionOf1(5)._2).isEqualTo(0);
-        assertThat(recurringCycleLengthForDivisionOf1(6)._2).isEqualTo(1);
-        assertThat(recurringCycleLengthForDivisionOf1(7)._2).isEqualTo(6);
-        assertThat(recurringCycleLengthForDivisionOf1(8)._2).isEqualTo(0);
-        assertThat(recurringCycleLengthForDivisionOf1(9)._2).isEqualTo(1);
-        assertThat(recurringCycleLengthForDivisionOf1(10)._2).isEqualTo(0);
+        assertThat(recurringCycleLengthForDivisionOf1(2)._2()).isEqualTo(0);
+        assertThat(recurringCycleLengthForDivisionOf1(3)._2()).isEqualTo(1);
+        assertThat(recurringCycleLengthForDivisionOf1(4)._2()).isEqualTo(0);
+        assertThat(recurringCycleLengthForDivisionOf1(5)._2()).isEqualTo(0);
+        assertThat(recurringCycleLengthForDivisionOf1(6)._2()).isEqualTo(1);
+        assertThat(recurringCycleLengthForDivisionOf1(7)._2()).isEqualTo(6);
+        assertThat(recurringCycleLengthForDivisionOf1(8)._2()).isEqualTo(0);
+        assertThat(recurringCycleLengthForDivisionOf1(9)._2()).isEqualTo(1);
+        assertThat(recurringCycleLengthForDivisionOf1(10)._2()).isEqualTo(0);
         assertThat(denominatorBelow1000WithTheLongetsRecurringCycleOfDecimalFractions()).isEqualTo(983);
     }
 
@@ -75,7 +75,7 @@ public class Euler26Test {
         return List.range(2, 1000)
                 .map(Euler26Test::recurringCycleLengthForDivisionOf1)
                 .maxBy(Tuple2::_2)
-                .get()._1;
+                .get()._1();
     }
 
     private static Tuple2<Integer, Integer> recurringCycleLengthForDivisionOf1(int divisor) {

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler27Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler27Test.java
@@ -68,8 +68,8 @@ public class Euler27Test {
     private static int productOfCoefficientsWithMostConsecutivePrimes(int coefficientsLowerBound, int coefficientsUpperBound) {
         final List<Integer> coefficients = List.rangeClosed(coefficientsLowerBound, coefficientsUpperBound);
         return API.For(coefficients, coefficients).yield(Tuple::of)
-                .map(c -> Tuple.of(c._1, c._2, numberOfConsecutivePrimesProducedByFormulaWithCoefficients(c._1, c._2)))
-                .fold(Tuple.of(0, 0, -1), (n, m) -> n._3 >= m._3 ? n : m)
+                .map(c -> Tuple.of(c._1(), c._2(), numberOfConsecutivePrimesProducedByFormulaWithCoefficients(c._1(), c._2())))
+                .fold(Tuple.of(0, 0, -1), (n, m) -> n._3() >= m._3() ? n : m)
                 .apply((a, b, p) -> a * b);
     }
 

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler28Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler28Test.java
@@ -59,9 +59,9 @@ public class Euler28Test {
     }
 
     private static Stream<Long> diagonalNumbersInSpiralWithSide(long maxSideLength) {
-        return Stream.iterate(Tuple.of(1, center()), t -> Tuple.of(nextSideLength(t._1), nextRoundOfCorners(t._2.last(), nextSideLength(t._1))))
-                .takeWhile(t -> t._1 <= maxSideLength)
-                .flatMap(t -> t._2);
+        return Stream.iterate(Tuple.of(1, center()), t -> Tuple.of(nextSideLength(t._1()), nextRoundOfCorners(t._2().last(), nextSideLength(t._1()))))
+                .takeWhile(t -> t._1() <= maxSideLength)
+                .flatMap(t -> t._2());
     }
 
     private static Stream<Long> center() {

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler30Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler30Test.java
@@ -65,8 +65,8 @@ public class Euler30Test {
     private static long maximalSumForPowers(int powers) {
         return Stream.from(1)
                 .map(i -> Tuple.of((long) Math.pow(10, i) - 1, List.fill(i, () -> Math.pow(9, powers)).sum().longValue()))
-                .find(t -> t._1 > t._2)
-                .map(t -> t._1).get();
+                .find(t -> t._1() > t._2())
+                .map(t -> t._1()).get();
     }
 
     private static long sumOfPowersOfDigits(int powers, long num) {

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler32Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler32Test.java
@@ -69,8 +69,8 @@ public class Euler32Test {
                                 .map(multiplier -> Tuple.of(multiplicand.mkString(), multiplier.mkString()))
                         )
                 )
-                .map(t -> Tuple.of(t._1, t._2, Long.valueOf(t._1) * Long.valueOf(t._2)))
-                .filter(t -> isPandigital(1, 9, t._1 + t._2 + Long.toString(t._3)))
+                .map(t -> Tuple.of(t._1(), t._2(), Long.valueOf(t._1()) * Long.valueOf(t._2())))
+                .filter(t -> isPandigital(1, 9, t._1() + t._2() + Long.toString(t._3())))
                 .map(Tuple3::_3)
                 .distinct()
                 .sum().longValue();

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler33Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler33Test.java
@@ -61,26 +61,26 @@ public class Euler33Test {
                 .flatMap(n -> List.rangeClosed(n + 1, 99).map(d -> Tuple.of(n, d)))
                 .filter(Euler33Test::isNonTrivialDigitCancellingFraction)
                 .fold(Tuple.of(1, 1), Euler33Test::multiplyFractions)
-                .apply(Euler33Test::simplifyFraction)._2;
+                .apply(Euler33Test::simplifyFraction)._2();
     }
 
     private static boolean isNonTrivialDigitCancellingFraction(Tuple2<Integer, Integer> fraction) {
-        return CharSeq.of(fraction._1.toString())
+        return CharSeq.of(fraction._1().toString())
                 .filter(d -> d != '0')
-                .find(d -> CharSeq.of(fraction._2.toString()).contains(d))
+                .find(d -> CharSeq.of(fraction._2().toString()).contains(d))
                 .map(d -> fractionCanBeSimplifiedByCancellingDigit(fraction, d))
                 .getOrElse(false);
     }
 
     private static boolean fractionCanBeSimplifiedByCancellingDigit(Tuple2<Integer, Integer> fraction, char d) {
-        return Tuple.of(CharSeq.of(fraction._1.toString()).remove(d), CharSeq.of(fraction._2.toString()).remove(d))
+        return Tuple.of(CharSeq.of(fraction._1().toString()).remove(d), CharSeq.of(fraction._2().toString()).remove(d))
                 .map(CharSeq::mkString, CharSeq::mkString)
                 .map(Double::valueOf, Double::valueOf)
-                .apply((d1, d2) -> fraction._1 / d1 == fraction._2 / d2);
+                .apply((d1, d2) -> fraction._1() / d1 == fraction._2() / d2);
     }
 
     private static Tuple2<Integer, Integer> multiplyFractions(Tuple2<Integer, Integer> f1, Tuple2<Integer, Integer> f2) {
-        return Tuple.of(f1._1 * f2._1, f1._2 * f2._2);
+        return Tuple.of(f1._1() * f2._1(), f1._2() * f2._2());
     }
 
     private static Tuple2<Integer, Integer> simplifyFraction(int numerator, int denominator) {

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler39Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler39Test.java
@@ -57,14 +57,14 @@ public class Euler39Test {
         return SOLUTIONS_FOR_PERIMETERS_UP_TO_1000
                 .map((perimeter, listOfSolutions) -> Tuple.of(perimeter, listOfSolutions.length()))
                 .maxBy(Tuple2::_2)
-                .get()._1;
+                .get()._1();
     }
 
     private static final Map<Integer, List<Tuple3<Integer, Integer, Integer>>> SOLUTIONS_FOR_PERIMETERS_UP_TO_1000
             = List.rangeClosed(1, 500)
             .flatMap(a -> List.rangeClosed(a, 500)
                     .map(b -> Tuple.of(a, b, hypot(a, b))))
-            .filter(t -> floor(t._3) == t._3)
+            .filter(t -> floor(t._3()) == t._3())
             .map(t -> t.map3(Double::intValue))
             .groupBy(t -> t.apply((a, b, c) -> a + b + c))
             .filterKeys(d -> d <= 1_000);

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler57Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler57Test.java
@@ -57,7 +57,7 @@ public class Euler57Test {
     private static int cnt() {
         return fractions()
                 .take(1000)
-                .filter(f -> f._1.toPlainString().length() > f._2.toPlainString().length())
+                .filter(f -> f._1().toPlainString().length() > f._2().toPlainString().length())
                 .length();
     }
 
@@ -69,6 +69,6 @@ public class Euler57Test {
      * a/b -> 1 + 1/(1 + a/b) = (a + 2b)/(a + b)
      */
     private static Tuple2<BigDecimal, BigDecimal> it(Tuple2<BigDecimal, BigDecimal> val) {
-        return Tuple.of(val._1.add(val._2.add(val._2)), val._1.add(val._2));
+        return Tuple.of(val._1().add(val._2().add(val._2())), val._1().add(val._2()));
     }
 }

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler71Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler71Test.java
@@ -50,13 +50,13 @@ public class Euler71Test {
 
     private static int left37(int maxDenominator) {
         return Stream.iterate(Tuple.of(0, 1, 1, 1), (Tuple4<Integer, Integer, Integer, Integer> t) -> {
-            final int m1 = t._1 + t._3;
-            final int m2 = t._2 + t._4;
+            final int m1 = t._1() + t._3();
+            final int m2 = t._2() + t._4();
             if (m1 * 7 >= m2 * 3) {
-                return Tuple.of(t._1, t._2, m1, m2);
+                return Tuple.of(t._1(), t._2(), m1, m2);
             } else {
-                return Tuple.of(m1, m2, t._3, t._4);
+                return Tuple.of(m1, m2, t._3(), t._4());
             }
-        }).takeWhile(t -> t._2 <= maxDenominator && t._4 <= maxDenominator).last()._1;
+        }).takeWhile(t -> t._2() <= maxDenominator && t._4() <= maxDenominator).last()._1();
     }
 }

--- a/vavr/src/test/java/io/vavr/collection/euler/Euler99Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler99Test.java
@@ -53,7 +53,7 @@ public class Euler99Test {
                 .grouped(2)
                 .map(t -> t.get(1) * Math.log(t.get(0)))
                 .zipWithIndex()
-                .reduce((t1, t2) -> t1._1 > t2._1 ? t1 : t2)
-                ._2 + 1;
+                .reduce((t1, t2) -> t1._1() > t2._1() ? t1 : t2)
+                ._2() + 1;
     }
 }

--- a/vavr/src/test/java/io/vavr/collection/euler/Sieve.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Sieve.java
@@ -39,7 +39,7 @@ final class Sieve {
     private final static List<Function3<Set<Integer>, Integer, Integer, Set<Integer>>> STEPS = List.of(
             (sieve, limit, root) -> Stream.rangeClosed(1, root).crossProduct()
                     .foldLeft(sieve, (xs, xy) ->
-                            RULES.foldLeft(xs, (ss, r) -> r.apply(xy._1, xy._2)
+                            RULES.foldLeft(xs, (ss, r) -> r.apply(xy._1(), xy._2())
                                     .filter(p -> p < limit)
                                     .map(p -> ss.contains(p) ? ss.remove(p) : ss.add(p))
                                     .getOrElse(ss)

--- a/vavr/src/test/java/io/vavr/collection/euler/Utils.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Utils.java
@@ -40,7 +40,7 @@ final class Utils {
     static final Function1<Long, Boolean> MEMOIZED_IS_PRIME = Function1.of(Utils::isPrime).memoized();
 
     static Stream<BigInteger> fibonacci() {
-        return Stream.of(BigInteger.ZERO, BigInteger.ONE).appendSelf(self -> self.zip(self.tail()).map(t -> t._1.add(t._2)));
+        return Stream.of(BigInteger.ZERO, BigInteger.ONE).appendSelf(self -> self.zip(self.tail()).map(t -> t._1().add(t._2())));
     }
 
     static BigInteger factorial(int n) {

--- a/vavr/src/test/java/io/vavr/issues/Issue2559Test.java
+++ b/vavr/src/test/java/io/vavr/issues/Issue2559Test.java
@@ -44,8 +44,8 @@ public class Issue2559Test {
     public void partitionShouldBeUnique() {
         final Set<String> fruitsToEat = HashSet.of("apple", "banana");
         final Tuple2<? extends Set<String>, ? extends Set<String>> partition = fruitsToEat.partition(this::biteAndCheck);
-        assertThat(partition._1).isEmpty();
-        assertThat(partition._2).isEqualTo(HashSet.of("apple", "banana"));
+        assertThat(partition._1()).isEmpty();
+        assertThat(partition._2()).isEqualTo(HashSet.of("apple", "banana"));
         assertThat(fruitsBeingEaten)
           .hasSize(2)
           .containsEntry("apple", new Eat(1, "apple"))


### PR DESCRIPTION
there is no need to add a serialVersionUID field, since the serialVersionUID of a record class is 0L unless explicitly declared