### PR TITLE
stop @Nested subclass test classes from shadowing abstract-base ones

### DIFF
--- a/vavr/src/test/java/io/vavr/collection/AbstractIndexedSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractIndexedSeqTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractIndexedSeqTest extends AbstractSeqTest {
     abstract protected <T> IndexedSeq<T> of(T element);
 
     @Nested
-    class StaticNarrowTests {
+    class IndexedSeqStaticNarrowTests {
         @Test
         public void shouldNarrowIndexedSeq() {
             final IndexedSeq<Double> doubles = of(1.0d);
@@ -40,7 +40,7 @@ public abstract class AbstractIndexedSeqTest extends AbstractSeqTest {
     }
 
     @Nested
-    class SpliteratorTests {
+    class IndexedSeqSpliteratorTests {
         @Test
         public void shouldHaveSizedSpliterator() {
             assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.SIZED | Spliterator.SUBSIZED)).isTrue();

--- a/vavr/src/test/java/io/vavr/collection/AbstractLinearSeqTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractLinearSeqTest.java
@@ -28,7 +28,7 @@ public abstract class AbstractLinearSeqTest extends AbstractSeqTest {
     abstract protected <T> LinearSeq<T> of(T element);
 
     @Nested
-    class StaticNarrowTests {
+    class LinearSeqStaticNarrowTests {
         @Test
         public void shouldNarrowIndexedSeq() {
             final LinearSeq<Double> doubles = of(1.0d);

--- a/vavr/src/test/java/io/vavr/collection/AbstractSortedSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractSortedSetTest.java
@@ -153,7 +153,7 @@ public abstract class AbstractSortedSetTest extends AbstractSetTest {
     }
 
     @Nested
-    class SpliteratorTests {
+    class SortedSetSpliteratorTests {
         @Test
         public void shouldHaveSortedSpliterator() {
             assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.SORTED)).isTrue();

--- a/vavr/src/test/java/io/vavr/collection/ArrayTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ArrayTest.java
@@ -210,7 +210,7 @@ public class ArrayTest extends AbstractIndexedSeqTest {
     }
 
     @Nested
-    class StaticNarrowTests {
+    class ArrayStaticNarrowTests {
         @Test
         public void shouldNarrowArray() {
             final Array<Double> doubles = of(1.0d);
@@ -239,7 +239,7 @@ public class ArrayTest extends AbstractIndexedSeqTest {
     }
 
     @Nested
-    class GetTests {
+    class ArrayGetTests {
         @Test
         public void shouldThrowExceptionWhenGetIndexEqualToLength() {
             final Array<Integer> array = of(1);

--- a/vavr/src/test/java/io/vavr/collection/HashSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/HashSetTest.java
@@ -493,7 +493,7 @@ public class HashSetTest extends AbstractSetTest {
     }
 
     @Nested
-    class SpliteratorTests {
+    class HashSetSpliteratorTests {
         @Test
         public void shouldNotHaveSortedSpliterator() {
             assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.SORTED)).isFalse();

--- a/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
@@ -161,7 +161,7 @@ public class LinkedHashMapTest extends AbstractMapTest {
     }
 
     @Nested
-    class KeysetTests {
+    class LinkedHashMapKeysetTests {
         @Test
         public void shouldKeepKeySetOrder() {
             final Set<Integer> keySet = LinkedHashMap.of(4, "d", 1, "a", 2, "b").keySet();
@@ -182,7 +182,7 @@ public class LinkedHashMapTest extends AbstractMapTest {
     
 
     @Nested
-    class PutTests {
+    class LinkedHashMapPutTests {
         @Test
         public void shouldKeepOrderWhenPuttingAnExistingKeyAndNonExistingValue() {
             final Map<Integer, String> map = mapOf(1, "a", 2, "b", 3, "c");

--- a/vavr/src/test/java/io/vavr/collection/LinkedHashSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/LinkedHashSetTest.java
@@ -269,7 +269,7 @@ public class LinkedHashSetTest extends AbstractSetTest {
     }
 
     @Nested
-    class SpliteratorTests {
+    class LinkedHashSetSpliteratorTests {
         @Test
         public void shouldNotHaveSortedSpliterator() {
             assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.SORTED)).isFalse();

--- a/vavr/src/test/java/io/vavr/collection/ListTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ListTest.java
@@ -210,7 +210,7 @@ public class ListTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class StaticNarrowTests {
+    class ListStaticNarrowTests {
         @Test
         public void shouldNarrowList() {
             final List<Double> doubles = of(1.0d);
@@ -473,7 +473,7 @@ public class ListTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class SpliteratorTests {
+    class ListSpliteratorTests {
         @Test
         public void shouldHaveSizedSpliterator() {
             assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.SIZED | Spliterator.SUBSIZED)).isTrue();

--- a/vavr/src/test/java/io/vavr/collection/QueueTest.java
+++ b/vavr/src/test/java/io/vavr/collection/QueueTest.java
@@ -214,7 +214,7 @@ public class QueueTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class StaticNarrowTests {
+    class QueueStaticNarrowTests {
         @Test
         public void shouldNarrowQueue() {
             final Queue<Double> doubles = of(1.0d);
@@ -302,7 +302,7 @@ public class QueueTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class GetTests {
+    class QueueGetTests {
         @Test
         public void shouldGetFrontEnc() {
             assertThat(enqueued().get(0)).isEqualTo(1);
@@ -353,7 +353,7 @@ public class QueueTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class IndexofTests {
+    class QueueIndexofTests {
         @Test
         public void shouldNotFindIndexOfElementWhenStartIsGreaterEnc() {
             assertThat(enqueued().indexOf(2, 2)).isEqualTo(-1);
@@ -384,7 +384,7 @@ public class QueueTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class LastindexofTests {
+    class QueueLastindexofTests {
         @Test
         public void shouldNotFindLastIndexOfElementWhenEndIdLessEnc() {
             assertThat(enqueued().lastIndexOf(3, 1)).isEqualTo(-1);
@@ -472,7 +472,7 @@ public class QueueTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class SpliteratorTests {
+    class QueueSpliteratorTests {
         @Test
         public void shouldHaveSizedSpliterator() {
             assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.SIZED | Spliterator.SUBSIZED)).isTrue();

--- a/vavr/src/test/java/io/vavr/collection/StreamTest.java
+++ b/vavr/src/test/java/io/vavr/collection/StreamTest.java
@@ -392,7 +392,7 @@ public class StreamTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class StaticNarrowTests {
+    class StreamStaticNarrowTests {
         @Test
         public void shouldNarrowStream() {
             final Stream<Double> doubles = of(1.0d);
@@ -453,7 +453,7 @@ public class StreamTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class CombinationsTests {
+    class StreamCombinationsTests {
         @Test
         public void shouldComputeCombinationsOfEmptyStream() {
             assertThat(Stream.empty().combinations()).isEqualTo(Stream.of(Stream.empty()));
@@ -467,7 +467,7 @@ public class StreamTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class CombinationsKTests {
+    class StreamCombinationsKTests {
         @Test
         public void shouldComputeKCombinationsOfEmptyStream() {
             assertThat(Stream.empty().combinations(1)).isEqualTo(Stream.empty());
@@ -531,7 +531,7 @@ public class StreamTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class PermutationsTests {
+    class StreamPermutationsTests {
         @Test
         public void shouldComputePermutationsOfEmptyStream() {
             assertThat(Stream.empty().permutations()).isEqualTo(Stream.empty());
@@ -579,7 +579,7 @@ public class StreamTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class ContainssliceTests {
+    class StreamContainssliceTests {
         @Test
         public void shouldRecognizeInfiniteDoesContainSlice() {
             final boolean actual = Stream.iterate(1, i -> i + 1).containsSlice(of(12, 13, 14));
@@ -933,7 +933,7 @@ public class StreamTest extends AbstractLinearSeqTest {
     }
 
     @Nested
-    class SpliteratorTests {
+    class StreamSpliteratorTests {
         @Test
         public void shouldNotHaveSizedSpliterator() {
             assertThat(of(1, 2, 3).spliterator().hasCharacteristics(Spliterator.SIZED | Spliterator.SUBSIZED)).isFalse();

--- a/vavr/src/test/java/io/vavr/collection/TreeMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/TreeMapTest.java
@@ -365,7 +365,7 @@ public class TreeMapTest extends AbstractSortedMapTest {
     }
 
     @Nested
-    class FlatmapTests {
+    class TreeMapFlatmapTests {
         @Test
         public void shouldReturnATreeMapWithCorrectComparatorWhenFlatMappingToEmpty() {
 

--- a/vavr/src/test/java/io/vavr/collection/TreeSetTest.java
+++ b/vavr/src/test/java/io/vavr/collection/TreeSetTest.java
@@ -285,7 +285,7 @@ public class TreeSetTest extends AbstractSortedSetTest {
     }
 
     @Nested
-    class AddallTests {
+    class TreeSetAddallTests {
         @Test
         public void shouldKeepComparator() {
             final List<Integer> actual = TreeSet.empty(inverseIntComparator()).addAll(TreeSet.of(1, 2, 3)).toList();
@@ -296,7 +296,7 @@ public class TreeSetTest extends AbstractSortedSetTest {
     
 
     @Nested
-    class RemoveallTests {
+    class TreeSetRemoveallTests {
         @Test
         public void shouldKeepComparatorOnRemoveAll() {
             final TreeSet<Integer> ts = TreeSet.of(Comparators.naturalComparator()
@@ -308,7 +308,7 @@ public class TreeSetTest extends AbstractSortedSetTest {
     }
 
     @Nested
-    class DiffTests {
+    class TreeSetDiffTests {
         @Test
         public void shouldCalculateDiffIfNotTreeSet() {
             final TreeSet<Integer> actual = of(1, 2, 3).diff(HashSet.of(1, 2));
@@ -328,7 +328,7 @@ public class TreeSetTest extends AbstractSortedSetTest {
     }
 
     @Nested
-    class IntersectTests {
+    class TreeSetIntersectTests {
         @Test
         public void shouldCalculateEmptyIntersectIfNotTreeSet() {
             final TreeSet<Integer> actual = of(1, 2, 3).intersect(HashSet.of(4));

--- a/vavr/src/test/java/io/vavr/collection/VectorTest.java
+++ b/vavr/src/test/java/io/vavr/collection/VectorTest.java
@@ -213,7 +213,7 @@ public class VectorTest extends AbstractIndexedSeqTest {
     }
 
     @Nested
-    class StaticNarrowTests {
+    class VectorStaticNarrowTests {
         @Test
         public void shouldNarrowVector() {
             final Vector<Double> doubles = of(1.0d);


### PR DESCRIPTION
`@Nested` test classes refactor introduced a sneaky bug due to nested class shadowing - as a result 90 tests were not run