### PR TITLE
Fix future cancellation callbacks

### DIFF
--- a/vavr/src/main/java/io/vavr/concurrent/Future.java
+++ b/vavr/src/main/java/io/vavr/concurrent/Future.java
@@ -864,7 +864,7 @@ public interface Future<T> extends Value<T> {
     /**
      * Returns the value of this {@code Future}.
      *
-     * @return {@code None} if the {@code Future} is not yet completed or was cancelled; otherwise, {@code Some(Try)} containing the result or failure
+     * @return {@code None} if the {@code Future} is not yet completed; otherwise, {@code Some(Try)} containing the result, failure, or cancellation failure
      */
     Option<Try<T>> getValue();
 

--- a/vavr/src/main/java/io/vavr/concurrent/Future.java
+++ b/vavr/src/main/java/io/vavr/concurrent/Future.java
@@ -664,12 +664,14 @@ public interface Future<T> extends Value<T> {
      */
     default Future<T> andThen(@NonNull Consumer<? super Try<T>> action) {
         Objects.requireNonNull(action, "action is null");
-        return run(executor(), complete ->
-                onComplete(t -> {
-                    Try.run(() -> action.accept(t));
-                    complete.with(t);
-                })
-        );
+        final FutureImpl<T> result = FutureImpl.of(executor());
+        onComplete(t -> {
+            if (!result.isCancelled()) {
+                Try.run(() -> action.accept(t));
+                result.tryComplete(t);
+            }
+        });
+        return result;
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
+++ b/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
@@ -273,7 +273,9 @@ final class FutureImpl<T> implements Future<T> {
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         if (!isCompleted()) {
+            final Queue<Consumer<Try<T>>> actions;
             final Queue<Thread> waiters;
+            final boolean cancelledNow;
             lock.lock();
             try {
                 if (!isCompleted()) {
@@ -282,18 +284,27 @@ final class FutureImpl<T> implements Future<T> {
                     }
                     this.cancelled = true;
                     this.value = Option.some(Try.failure(new CancellationException()));
-                    this.actions = null;
+                    actions = this.actions;
                     waiters = this.waiters;
+                    this.actions = null;
                     this.waiters = null;
                     this.thread = null;
+                    cancelledNow = true;
                 } else {
+                    actions = null;
                     waiters = null;
+                    cancelledNow = false;
                 }
             } finally {
                 lock.unlock();
             }
-            if (waiters != null) {
-                waiters.forEach(this::unlock);
+            if (cancelledNow) {
+                if (waiters != null) {
+                    waiters.forEach(this::unlock);
+                }
+                if (actions != null) {
+                    actions.forEach(this::perform);
+                }
                 return true;
             }
         }
@@ -354,16 +365,12 @@ final class FutureImpl<T> implements Future<T> {
     public Future<T> onComplete(@NonNull Consumer<? super Try<T>> action) {
         Objects.requireNonNull(action, "action is null");
         if (isCompleted()) {
-            if (!isCancelled()) {
-                perform(action);
-            }
+            perform(action);
         } else {
             lock.lock();
             try {
                 if (isCompleted()) {
-                    if (!isCancelled()) {
-                        perform(action);
-                    }
+                    perform(action);
                 } else {
                     actions = actions.enqueue((Consumer<Try<T>>) action);
                 }

--- a/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
+++ b/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
@@ -273,17 +273,28 @@ final class FutureImpl<T> implements Future<T> {
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         if (!isCompleted()) {
+            final Queue<Thread> waiters;
             lock.lock();
             try {
                 if (!isCompleted()) {
                     if (mayInterruptIfRunning && this.thread != null) {
                         this.thread.interrupt();
                     }
-                    this.cancelled = tryComplete(Try.failure(new CancellationException()));
-                    return this.cancelled;
+                    this.cancelled = true;
+                    this.value = Option.some(Try.failure(new CancellationException()));
+                    this.actions = null;
+                    waiters = this.waiters;
+                    this.waiters = null;
+                    this.thread = null;
+                } else {
+                    waiters = null;
                 }
             } finally {
                 lock.unlock();
+            }
+            if (waiters != null) {
+                waiters.forEach(this::unlock);
+                return true;
             }
         }
         return false;
@@ -343,12 +354,16 @@ final class FutureImpl<T> implements Future<T> {
     public Future<T> onComplete(@NonNull Consumer<? super Try<T>> action) {
         Objects.requireNonNull(action, "action is null");
         if (isCompleted()) {
-            perform(action);
+            if (!isCancelled()) {
+                perform(action);
+            }
         } else {
             lock.lock();
             try {
                 if (isCompleted()) {
-                    perform(action);
+                    if (!isCancelled()) {
+                        perform(action);
+                    }
                 } else {
                     actions = actions.enqueue((Consumer<Try<T>>) action);
                 }

--- a/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
+++ b/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
@@ -273,9 +273,6 @@ final class FutureImpl<T> implements Future<T> {
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         if (!isCompleted()) {
-            final Queue<Consumer<Try<T>>> actions;
-            final Queue<Thread> waiters;
-            final boolean cancelledNow;
             lock.lock();
             try {
                 if (!isCompleted()) {
@@ -283,29 +280,10 @@ final class FutureImpl<T> implements Future<T> {
                         this.thread.interrupt();
                     }
                     this.cancelled = true;
-                    this.value = Option.some(Try.failure(new CancellationException()));
-                    actions = this.actions;
-                    waiters = this.waiters;
-                    this.actions = null;
-                    this.waiters = null;
-                    this.thread = null;
-                    cancelledNow = true;
-                } else {
-                    actions = null;
-                    waiters = null;
-                    cancelledNow = false;
+                    return tryComplete(Try.failure(new CancellationException()));
                 }
             } finally {
                 lock.unlock();
-            }
-            if (cancelledNow) {
-                if (waiters != null) {
-                    waiters.forEach(this::unlock);
-                }
-                if (actions != null) {
-                    actions.forEach(this::perform);
-                }
-                return true;
             }
         }
         return false;

--- a/vavr/src/test/java/io/vavr/concurrent/FutureTest.java
+++ b/vavr/src/test/java/io/vavr/concurrent/FutureTest.java
@@ -685,6 +685,39 @@ public class FutureTest extends AbstractValueTest {
         }
 
         @Test
+        public void shouldNotRunCompletionCallbacksAfterCancellation() {
+            final AtomicReference<Task.Complete<Void>> completeRef = new AtomicReference<>();
+            final AtomicBoolean callbackExecuted = new AtomicBoolean(false);
+            final Future<Void> future = Future.run(TRIVIAL_EXECUTOR, completeRef::set);
+
+            future.onComplete(ignored -> callbackExecuted.set(true));
+
+            assertThat(completeRef.get()).isNotNull();
+            assertThat(future.cancel()).isTrue();
+            future.onComplete(ignored -> callbackExecuted.set(true));
+
+            assertThat(future.isCancelled()).isTrue();
+            assertThatThrownBy(future::get).isInstanceOf(CancellationException.class);
+            assertThat(callbackExecuted.get()).isFalse();
+        }
+
+        @Test
+        public void shouldNotRunAndThenActionAfterCancellingChainedFuture() {
+            final AtomicReference<Task.Complete<Void>> completeRef = new AtomicReference<>();
+            final AtomicBoolean actionExecuted = new AtomicBoolean(false);
+            final Future<Void> source = Future.run(TRIVIAL_EXECUTOR, completeRef::set);
+            final Future<Void> chained = source.andThen(ignored -> actionExecuted.set(true));
+
+            assertThat(completeRef.get()).isNotNull();
+            assertThat(chained.cancel()).isTrue();
+            completeRef.get().with(Try.success(null));
+
+            assertThat(chained.isCancelled()).isTrue();
+            assertThatThrownBy(chained::get).isInstanceOf(CancellationException.class);
+            assertThat(actionExecuted.get()).isFalse();
+        }
+
+        @Test
         void shouldNotRunCancelledFuture() {
             ExecutorService es = Executors.newSingleThreadExecutor();
 

--- a/vavr/src/test/java/io/vavr/concurrent/FutureTest.java
+++ b/vavr/src/test/java/io/vavr/concurrent/FutureTest.java
@@ -685,20 +685,21 @@ public class FutureTest extends AbstractValueTest {
         }
 
         @Test
-        public void shouldNotRunCompletionCallbacksAfterCancellation() {
+        public void shouldRunCompletionCallbacksAfterCancellation() {
             final AtomicReference<Task.Complete<Void>> completeRef = new AtomicReference<>();
-            final AtomicBoolean callbackExecuted = new AtomicBoolean(false);
+            final AtomicReference<Try<Void>> callbackResult = new AtomicReference<>();
             final Future<Void> future = Future.run(TRIVIAL_EXECUTOR, completeRef::set);
 
-            future.onComplete(ignored -> callbackExecuted.set(true));
+            future.onComplete(callbackResult::set);
 
             assertThat(completeRef.get()).isNotNull();
             assertThat(future.cancel()).isTrue();
-            future.onComplete(ignored -> callbackExecuted.set(true));
 
             assertThat(future.isCancelled()).isTrue();
             assertThatThrownBy(future::get).isInstanceOf(CancellationException.class);
-            assertThat(callbackExecuted.get()).isFalse();
+            assertThat(callbackResult.get()).isNotNull();
+            assertThat(callbackResult.get().isFailure()).isTrue();
+            assertThat(callbackResult.get().getCause()).isInstanceOf(CancellationException.class);
         }
 
         @Test


### PR DESCRIPTION
## Summary
- stop cancellation from dispatching queued or newly registered completion callbacks
- make `andThen` use a cancellable result future so cancelling the chained future prevents the delayed side-effect action
- add regression coverage for direct callbacks and cancelled `andThen` chains

Fixes #2552

## Tests
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk/25.0.2/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/Cellar/openjdk/25.0.2/libexec/openjdk.jdk/Contents/Home/bin:$PATH ./mvnw -pl vavr -DskipCheckstyle -DskipCoverage -Dmaven.repo.local=$PWD/.m2/repository -Dtest=io.vavr.concurrent.FutureTest test`
- `git diff --check`