### PR TITLE
Fix: Missing .mapTo / .mapToVoid override on Either

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Either.java
+++ b/vavr/src/main/java/io/vavr/control/Either.java
@@ -596,6 +596,16 @@ public interface Either<L, R> extends Value<R>, Serializable {
         return isRight() ? this : (Either<L, R>) supplier.get();
     }
 
+    @Override
+    default <U> Either<L, U> mapTo(U value) {
+        return this.map(__ -> value);
+    }
+
+    @Override
+    default Either<L, Void> mapToVoid() {
+        return this.mapTo(null);
+    }
+
     /**
      * Indicates that a right-biased {@code Either} computes its value synchronously.
      *


### PR DESCRIPTION
Hey, this is just a small fix for the Either :) I missed it before 🙈 