### PR TITLE
fix Queue#replace violating first-occurrence-only semantics

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/Queue.java
+++ b/vavr/src/main/java/io/vavr/collection/Queue.java
@@ -1200,10 +1200,15 @@ public final class Queue<T> extends AbstractQueue<T, Queue<T>> implements Linear
     @Override
     public Queue<T> replace(T currentElement, T newElement) {
         final io.vavr.collection.List<T> newFront = front.replace(currentElement, newElement);
-        final io.vavr.collection.List<T> newRear = rear.replace(currentElement, newElement);
-        return newFront.size() + newRear.size() == 0 ? empty()
-                                                     : newFront == front && newRear == rear ? this
-                                                                                            : new Queue<>(newFront, newRear);
+        if (newFront != front) {
+            return new Queue<>(newFront, rear);
+        }
+        final io.vavr.collection.List<T> rearInOrder = rear.reverse();
+        final io.vavr.collection.List<T> newRearInOrder = rearInOrder.replace(currentElement, newElement);
+        if (newRearInOrder == rearInOrder) {
+            return this;
+        }
+        return new Queue<>(front, newRearInOrder.reverse());
     }
 
     @Override

--- a/vavr/src/test/java/io/vavr/collection/QueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/QueueTest.java
@@ -467,4 +467,15 @@ public class QueueTest extends AbstractLinearSeqTest {
     public void shouldReturnSizeWhenSpliterator() {
         assertThat(of(1, 2, 3).spliterator().getExactSizeIfKnown()).isEqualTo(3);
     }
+
+    // -- replace
+
+    @Test
+    public void shouldReplaceOnlyFirstOccurrenceWhenRearIsNonEmpty() {
+        Queue<Integer> queue = Queue.of(1, 2, 3).enqueue(3);
+
+        Queue<Integer> result = queue.replace(3, 42);
+
+        assertThat(result).isEqualTo(Queue.of(1, 2, 42, 3));
+    }
 }


### PR DESCRIPTION
The old implementation independently called replace on both front and rear, causing up to two replacements instead of one.