### PR TITLE
Fix Javadoc in Euler71Test

### DIFF
--- a/vavr/src/test/java/io/vavr/collection/euler/Euler71Test.java
+++ b/vavr/src/test/java/io/vavr/collection/euler/Euler71Test.java
@@ -30,7 +30,7 @@ public class Euler71Test {
     /**
      * <strong>Problem 71: Ordered fractions</strong>
      * <p>
-     * Consider the fraction, n/d, where n and d are positive integers. If n<d and HCF(n,d)=1, it is called a reduced proper fraction.
+     * Consider the fraction, n/d, where n and d are positive integers. If {@code n < d} and HCF(n,d)=1, it is called a reduced proper fraction.
      * <p>
      * If we list the set of reduced proper fractions for d ≤ 8 in ascending order of size, we get:
      * <p>


### PR DESCRIPTION
Fixes an invalid Javadoc snippet in `Euler71Test`.

The text used `n<d` directly in a Javadoc comment, which is parsed as malformed HTML because of the raw `<` character. This wraps the expression in `{@code ...}`.

Detected by Checkstyle diff report:
https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/927e1b3_2026093916/reports/diff/Vavr/index.html#A1

Detected violation:
`Javadoc comment at column 7 has parse error. Details: token recognition error at: '<' while parsing`