### PR TITLE
swap Queue for Vector in LinkedHashMap

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -41,18 +41,18 @@ import org.jspecify.annotations.NonNull;
  *
  * @param <K> Key type
  * @param <V> Value type
- * @author Ruslan Sennov
+ * @author Ruslan Sennov, Grzegorz Piwowarek
  */
 public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final LinkedHashMap<?, ?> EMPTY = new LinkedHashMap<>(Queue.empty(), HashMap.empty());
+    private static final LinkedHashMap<?, ?> EMPTY = new LinkedHashMap<>(Vector.empty(), HashMap.empty());
 
-    private final Queue<K> list;
+    private final Vector<K> list;
     private final HashMap<K, V> map;
 
-    private LinkedHashMap(Queue<K> list, HashMap<K, V> map) {
+    private LinkedHashMap(Vector<K> list, HashMap<K, V> map) {
         this.list = list;
         this.map = map;
     }
@@ -148,7 +148,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> LinkedHashMap<K, V> of(@NonNull Tuple2<? extends K, ? extends V> entry) {
         final HashMap<K, V> map = HashMap.of(entry);
-        final Queue<K> list = Queue.of(((Tuple2<K, V>) entry)._1);
+        final Vector<K> list = Vector.of(((Tuple2<K, V>) entry)._1);
         return wrap(list, map);
     }
 
@@ -212,7 +212,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K key, V value) {
         final HashMap<K, V> map = HashMap.of(key, value);
-        final Queue<K> list = Queue.of(key);
+        final Vector<K> list = Vector.of(key);
         return wrap(list, map);
     }
 
@@ -229,7 +229,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2);
-        final Queue<K> list = Queue.of(k1, k2);
+        final Vector<K> list = Vector.of(k1, k2);
         return wrapNonUnique(list, map);
     }
 
@@ -248,7 +248,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3);
-        final Queue<K> list = Queue.of(k1, k2, k3);
+        final Vector<K> list = Vector.of(k1, k2, k3);
         return wrapNonUnique(list, map);
     }
 
@@ -269,7 +269,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4);
-        final Queue<K> list = Queue.of(k1, k2, k3, k4);
+        final Vector<K> list = Vector.of(k1, k2, k3, k4);
         return wrapNonUnique(list, map);
     }
 
@@ -292,7 +292,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5);
-        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5);
+        final Vector<K> list = Vector.of(k1, k2, k3, k4, k5);
         return wrapNonUnique(list, map);
     }
 
@@ -317,7 +317,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6);
-        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5, k6);
+        final Vector<K> list = Vector.of(k1, k2, k3, k4, k5, k6);
         return wrapNonUnique(list, map);
     }
 
@@ -344,7 +344,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7);
-        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5, k6, k7);
+        final Vector<K> list = Vector.of(k1, k2, k3, k4, k5, k6, k7);
         return wrapNonUnique(list, map);
     }
 
@@ -373,7 +373,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8);
-        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5, k6, k7, k8);
+        final Vector<K> list = Vector.of(k1, k2, k3, k4, k5, k6, k7, k8);
         return wrapNonUnique(list, map);
     }
 
@@ -404,7 +404,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9);
-        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5, k6, k7, k8, k9);
+        final Vector<K> list = Vector.of(k1, k2, k3, k4, k5, k6, k7, k8, k9);
         return wrapNonUnique(list, map);
     }
 
@@ -437,7 +437,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
         final HashMap<K, V> map = HashMap.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
-        final Queue<K> list = Queue.of(k1, k2, k3, k4, k5, k6, k7, k8, k9, k10);
+        final Vector<K> list = Vector.of(k1, k2, k3, k4, k5, k6, k7, k8, k9, k10);
         return wrapNonUnique(list, map);
     }
 
@@ -485,7 +485,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> LinkedHashMap<K, V> ofEntries(java.util.Map.@NonNull Entry<? extends K, ? extends V> @NonNull ... entries) {
         HashMap<K, V> map = HashMap.empty();
-        Queue<K> list = Queue.empty();
+        Vector<K> list = Vector.empty();
         for (java.util.Map.Entry<? extends K, ? extends V> entry : entries) {
             map = map.put(entry.getKey(), entry.getValue());
             list = list.append(entry.getKey());
@@ -504,7 +504,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @SuppressWarnings("unchecked")
     public static <K, V> LinkedHashMap<K, V> ofEntries(@NonNull Tuple2<? extends K, ? extends V> @NonNull ... entries) {
         final HashMap<K, V> map = HashMap.ofEntries(entries);
-        Queue<K> list = Queue.empty();
+        Vector<K> list = Vector.empty();
         for (Tuple2<? extends K, ? extends V> entry : entries) {
             list = list.append(entry._1);
         }
@@ -526,7 +526,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
             return (LinkedHashMap<K, V>) entries;
         } else {
             HashMap<K, V> map = HashMap.empty();
-            Queue<K> list = Queue.empty();
+            Vector<K> list = Vector.empty();
             for (Tuple2<? extends K, ? extends V> entry : entries) {
                 map = map.put(entry);
                 list = list.append(entry._1);
@@ -817,7 +817,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public LinkedHashMap<K, V> put(K key, V value) {
         final boolean containsKey = map.containsKey(key);
         final HashMap<K, V> newMap = map.put(key, value);
-        final Queue<K> newList = containsKey ? list : list.append(key);
+        final Vector<K> newList = containsKey ? list : list.append(key);
         return wrap(newList, newMap);
     }
 
@@ -835,7 +835,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     @Override
     public LinkedHashMap<K, V> remove(K key) {
         if (containsKey(key)) {
-            final Queue<K> newList = list.removeFirst(k -> Objects.equals(k, key));
+            final Vector<K> newList = list.removeFirst(k -> Objects.equals(k, key));
             final HashMap<K, V> newMap = map.remove(key);
             return wrap(newList, newMap);
         } else {
@@ -854,7 +854,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public LinkedHashMap<K, V> removeAll(@NonNull Iterable<? extends K> keys) {
         Objects.requireNonNull(keys, "keys is null");
         final HashSet<K> toRemove = HashSet.ofAll(keys);
-        final Queue<K> newList = list.filter(k -> !toRemove.contains(k));
+        final Vector<K> newList = list.filter(k -> !toRemove.contains(k));
         final HashMap<K, V> newMap = map.filter(t -> !toRemove.contains(t._1));
         return newList.size() == size() ? this : wrap(newList, newMap);
     }
@@ -881,7 +881,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         // We replace the whole element, i.e. key and value have to be present.
         if (!Objects.equals(currentElement, newElement) && contains(currentElement)) {
 
-            Queue<K> newList = list;
+            Vector<K> newList = list;
             HashMap<K, V> newMap = map;
 
             final K currentKey = currentElement._1;
@@ -1044,7 +1044,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      * @param <V>  The value type
      * @return A new Map containing the given map with given key order
      */
-    private static <K, V> LinkedHashMap<K, V> wrap(@NonNull Queue<K> list, HashMap<K, V> map) {
+    private static <K, V> LinkedHashMap<K, V> wrap(@NonNull Vector<K> list, HashMap<K, V> map) {
         return list.isEmpty() ? empty() : new LinkedHashMap<>(list, map);
     }
 
@@ -1057,7 +1057,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      * @param <V>  The value type
      * @return A new Map containing the given map with given key order
      */
-    private static <K, V> LinkedHashMap<K, V> wrapNonUnique(@NonNull Queue<K> list, HashMap<K, V> map) {
+    private static <K, V> LinkedHashMap<K, V> wrapNonUnique(@NonNull Vector<K> list, HashMap<K, V> map) {
         if (list.isEmpty()) {
             return empty();
         }
@@ -1065,7 +1065,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
             return new LinkedHashMap<>(list, map);
         }
         // Keep the last occurrence of every key, matching the value precedence in `map`.
-        return new LinkedHashMap<>(list.reverse().distinct().reverse().toQueue(), map);
+        return new LinkedHashMap<>(list.reverse().distinct().reverse().toVector(), map);
     }
 
     // We need this method to narrow the argument of `ofEntries`.


### PR DESCRIPTION
Queue and Vector make very different tradeoffs, and Queue's tradeoffs are wrong for this job.

`LinkedHashMap` doesn't use it like a queue. It uses it as an insertion-ordered sequence it reads many times without consuming. That breaks the amortization.

Vector keeps everything already in the correct order. Nothing is stored backwards, so nothing ever has to be flipped before reading. Getting the first element is instant. It uses slightly more memory, but it sounds like a reasonable trade-off.

Before:
```
size       per-call (us)    ratio vs prev
20000      95,305           -         
40000      186,741          1,96x     
80000      295,748          1,58x     
160000     1153,626         3,90x     
320000     1878,587         1,63x     
```

After:
```
size       per-call (us)    ratio vs prev
20000      0,278            -         
40000      0,299            1,07x     
80000      0,134            0,45x     
160000     0,108            0,80x     
320000     0,122            1,13x  
```

----

reproducer:
```
private static double measureFirstElementNanos(LinkedHashSet<Integer> set, int reps) {
    int sink = 0;
    long t0 = System.nanoTime();
    for (int r = 0; r < reps; r++) {
        sink ^= set.iterator().next();
    }
    long t1 = System.nanoTime();
    if (sink == 0xDEADBEEF) {
        System.out.print("");
    }
    return (t1 - t0) / (double) reps;
}
```

related:
- https://github.com/vavr-io/vavr/issues/2727