### PR TITLE
fix: make Iterator.head() non-destructive to fix Traversable contract (#2936)

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/AbstractIterator.java
+++ b/vavr/src/main/java/io/vavr/collection/AbstractIterator.java
@@ -31,6 +31,14 @@ import java.util.NoSuchElementException;
  */
 abstract class AbstractIterator<T> implements Iterator<T> {
 
+    /**
+     * Peek buffer: when {@code hasPeeked} is true, {@code peeked} holds an element that
+     * was read via {@link #getNext()} but not yet consumed by an external {@link #next()}
+     * call. This allows {@link #head()} to be non-destructive.
+     */
+    private T peeked;
+    private boolean hasPeeked = false;
+
     @Override
     public String toString() {
         return stringPrefix() + "(" + (isEmpty() ? "" : "?") + ")";
@@ -40,9 +48,54 @@ abstract class AbstractIterator<T> implements Iterator<T> {
 
     @Override
     public final T next() {
+        if (hasPeeked) {
+            T result = peeked;
+            peeked = null;
+            hasPeeked = false;
+            return result;
+        }
         if (!hasNext()) {
             throw new NoSuchElementException("next() on empty iterator");
         }
         return getNext();
+    }
+
+    /**
+     * Returns the first element of this iterator without advancing it, so that a
+     * subsequent call to {@link #tail()} correctly skips only the first element and
+     * not the second.
+     *
+     * <p>Fixes the {@code Traversable} contract violation where:
+     * <pre>{@code
+     *   Iterator<Integer> it = Iterator.of(0, 1, 2, 3);
+     *   it.head();              // must return 0
+     *   it = it.tail();         // must position iterator at 1
+     *   it.head();              // must return 1
+     * }</pre>
+     */
+    @Override
+    public T head() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("head() on empty iterator");
+        }
+        if (!hasPeeked) {
+            peeked = getNext();
+            hasPeeked = true;
+        }
+        return peeked;
+    }
+
+    /**
+     * Returns this iterator positioned after the first element. If {@link #head()} was
+     * previously called (peeked), the peeked value is discarded; otherwise the first
+     * element is consumed by calling {@link #next()}.
+     */
+    @Override
+    public Iterator<T> tail() {
+        if (!hasNext()) {
+            throw new UnsupportedOperationException("tail() on empty iterator");
+        }
+        next(); // drains either the peek buffer or the real next element
+        return this;
     }
 }

--- a/vavr/src/test/java/io/vavr/collection/IteratorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/IteratorTest.java
@@ -949,4 +949,31 @@ public class IteratorTest extends AbstractTraversableTest {
         assertThat(of(1, 2, 3).isSequential()).isTrue();
     }
 
+    // -- head() / tail() Traversable contract
+
+    @Test
+    public void shouldHeadNotAdvanceIteratorSoTailSkipsCorrectElement() {
+        Iterator<Integer> it = of(0, 1, 2, 3);
+        assertThat(it.head()).isEqualTo(0);
+        it = it.tail(); // should skip only 0
+        assertThat(it.head()).isEqualTo(1);
+        it = it.tail(); // should skip only 1
+        assertThat(it.head()).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldHeadReturnSameValueOnRepeatedCalls() {
+        Iterator<Integer> it = of(10, 20, 30);
+        assertThat(it.head()).isEqualTo(10);
+        assertThat(it.head()).isEqualTo(10);
+        assertThat(it.head()).isEqualTo(10);
+    }
+
+    @Test
+    public void shouldTailWithoutPriorHeadCallSkipFirstElement() {
+        Iterator<Integer> it = of(0, 1, 2);
+        it = it.tail();
+        assertThat(it.head()).isEqualTo(1);
+    }
+
 }


### PR DESCRIPTION
## Problem

`Iterator.head()` violated the `Traversable` contract by consuming the first element via `next()`. This meant that:

```java
Iterator<Integer> it = Iterator.of(0, 1, 2, 3);
it.head();        // returns 0, but also advances the iterator
it = it.tail();   // skips 1 (wrong!), because head() already consumed 0
it.head();        // returns 2, not 1
```

The expected behaviour per `Traversable` semantics is that `head()` is non-destructive — calling `head()` repeatedly should always return the same element, and `tail()` should skip exactly one element regardless of whether `head()` was called.

Fixes #2936.

## Solution

Introduced a **peek buffer** (`peeked` / `hasPeeked`) in `AbstractIterator`:

- `head()` calls `getNext()` once and stores the result in the buffer; subsequent calls return the same buffered value.
- `next()` drains the peek buffer first before calling `getNext()`.
- `tail()` calls `next()`, which correctly drains either the peeked element or the real next element.

`getNext()` (the abstract method subclasses implement) is unchanged — existing `AbstractIterator` subclasses are unaffected.

## Tests

Three new regression tests added to `IteratorTest`:

| Test | Verifies |
|------|----------|
| `shouldHeadNotAdvanceIteratorSoTailSkipsCorrectElement` | `head()+tail()` chaining respects element order |
| `shouldHeadReturnSameValueOnRepeatedCalls` | repeated `head()` always returns same element |
| `shouldTailWithoutPriorHeadCallSkipFirstElement` | `tail()` without prior `head()` still skips exactly one element |