### PR TITLE
Added the serialization proxy pattern to HashMap

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/HashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/HashSet.java
@@ -37,6 +37,7 @@ import org.jspecify.annotations.NonNull;
  */
 public final class HashSet<T> implements Set<T>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final HashSet<?> EMPTY = new HashSet<>(HashArrayMappedTrie.empty());
@@ -1117,6 +1118,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
      *
      * @return A SerializationProxy for this enclosing class.
      */
+    @Serial
     private Object writeReplace() {
         return new SerializationProxy<>(this.tree);
     }
@@ -1129,6 +1131,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
      * @param stream An object serialization stream.
      * @throws java.io.InvalidObjectException This method will throw with the message "Proxy required".
      */
+    @Serial
     private void readObject(ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }
@@ -1143,6 +1146,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
     // classes. Also, it may not be compatible with circular object graphs.
     private static final class SerializationProxy<T> implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         // the instance to be serialized/deserialized
@@ -1166,6 +1170,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
          * @param s An object serialization stream.
          * @throws java.io.IOException If an error occurs writing to the stream.
          */
+        @Serial
         private void writeObject(ObjectOutputStream s) throws IOException {
             s.defaultWriteObject();
             s.writeInt(tree.size());
@@ -1182,6 +1187,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
          * @throws InvalidObjectException If the stream contains no list elements.
          * @throws IOException            If an error occurs reading from the stream.
          */
+        @Serial
         private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
             s.defaultReadObject();
             final int size = s.readInt();
@@ -1206,6 +1212,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
          *
          * @return A deserialized instance of the enclosing class.
          */
+        @Serial
         private Object readResolve() {
             return tree.isEmpty() ? HashSet.empty() : new HashSet<>(tree);
         }

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -37,6 +37,7 @@ import org.jspecify.annotations.NonNull;
  */
 public final class LinkedHashSet<T> implements Set<T>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final LinkedHashSet<?> EMPTY = new LinkedHashSet<>(LinkedHashMap.empty());
@@ -1147,6 +1148,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
      *
      * @return A SerializationProxy for this enclosing class.
      */
+    @Serial
     private Object writeReplace() {
         return new SerializationProxy<>(this.map);
     }
@@ -1159,6 +1161,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
      * @param stream An object serialization stream.
      * @throws InvalidObjectException This method will throw with the message "Proxy required".
      */
+    @Serial
     private void readObject(ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }
@@ -1173,6 +1176,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
     // classes. Also, it may not be compatible with circular object graphs.
     private static final class SerializationProxy<T> implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         // the instance to be serialized/deserialized
@@ -1196,6 +1200,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
          * @param s An object serialization stream.
          * @throws IOException If an error occurs writing to the stream.
          */
+        @Serial
         private void writeObject(ObjectOutputStream s) throws IOException {
             s.defaultWriteObject();
             s.writeInt(map.size());
@@ -1212,6 +1217,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
          * @throws InvalidObjectException If the stream contains no list elements.
          * @throws IOException            If an error occurs reading from the stream.
          */
+        @Serial
         private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
             s.defaultReadObject();
             final int size = s.readInt();
@@ -1236,6 +1242,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
          *
          * @return A deserialized instance of the enclosing class.
          */
+        @Serial
         private Object readResolve() {
             return map.isEmpty() ? LinkedHashSet.empty() : new LinkedHashSet<>(map);
         }

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -130,6 +130,7 @@ public interface List<T> extends LinearSeq<T> {
     /**
      * The serial version UID for serialization.
      */
+    @Serial
     long serialVersionUID = 1L;
 
     /**
@@ -1866,6 +1867,7 @@ public interface List<T> extends LinearSeq<T> {
      */
     final class Nil<T> implements List<T>, Serializable {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         private static final Nil<?> INSTANCE = new Nil<>();
@@ -1926,6 +1928,7 @@ public interface List<T> extends LinearSeq<T> {
          * @return The singleton instance of Nil.
          * @see java.io.Serializable
          */
+        @Serial
         private Object readResolve() {
             return INSTANCE;
         }
@@ -1939,6 +1942,7 @@ public interface List<T> extends LinearSeq<T> {
     // DEV NOTE: class declared final because of serialization proxy pattern (see Effective Java, 2nd ed., p. 315)
     final class Cons<T> implements List<T>, Serializable {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         @SuppressWarnings("serial") // Conditionally serializable
@@ -2001,6 +2005,7 @@ public interface List<T> extends LinearSeq<T> {
          *
          * @return A SerializationProxy for this enclosing class.
          */
+        @Serial
         private Object writeReplace() {
             return new SerializationProxy<>(this);
         }
@@ -2013,6 +2018,7 @@ public interface List<T> extends LinearSeq<T> {
          * @param stream An object serialization stream.
          * @throws java.io.InvalidObjectException This method will throw with the message "Proxy required".
          */
+        @Serial
         private void readObject(ObjectInputStream stream) throws InvalidObjectException {
             throw new InvalidObjectException("Proxy required");
         }
@@ -2027,6 +2033,7 @@ public interface List<T> extends LinearSeq<T> {
         // classes. Also, it may not be compatible with circular object graphs.
         private static final class SerializationProxy<T> implements Serializable {
 
+            @Serial
             private static final long serialVersionUID = 1L;
 
             // the instance to be serialized/deserialized
@@ -2050,6 +2057,7 @@ public interface List<T> extends LinearSeq<T> {
              * @param s An object serialization stream.
              * @throws java.io.IOException If an error occurs writing to the stream.
              */
+            @Serial
             private void writeObject(ObjectOutputStream s) throws IOException {
                 s.defaultWriteObject();
                 s.writeInt(list.length());
@@ -2066,6 +2074,7 @@ public interface List<T> extends LinearSeq<T> {
              * @throws InvalidObjectException If the stream contains no list elements.
              * @throws IOException            If an error occurs reading from the stream.
              */
+            @Serial
             private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
                 s.defaultReadObject();
                 final int size = s.readInt();
@@ -2090,6 +2099,7 @@ public interface List<T> extends LinearSeq<T> {
              *
              * @return A deserialized instance of the enclosing class.
              */
+            @Serial
             private Object readResolve() {
                 return list;
             }

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -117,6 +117,7 @@ public interface Stream<T> extends LinearSeq<T> {
     /**
      * The serial version UID for serialization.
      */
+    @Serial
     long serialVersionUID = 1L;
 
     /**
@@ -1877,6 +1878,7 @@ public interface Stream<T> extends LinearSeq<T> {
      */
     final class Empty<T> implements Stream<T>, Serializable {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         private static final Empty<?> INSTANCE = new Empty<>();
@@ -1937,6 +1939,7 @@ public interface Stream<T> extends LinearSeq<T> {
          * @return The singleton instance of Nil.
          * @see java.io.Serializable
          */
+        @Serial
         private Object readResolve() {
             return INSTANCE;
         }
@@ -1949,6 +1952,7 @@ public interface Stream<T> extends LinearSeq<T> {
      */
     abstract class Cons<T> implements Stream<T> {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         @SuppressWarnings("serial") // Conditionally serializable
@@ -2012,6 +2016,7 @@ interface StreamModule {
 
     final class ConsImpl<T> extends Cons<T> implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         ConsImpl(T head, Supplier<Stream<T>> tail) {
@@ -2023,10 +2028,12 @@ interface StreamModule {
             return tail.get();
         }
 
+        @Serial
         private Object writeReplace() {
             return new SerializationProxy<>(this);
         }
 
+        @Serial
         private void readObject(ObjectInputStream stream) throws InvalidObjectException {
             throw new InvalidObjectException("Proxy required");
         }
@@ -2034,6 +2041,7 @@ interface StreamModule {
 
     final class AppendElements<T> extends Cons<T> implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         private final io.vavr.collection.Queue<T> queue;
@@ -2070,10 +2078,12 @@ interface StreamModule {
             }
         }
 
+        @Serial
         private Object writeReplace() {
             return new SerializationProxy<>(this);
         }
 
+        @Serial
         private void readObject(ObjectInputStream stream) throws InvalidObjectException {
             throw new InvalidObjectException("Proxy required");
         }
@@ -2089,6 +2099,7 @@ interface StreamModule {
     // classes. Also, it may not be compatible with circular object graphs.
     final class SerializationProxy<T> implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         // the instance to be serialized/deserialized
@@ -2112,6 +2123,7 @@ interface StreamModule {
          * @param s An object serialization stream.
          * @throws java.io.IOException If an error occurs writing to the stream.
          */
+        @Serial
         private void writeObject(ObjectOutputStream s) throws IOException {
             s.defaultWriteObject();
             s.writeInt(stream.length());
@@ -2128,6 +2140,7 @@ interface StreamModule {
          * @throws InvalidObjectException If the stream contains no stream elements.
          * @throws IOException            If an error occurs reading from the stream.
          */
+        @Serial
         private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
             s.defaultReadObject();
             final int size = s.readInt();
@@ -2153,6 +2166,7 @@ interface StreamModule {
          *
          * @return A deserialized instance of the enclosing class.
          */
+        @Serial
         private Object readResolve() {
             return stream;
         }

--- a/vavr/src/main/java/io/vavr/collection/Tree.java
+++ b/vavr/src/main/java/io/vavr/collection/Tree.java
@@ -41,6 +41,7 @@ import static io.vavr.collection.Tree.Order.PRE_ORDER;
  */
 public interface Tree<T> extends Traversable<T>, Serializable {
 
+    @Serial
     long serialVersionUID = 1L;
 
     /**
@@ -871,6 +872,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      */
     final class Node<T> implements Tree<T>, Serializable {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         @SuppressWarnings("serial") // Conditionally serializable
@@ -990,6 +992,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
          *
          * @return A SerializationProxy for this enclosing class.
          */
+        @Serial
         private Object writeReplace() {
             return new SerializationProxy<>(this);
         }
@@ -1002,6 +1005,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
          * @param stream An object serialization stream.
          * @throws java.io.InvalidObjectException This method will throw with the message "Proxy required".
          */
+        @Serial
         private void readObject(ObjectInputStream stream) throws InvalidObjectException {
             throw new InvalidObjectException("Proxy required");
         }
@@ -1016,6 +1020,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
         // classes. Also, it may not be compatible with circular object graphs.
         private static final class SerializationProxy<T> implements Serializable {
 
+            @Serial
             private static final long serialVersionUID = 1L;
 
             // the instance to be serialized/deserialized
@@ -1039,6 +1044,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
              * @param s An object serialization stream.
              * @throws java.io.IOException If an error occurs writing to the stream.
              */
+            @Serial
             private void writeObject(ObjectOutputStream s) throws IOException {
                 s.defaultWriteObject();
                 s.writeObject(node.value);
@@ -1052,6 +1058,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
              * @throws ClassNotFoundException If the object's class read from the stream cannot be found.
              * @throws IOException            If an error occurs reading from the stream.
              */
+            @Serial
             @SuppressWarnings("unchecked")
             private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
                 s.defaultReadObject();
@@ -1069,6 +1076,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
              *
              * @return A deserialized instance of the enclosing class.
              */
+            @Serial
             private Object readResolve() {
                 return node;
             }
@@ -1082,6 +1090,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
      */
     final class Empty<T> implements Tree<T>, Serializable {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         private static final Empty<?> INSTANCE = new Empty<>();
@@ -1156,6 +1165,7 @@ public interface Tree<T> extends Traversable<T>, Serializable {
          * @return The singleton instance of Nil.
          * @see java.io.Serializable
          */
+        @Serial
         private Object readResolve() {
             return INSTANCE;
         }


### PR DESCRIPTION
HashMap was using default Java serialization, which serialized the internal `HashArrayMappedTrie` structure including the pre-computed hash values of keys. 

For keys like enums that use `Object.hashCode()` (non-deterministic across JVM restarts), these stored hash values would differ in another process, causing lookups to fail.
                                                                                                                                       

fixes https://github.com/vavr-io/vavr/issues/3011