### PR TITLE
fix Queue#flatMap ordering issue

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -907,7 +907,7 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
         if (isEmpty()) {
             return empty();
         } else {
-            return new Queue<>(front.flatMap(mapper), rear.flatMap(mapper));
+            return new Queue<>(toList().flatMap(mapper), io.vavr.collection.List.empty());
         }
     }
 

--- a/vavr/src/test/java/io/vavr/collection/QueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/QueueTest.java
@@ -467,4 +467,15 @@ public class QueueTest extends AbstractLinearSeqTest {
     public void shouldReturnSizeWhenSpliterator() {
         assertThat(of(1, 2, 3).spliterator().getExactSizeIfKnown()).isEqualTo(3);
     }
+
+    // -- flatMap
+
+    @Test
+    public void shouldFlatMapCorrectlyWhenRearIsNonEmpty() {
+        Queue<Integer> queue = Queue.of(1, 2).enqueue(3).enqueue(4);
+
+        Queue<Integer> result = queue.flatMap(x -> Queue.of(x, x * 10));
+
+        assertThat(result).isEqualTo(Queue.of(1, 10, 2, 20, 3, 30, 4, 40));
+    }
 }


### PR DESCRIPTION
Queue#flatMap produced incorrectly ordered results when the queue had elements in its internal rear list