### PR TITLE
O(1) LinkedHashMap/LinkedHashSet#put() for existing keys

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -49,10 +49,10 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     private static final LinkedHashMap<?, ?> EMPTY = new LinkedHashMap<>(Queue.empty(), HashMap.empty());
 
-    private final Queue<Tuple2<K, V>> list;
+    private final Queue<K> list;
     private final HashMap<K, V> map;
 
-    private LinkedHashMap(Queue<Tuple2<K, V>> list, HashMap<K, V> map) {
+    private LinkedHashMap(Queue<K> list, HashMap<K, V> map) {
         this.list = list;
         this.map = map;
     }
@@ -148,7 +148,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> LinkedHashMap<K, V> of(@NonNull Tuple2<? extends K, ? extends V> entry) {
         final HashMap<K, V> map = HashMap.of(entry);
-        final Queue<Tuple2<K, V>> list = Queue.of((Tuple2<K, V>) entry);
+        final Queue<K> list = Queue.of(((Tuple2<K, V>) entry)._1);
         return wrap(list, map);
     }
 
@@ -212,7 +212,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K key, V value) {
         final HashMap<K, V> map = HashMap.of(key, value);
-        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(key, value));
+        final Queue<K> list = Queue.of(key);
         return wrap(list, map);
     }
 
@@ -229,7 +229,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2);
-        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2));
+        final Queue<K> list = Queue.of(k1, k2);
         return wrapNonUnique(list, map);
     }
 
@@ -248,7 +248,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3);
-        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3));
+        final Queue<K> list = Queue.of(k1, k2, k3);
         return wrapNonUnique(list, map);
     }
 
@@ -269,7 +269,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4);
-        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4));
+        final Queue<K> list = Queue.of(k1, k2, k3, k4);
         return wrapNonUnique(list, map);
     }
 
@@ -292,7 +292,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5);
-        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5));
+        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5);
         return wrapNonUnique(list, map);
     }
 
@@ -317,7 +317,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6);
-        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5), Tuple.of(k6, v6));
+        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5, k6);
         return wrapNonUnique(list, map);
     }
 
@@ -344,7 +344,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7);
-        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5), Tuple.of(k6, v6), Tuple.of(k7, v7));
+        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5, k6, k7);
         return wrapNonUnique(list, map);
     }
 
@@ -373,7 +373,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8);
-        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5), Tuple.of(k6, v6), Tuple.of(k7, v7), Tuple.of(k8, v8));
+        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5, k6, k7, k8);
         return wrapNonUnique(list, map);
     }
 
@@ -404,7 +404,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9);
-        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5), Tuple.of(k6, v6), Tuple.of(k7, v7), Tuple.of(k8, v8), Tuple.of(k9, v9));
+        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5, k6, k7, k8, k9);
         return wrapNonUnique(list, map);
     }
 
@@ -437,7 +437,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
-        final Queue<Tuple2<K, V>> list = Queue.of(Tuple.of(k1, v1), Tuple.of(k2, v2), Tuple.of(k3, v3), Tuple.of(k4, v4), Tuple.of(k5, v5), Tuple.of(k6, v6), Tuple.of(k7, v7), Tuple.of(k8, v8), Tuple.of(k9, v9), Tuple.of(k10, v10));
+        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5, k6, k7, k8, k9, k10);
         return wrapNonUnique(list, map);
     }
 
@@ -485,11 +485,10 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> LinkedHashMap<K, V> ofEntries(java.util.Map.@NonNull Entry<? extends K, ? extends V> @NonNull ... entries) {
         HashMap<K, V> map = HashMap.empty();
-        Queue<Tuple2<K, V>> list = Queue.empty();
+        Queue<K> list = Queue.empty();
         for (java.util.Map.Entry<? extends K, ? extends V> entry : entries) {
-            final Tuple2<K, V> tuple = Tuple.of(entry.getKey(), entry.getValue());
-            map = map.put(tuple);
-            list = list.append(tuple);
+            map = map.put(entry.getKey(), entry.getValue());
+            list = list.append(entry.getKey());
         }
         return wrapNonUnique(list, map);
     }
@@ -505,7 +504,10 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> LinkedHashMap<K, V> ofEntries(@NonNull Tuple2<? extends K, ? extends V> @NonNull ... entries) {
         final HashMap<K, V> map = HashMap.ofEntries(entries);
-        final Queue<Tuple2<K, V>> list = Queue.of((Tuple2<K, V>[]) entries);
+        Queue<K> list = Queue.empty();
+        for (Tuple2<? extends K, ? extends V> entry : entries) {
+            list = list.append(entry._1);
+        }
         return wrapNonUnique(list, map);
     }
 
@@ -524,10 +526,10 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
             return (LinkedHashMap<K, V>) entries;
         } else {
             HashMap<K, V> map = HashMap.empty();
-            Queue<Tuple2<K, V>> list = Queue.empty();
+            Queue<K> list = Queue.empty();
             for (Tuple2<? extends K, ? extends V> entry : entries) {
                 map = map.put(entry);
-                list = list.append((Tuple2<K, V>) entry);
+                list = list.append(entry._1);
             }
             return wrapNonUnique(list, map);
         }
@@ -664,7 +666,8 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public Tuple2<K, V> head() {
-        return list.head();
+        final K key = list.head();
+        return Tuple.of(key, map.get(key).get());
     }
 
     @Override
@@ -672,7 +675,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         if (isEmpty()) {
             throw new UnsupportedOperationException("init of empty LinkedHashMap");
         } else {
-            return LinkedHashMap.ofEntries(list.init());
+            return wrap(list.init(), map.remove(list.last()));
         }
     }
 
@@ -713,41 +716,17 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public @NonNull Iterator<Tuple2<K, V>> iterator() {
-        return list.iterator();
+        return list.iterator().map(key -> Tuple.of(key, map.get(key).get()));
     }
 
     @Override
     public Iterator<K> keysIterator() {
-        return new Iterator<>() {
-            private final Iterator<Tuple2<K, V>> it = list.iterator();
-
-            @Override
-            public boolean hasNext() {
-                return it.hasNext();
-            }
-
-            @Override
-            public K next() {
-                return it.next()._1;
-            }
-        };
+        return list.iterator();
     }
 
     @Override
     public Iterator<V> valuesIterator() {
-        return new Iterator<>() {
-            private final Iterator<Tuple2<K, V>> it = list.iterator();
-
-            @Override
-            public boolean hasNext() {
-                return it.hasNext();
-            }
-
-            @Override
-            public V next() {
-                return it.next()._2;
-            }
-        };
+        return list.iterator().map(key -> map.get(key).get());
     }
 
     @SuppressWarnings("unchecked")
@@ -758,7 +737,8 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public Tuple2<K, V> last() {
-        return list.last();
+        final K key = list.last();
+        return Tuple.of(key, map.get(key).get());
     }
 
     @Override
@@ -825,7 +805,9 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      * If the map previously contained a mapping for the key, the old value is
      * replaced by the specified value.
      * <p>
-     * Note that this method has a worst-case linear complexity.
+     * Overwriting an existing key runs in (amortized) constant time, since the
+     * insertion-order structure is left untouched; inserting a new key appends
+     * to it in (amortized) constant time as well.
      *
      * @param key   key with which the specified value is to be associated
      * @param value value to be associated with the specified key
@@ -833,14 +815,9 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     @Override
     public LinkedHashMap<K, V> put(K key, V value) {
-        final Queue<Tuple2<K, V>> newList;
-        final Option<V> currentEntry = get(key);
-        if (currentEntry.isDefined()) {
-            newList = list.replace(Tuple.of(key, currentEntry.get()), Tuple.of(key, value));
-        } else {
-            newList = list.append(Tuple.of(key, value));
-        }
+        final boolean containsKey = map.containsKey(key);
         final HashMap<K, V> newMap = map.put(key, value);
+        final Queue<K> newList = containsKey ? list : list.append(key);
         return wrap(newList, newMap);
     }
 
@@ -858,7 +835,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @Override
     public LinkedHashMap<K, V> remove(K key) {
         if (containsKey(key)) {
-            final Queue<Tuple2<K, V>> newList = list.removeFirst(t -> Objects.equals(t._1, key));
+            final Queue<K> newList = list.removeFirst(k -> Objects.equals(k, key));
             final HashMap<K, V> newMap = map.remove(key);
             return wrap(newList, newMap);
         } else {
@@ -877,7 +854,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public LinkedHashMap<K, V> removeAll(@NonNull Iterable<? extends K> keys) {
         Objects.requireNonNull(keys, "keys is null");
         final HashSet<K> toRemove = HashSet.ofAll(keys);
-        final Queue<Tuple2<K, V>> newList = list.filter(t -> !toRemove.contains(t._1));
+        final Queue<K> newList = list.filter(k -> !toRemove.contains(k));
         final HashMap<K, V> newMap = map.filter(t -> !toRemove.contains(t._1));
         return newList.size() == size() ? this : wrap(newList, newMap);
     }
@@ -904,22 +881,19 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         // We replace the whole element, i.e. key and value have to be present.
         if (!Objects.equals(currentElement, newElement) && contains(currentElement)) {
 
-            Queue<Tuple2<K, V>> newList = list;
+            Queue<K> newList = list;
             HashMap<K, V> newMap = map;
 
             final K currentKey = currentElement._1;
             final K newKey = newElement._1;
 
-            // If current key and new key are equal, the element will be automatically replaced,
-            // otherwise we need to remove the pair (newKey, ?) from the list manually.
-            if (!Objects.equals(currentKey, newKey)) {
-                final Option<V> value = newMap.get(newKey);
-                if (value.isDefined()) {
-                    newList = newList.remove(Tuple.of(newKey, value.get()));
-                }
+            // If current key and new key are equal, the key keeps its position,
+            // otherwise we need to remove an already present newKey from the order manually.
+            if (!Objects.equals(currentKey, newKey) && newMap.containsKey(newKey)) {
+                newList = newList.remove(newKey);
             }
 
-            newList = newList.replace(currentElement, newElement);
+            newList = newList.replace(currentKey, newKey);
             newMap = newMap.remove(currentKey).put(newElement);
 
             return wrap(newList, newMap);
@@ -998,7 +972,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         if (isEmpty()) {
             throw new UnsupportedOperationException("tail of empty LinkedHashMap");
         } else {
-            return wrap(list.tail(), map.remove(list.head()._1()));
+            return wrap(list.tail(), map.remove(list.head()));
         }
     }
 
@@ -1064,33 +1038,34 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     /**
      * Construct Map with given values and key order.
      *
-     * @param list The list of key-value tuples with unique keys.
+     * @param list The list of keys with unique entries.
      * @param map  The map of key-value tuples.
      * @param <K>  The key type
      * @param <V>  The value type
      * @return A new Map containing the given map with given key order
      */
-    private static <K, V> LinkedHashMap<K, V> wrap(@NonNull Queue<Tuple2<K, V>> list, HashMap<K, V> map) {
+    private static <K, V> LinkedHashMap<K, V> wrap(@NonNull Queue<K> list, HashMap<K, V> map) {
         return list.isEmpty() ? empty() : new LinkedHashMap<>(list, map);
     }
 
     /**
      * Construct Map with given values and key order.
      *
-     * @param list The list of key-value tuples with non-unique keys.
+     * @param list The list of keys with possibly non-unique entries.
      * @param map  The map of key-value tuples.
      * @param <K>  The key type
      * @param <V>  The value type
      * @return A new Map containing the given map with given key order
      */
-    private static <K, V> LinkedHashMap<K, V> wrapNonUnique(@NonNull Queue<Tuple2<K, V>> list, HashMap<K, V> map) {
+    private static <K, V> LinkedHashMap<K, V> wrapNonUnique(@NonNull Queue<K> list, HashMap<K, V> map) {
         if (list.isEmpty()) {
             return empty();
         }
         if (list.size() == map.size()) {
             return new LinkedHashMap<>(list, map);
         }
-        return new LinkedHashMap<>(list.reverse().distinctBy(Tuple2::_1).reverse().toQueue(), map);
+        // Keep the last occurrence of every key, matching the value precedence in `map`.
+        return new LinkedHashMap<>(list.reverse().distinct().reverse().toQueue(), map);
     }
 
     // We need this method to narrow the argument of `ofEntries`.

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -612,7 +612,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
     /**
      * Add the given element to this set, replacing existing one if it is already contained.
      * <p>
-     * Note that this method has a worst-case linear complexity.
+     * Note that this method runs in (amortized) constant time.
      *
      * @param element The element to be added.
      * @return A new set containing all elements of this set and also {@code element}.
@@ -625,7 +625,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
     /**
      * Adds all of the given elements to this set, replacing existing one if they are not already contained.
      * <p>
-     * Note that this method has a worst-case quadratic complexity.
+     * Note that this method has a worst-case linear complexity.
      *
      * @param elements The elements to be added.
      * @return A new set containing all elements of this set and the given {@code elements}, if not already contained.
@@ -1033,7 +1033,7 @@ public final class LinkedHashSet<T> implements Set<T>, Serializable {
     /**
      * Adds all of the elements of {@code elements} to this set, replacing existing ones if they already present.
      * <p>
-     * Note that this method has a worst-case quadratic complexity.
+     * Note that this method has a worst-case linear complexity.
      * <p>
      * See also {@link #addAll(Iterable)}.
      *

--- a/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
@@ -198,6 +198,19 @@ public class LinkedHashMapTest extends AbstractMapTest {
             final Map<Integer, String> expected = mapOf(1, "a", 2, "b", 3, "c");
             assertThat(actual.toList()).isEqualTo(expected.toList());
         }
+
+        @Test
+        public void shouldReuseOrderStructureWhenOverwritingAnExistingKey() throws Exception {
+            final LinkedHashMap<Integer, String> map = LinkedHashMap.of(1, "a", 2, "b", 3, "c");
+            final LinkedHashMap<Integer, String> actual = map.put(2, "B");
+            assertThat(orderStructureOf(actual)).isSameAs(orderStructureOf(map));
+        }
+
+        private static Object orderStructureOf(LinkedHashMap<?, ?> map) throws Exception {
+            var list = LinkedHashMap.class.getDeclaredField("list");
+            list.setAccessible(true);
+            return list.get(map);
+        }
     }
 
     @Nested


### PR DESCRIPTION
before:

```
distinct=66000 total=900000  ->  size=66000  in 178172 ms
```

after:
```
distinct=66000 total=900000  ->  size=66000  in 232 ms
```

reproducer:
```
static void shakespeareStyleWorkload() {
    int distinct = 66_000, total = 900_000;
    int[] corpus = new int[total];
    for (int i = 0; i < total; i++) {
        corpus[i] = i % distinct;
    }

    long t0 = System.nanoTime();
    LinkedHashMap<Integer, Integer> m = LinkedHashMap.empty();
    for (int word : corpus) {
        m = m.put(word, m.get(word).getOrElse(0) + 1);
    }
    long t1 = System.nanoTime();
    System.out.printf("distinct=%d total=%d  ->  size=%d  in %.0f ms%n",
      distinct, total, m.size(), (t1 - t0) / 1_000_000.0);
}
```

related: 
- https://github.com/vavr-io/vavr/issues/2727