### PR TITLE
Annotate Option's generic parameter as @NonNull

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -57,7 +57,7 @@ public interface Option<T> extends Value<T>, Serializable {
      * @param <T>   the value type
      * @return {@code Some(value)} if the value is non-null, otherwise {@code None}
      */
-    static <T> Option<T> of(T value) {
+    static <T> Option<@NonNull T> of(T value) {
         return (value == null) ? none() : some(value);
     }
 


### PR DESCRIPTION
This is a trivial change, but a game-changer when trying to avoid nullability warnings.