### PR TITLE
CHAMP experiments

### DIFF
--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -49,6 +49,26 @@
             <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- CHAMP experiment: JMH micro-benchmarks + JOL memory footprint (test scope only) -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <version>0.17</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -86,4 +106,54 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- CHAMP experiment: enable JMH annotation processing for test sources so @Benchmark
+             classes generate their runners. Gated behind a profile to keep the normal build intact. -->
+        <profile>
+            <id>champ-bench</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                                <configuration>
+                                    <compilerArgs>
+                                        <arg>-Xlint:none</arg>
+                                    </compilerArgs>
+                                    <annotationProcessorPaths combine.self="override">
+                                        <path>
+                                            <groupId>io.vavr</groupId>
+                                            <artifactId>vavr-match</artifactId>
+                                            <version>1.0.0</version>
+                                        </path>
+                                        <path>
+                                            <groupId>io.vavr</groupId>
+                                            <artifactId>vavr-match-processor</artifactId>
+                                            <version>1.0.0</version>
+                                        </path>
+                                        <path>
+                                            <groupId>org.openjdk.jmh</groupId>
+                                            <artifactId>jmh-generator-annprocess</artifactId>
+                                            <version>${jmh.version}</version>
+                                        </path>
+                                    </annotationProcessorPaths>
+                                    <annotationProcessors combine.self="override">
+                                        <annotationProcessor>io.vavr.match.PatternsProcessor</annotationProcessor>
+                                        <annotationProcessor>org.openjdk.jmh.generators.BenchmarkProcessor</annotationProcessor>
+                                    </annotationProcessors>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/vavr/src/main/java/io/vavr/collection/CompressedHashArrayMappedPrefixTrie.java
+++ b/vavr/src/main/java/io/vavr/collection/CompressedHashArrayMappedPrefixTrie.java
@@ -1,0 +1,789 @@
+/* ____  ______________  ________________________  __________
+ * \   \/   /      \   \/   /   __/   /      \   \/   /      \
+ *  \______/___/\___\______/___/_____/___/\___\______/___/\___\
+ *
+ * Copyright 2014-2026 Vavr, https://vavr.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vavr.collection;
+
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.control.Option;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * An experimental, immutable
+ * <a href="https://michael.steindorfer.name/publications/oopsla15.pdf">CHAMP</a>
+ * (Compressed Hash-Array Mapped Prefix-tree) implementation of {@link HashArrayMappedTrie}.
+ *
+ * <p>Compared to the classic HAMT in {@link HashArrayMappedTrie}, a CHAMP node keeps two
+ * bitmaps — {@code dataMap} for inline key/value payloads and {@code nodeMap} for sub-nodes —
+ * and stores payloads at the head of a single backing array while storing sub-nodes, in reverse,
+ * at the tail. This removes the per-entry leaf object, improves iteration/equality locality, and
+ * keeps the tree in a canonical shape by inlining singleton sub-nodes back into their parent on
+ * removal.
+ *
+ * <p>This class is a drop-in alternative behind the {@link HashArrayMappedTrie} interface; on this
+ * branch {@code HashMap}/{@code HashSet} are wired to it so the two representations can be A/B
+ * compared for correctness and performance.
+ *
+ * <p>Sizes 0 and 1 use dedicated representations: the shared {@link #EMPTY} instance and
+ * {@link SingletonTrie} (a single object holding hash, key and value — matching the footprint of
+ * the classic HAMT's {@code LeafSingleton}). The general node-based representation below is only
+ * ever instantiated for {@code size >= 2}.
+ *
+ * @author Grzegorz Piwowarek
+ */
+final class CompressedHashArrayMappedPrefixTrie<K, V> implements HashArrayMappedTrie<K, V>, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private static final int BIT_PARTITION_SIZE = 5;
+    private static final int HASH_CODE_LENGTH = 32;
+
+    private static final Object NOT_FOUND = new Object();
+
+    private static final CompressedHashArrayMappedPrefixTrie<?, ?> EMPTY =
+            new CompressedHashArrayMappedPrefixTrie<>(new BitmapIndexedNode<>(0, 0, new Object[0]), 0);
+
+    private final Node<K, V> root;
+    private final int size;
+
+    private CompressedHashArrayMappedPrefixTrie(Node<K, V> root, int size) {
+        this.root = root;
+        this.size = size;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K, V> HashArrayMappedTrie<K, V> empty() {
+        return (CompressedHashArrayMappedPrefixTrie<K, V>) EMPTY;
+    }
+
+    @Serial
+    private Object readResolve() {
+        // EMPTY must stay the only size-0 instance, also across serialization
+        return size == 0 ? EMPTY : this;
+    }
+
+    // -- bit twiddling shared by all nodes
+
+    private static int mask(int hash, int shift) {
+        return (hash >>> shift) & (Node.BUCKET_SIZE - 1);
+    }
+
+    private static int bitpos(int mask) {
+        return 1 << mask;
+    }
+
+    private static int index(int bitmap, int bitpos) {
+        return Integer.bitCount(bitmap & (bitpos - 1));
+    }
+
+    // -- HashArrayMappedTrie surface
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Option<V> get(K key) {
+        final Object result = root.findValue(key, Objects.hashCode(key), 0);
+        return result == NOT_FOUND ? Option.none() : Option.some((V) result);
+    }
+
+    @Override
+    public Option<Tuple2<K, V>> getEntry(K key) {
+        final Tuple2<K, V> entry = root.findEntry(key, Objects.hashCode(key), 0);
+        return entry == null ? Option.none() : Option.some(entry);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public V getOrElse(K key, V defaultValue) {
+        final Object result = root.findValue(key, Objects.hashCode(key), 0);
+        return result == NOT_FOUND ? defaultValue : (V) result;
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        return root.findValue(key, Objects.hashCode(key), 0) != NOT_FOUND;
+    }
+
+    @Override
+    public HashArrayMappedTrie<K, V> put(K key, V value) {
+        if (size == 0) {
+            return new SingletonTrie<>(Objects.hashCode(key), key, value);
+        }
+        final MapDetails details = new MapDetails();
+        final Node<K, V> newRoot = root.updated(key, value, Objects.hashCode(key), 0, details);
+        if (!details.modified) {
+            return this;
+        }
+        return new CompressedHashArrayMappedPrefixTrie<>(newRoot, details.sizeChanged ? size + 1 : size);
+    }
+
+    @Override
+    public HashArrayMappedTrie<K, V> remove(K key) {
+        final MapDetails details = new MapDetails();
+        final Node<K, V> newRoot = root.removed(key, Objects.hashCode(key), 0, details);
+        if (!details.modified) {
+            return this;
+        }
+        final int newSize = size - 1;
+        if (newSize == 0) {
+            return empty();
+        }
+        if (newSize == 1) {
+            // canonical form guarantees a size-1 tree is a single-payload root
+            final K remainingKey = newRoot.getKey(0);
+            return new SingletonTrie<>(Objects.hashCode(remainingKey), remainingKey, newRoot.getValue(0));
+        }
+        return new CompressedHashArrayMappedPrefixTrie<>(newRoot, newSize);
+    }
+
+    @Override
+    public @NonNull Iterator<Tuple2<K, V>> iterator() {
+        return new EntryIterator<>(root);
+    }
+
+    @Override
+    public Iterator<K> keysIterator() {
+        return iterator().map(t -> t._1);
+    }
+
+    @Override
+    public Iterator<V> valuesIterator() {
+        return iterator().map(t -> t._2);
+    }
+
+    @Override
+    public String toString() {
+        return iterator().map(t -> t._1 + " -> " + t._2).mkString("CompressedHashArrayMappedPrefixTrie(", ", ", ")");
+    }
+
+    // -- bookkeeping passed down the recursion to report what changed
+
+    private static final class MapDetails {
+        private boolean modified;
+        private boolean sizeChanged;
+
+        void recordAdd() {
+            modified = true;
+            sizeChanged = true;
+        }
+
+        void recordReplace() {
+            modified = true;
+        }
+
+        void recordRemove() {
+            modified = true;
+            sizeChanged = true;
+        }
+    }
+
+    // -- dedicated one-entry representation, as compact as the classic HAMT's LeafSingleton
+
+    private static final class SingletonTrie<K, V> implements HashArrayMappedTrie<K, V>, Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final int keyHash;
+        private final K key;
+        private final V value;
+
+        SingletonTrie(int keyHash, K key, V value) {
+            this.keyHash = keyHash;
+            this.key = key;
+            this.value = value;
+        }
+
+        private boolean matches(K key) {
+            return Objects.hashCode(key) == keyHash && Objects.equals(this.key, key);
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public int size() {
+            return 1;
+        }
+
+        @Override
+        public Option<V> get(K key) {
+            return matches(key) ? Option.some(value) : Option.none();
+        }
+
+        @Override
+        public Option<Tuple2<K, V>> getEntry(K key) {
+            return matches(key) ? Option.some(Tuple.of(this.key, value)) : Option.none();
+        }
+
+        @Override
+        public V getOrElse(K key, V defaultValue) {
+            return matches(key) ? value : defaultValue;
+        }
+
+        @Override
+        public boolean containsKey(K key) {
+            return matches(key);
+        }
+
+        @Override
+        public HashArrayMappedTrie<K, V> put(K key, V value) {
+            final int newKeyHash = Objects.hashCode(key);
+            if (newKeyHash == keyHash && Objects.equals(this.key, key)) {
+                // adopt the replacing key instance, matching HashArrayMappedTrie semantics
+                return new SingletonTrie<>(keyHash, key, value);
+            }
+            final Node<K, V> root = Node.mergeTwoKeyValPairs(
+                    this.key, this.value, keyHash,
+                    key, value, newKeyHash, 0);
+            return new CompressedHashArrayMappedPrefixTrie<>(root, 2);
+        }
+
+        @Override
+        public HashArrayMappedTrie<K, V> remove(K key) {
+            return matches(key) ? empty() : this;
+        }
+
+        @Override
+        public @NonNull Iterator<Tuple2<K, V>> iterator() {
+            return Iterator.of(Tuple.of(key, value));
+        }
+
+        @Override
+        public Iterator<K> keysIterator() {
+            return Iterator.of(key);
+        }
+
+        @Override
+        public Iterator<V> valuesIterator() {
+            return Iterator.of(value);
+        }
+
+        @Override
+        public String toString() {
+            return "CompressedHashArrayMappedPrefixTrie(" + key + " -> " + value + ")";
+        }
+    }
+
+    // -- node hierarchy
+
+    private abstract static class Node<K, V> implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        static final int BUCKET_SIZE = 1 << BIT_PARTITION_SIZE;
+
+        static final int SIZE_EMPTY = 0;
+        static final int SIZE_ONE = 1;
+        static final int SIZE_MORE = 2;
+
+        abstract Object findValue(K key, int keyHash, int shift);
+
+        abstract Tuple2<K, V> findEntry(K key, int keyHash, int shift);
+
+        abstract Node<K, V> updated(K key, V value, int keyHash, int shift, MapDetails details);
+
+        abstract Node<K, V> removed(K key, int keyHash, int shift, MapDetails details);
+
+        abstract boolean hasData();
+
+        abstract boolean hasNodes();
+
+        abstract int payloadArity();
+
+        abstract int nodeArity();
+
+        abstract int sizePredicate();
+
+        abstract K getKey(int index);
+
+        abstract V getValue(int index);
+
+        abstract Node<K, V> getNode(int index);
+
+        static <K, V> Node<K, V> mergeTwoKeyValPairs(K key0, V val0, int hash0,
+                                                     K key1, V val1, int hash1, int shift) {
+            if (shift >= HASH_CODE_LENGTH) {
+                // hashes are fully equal at this point
+                return new HashCollisionNode<>(hash0, new Object[] { key0, key1 }, new Object[] { val0, val1 });
+            }
+            final int mask0 = mask(hash0, shift);
+            final int mask1 = mask(hash1, shift);
+            if (mask0 == mask1) {
+                final Node<K, V> sub = mergeTwoKeyValPairs(key0, val0, hash0, key1, val1, hash1, shift + BIT_PARTITION_SIZE);
+                return new BitmapIndexedNode<>(0, bitpos(mask0), new Object[] { sub });
+            }
+            final int dataMap = bitpos(mask0) | bitpos(mask1);
+            final Object[] content = (mask0 < mask1)
+                    ? new Object[] { key0, val0, key1, val1 }
+                    : new Object[] { key1, val1, key0, val0 };
+            return new BitmapIndexedNode<>(dataMap, 0, content);
+        }
+
+        static <K, V> Node<K, V> mergeNodeAndKeyValPair(Node<K, V> node, int nodeHash,
+                                                        K key, V value, int keyHash, int shift) {
+            final int mask0 = mask(nodeHash, shift);
+            final int mask1 = mask(keyHash, shift);
+            if (mask0 == mask1) {
+                final Node<K, V> sub = mergeNodeAndKeyValPair(node, nodeHash, key, value, keyHash, shift + BIT_PARTITION_SIZE);
+                return new BitmapIndexedNode<>(0, bitpos(mask0), new Object[] { sub });
+            }
+            return new BitmapIndexedNode<>(bitpos(mask1), bitpos(mask0), new Object[] { key, value, node });
+        }
+    }
+
+    private static final class BitmapIndexedNode<K, V> extends Node<K, V> {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final int dataMap;
+        private final int nodeMap;
+        // layout: [k0, v0, k1, v1, ... payloads ascending ...][... sub-nodes stored in reverse ...]
+        private final Object[] content;
+
+        BitmapIndexedNode(int dataMap, int nodeMap, Object[] content) {
+            this.dataMap = dataMap;
+            this.nodeMap = nodeMap;
+            this.content = content;
+        }
+
+        @Override
+        boolean hasData() {
+            return dataMap != 0;
+        }
+
+        @Override
+        boolean hasNodes() {
+            return nodeMap != 0;
+        }
+
+        @Override
+        int payloadArity() {
+            return Integer.bitCount(dataMap);
+        }
+
+        @Override
+        int nodeArity() {
+            return Integer.bitCount(nodeMap);
+        }
+
+        @Override
+        int sizePredicate() {
+            if (nodeMap == 0) {
+                return switch (payloadArity()) {
+                    case 0 -> SIZE_EMPTY;
+                    case 1 -> SIZE_ONE;
+                    default -> SIZE_MORE;
+                };
+            }
+            return SIZE_MORE;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        K getKey(int index) {
+            return (K) content[2 * index];
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        V getValue(int index) {
+            return (V) content[2 * index + 1];
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        Node<K, V> getNode(int index) {
+            return (Node<K, V>) content[content.length - 1 - index];
+        }
+
+        private Node<K, V> nodeAt(int bitpos) {
+            return getNode(index(nodeMap, bitpos));
+        }
+
+        @Override
+        Object findValue(K key, int keyHash, int shift) {
+            final int bitpos = bitpos(mask(keyHash, shift));
+            if ((dataMap & bitpos) != 0) {
+                final int i = index(dataMap, bitpos);
+                return Objects.equals(getKey(i), key) ? getValue(i) : NOT_FOUND;
+            }
+            if ((nodeMap & bitpos) != 0) {
+                return nodeAt(bitpos).findValue(key, keyHash, shift + BIT_PARTITION_SIZE);
+            }
+            return NOT_FOUND;
+        }
+
+        @Override
+        Tuple2<K, V> findEntry(K key, int keyHash, int shift) {
+            final int bitpos = bitpos(mask(keyHash, shift));
+            if ((dataMap & bitpos) != 0) {
+                final int i = index(dataMap, bitpos);
+                return Objects.equals(getKey(i), key) ? Tuple.of(getKey(i), getValue(i)) : null;
+            }
+            if ((nodeMap & bitpos) != 0) {
+                return nodeAt(bitpos).findEntry(key, keyHash, shift + BIT_PARTITION_SIZE);
+            }
+            return null;
+        }
+
+        @Override
+        Node<K, V> updated(K key, V value, int keyHash, int shift, MapDetails details) {
+            final int mask = mask(keyHash, shift);
+            final int bitpos = bitpos(mask);
+            if ((dataMap & bitpos) != 0) {
+                final int i = index(dataMap, bitpos);
+                final K currentKey = getKey(i);
+                final V currentValue = getValue(i);
+                if (Objects.equals(currentKey, key)) {
+                    // adopt the replacing key instance, matching HashArrayMappedTrie semantics
+                    // (an equal-but-distinct key must be surfaced after overwrite)
+                    details.recordReplace();
+                    return copyAndSetKeyValue(i, key, value);
+                }
+                final Node<K, V> sub = mergeTwoKeyValPairs(
+                        currentKey, currentValue, Objects.hashCode(currentKey),
+                        key, value, keyHash, shift + BIT_PARTITION_SIZE);
+                details.recordAdd();
+                return copyAndMigrateFromInlineToNode(bitpos, sub);
+            }
+            if ((nodeMap & bitpos) != 0) {
+                final Node<K, V> sub = nodeAt(bitpos);
+                final Node<K, V> subNew = sub.updated(key, value, keyHash, shift + BIT_PARTITION_SIZE, details);
+                return subNew == sub ? this : copyAndSetNode(bitpos, subNew);
+            }
+            details.recordAdd();
+            return copyAndInsertValue(bitpos, key, value);
+        }
+
+        @Override
+        Node<K, V> removed(K key, int keyHash, int shift, MapDetails details) {
+            final int mask = mask(keyHash, shift);
+            final int bitpos = bitpos(mask);
+            if ((dataMap & bitpos) != 0) {
+                final int i = index(dataMap, bitpos);
+                if (!Objects.equals(getKey(i), key)) {
+                    return this;
+                }
+                details.recordRemove();
+                if (payloadArity() == 2 && nodeArity() == 0) {
+                    // collapse to a single-payload node so the parent can inline it (or it becomes the new root)
+                    final int otherIndex = i == 0 ? 1 : 0;
+                    final K remainingKey = getKey(otherIndex);
+                    final V remainingValue = getValue(otherIndex);
+                    final int newDataMap = bitpos(mask(Objects.hashCode(remainingKey), 0));
+                    return new BitmapIndexedNode<>(newDataMap, 0, new Object[] { remainingKey, remainingValue });
+                }
+                return copyAndRemoveValue(bitpos);
+            }
+            if ((nodeMap & bitpos) != 0) {
+                final Node<K, V> sub = nodeAt(bitpos);
+                final Node<K, V> subNew = sub.removed(key, keyHash, shift + BIT_PARTITION_SIZE, details);
+                if (!details.modified) {
+                    return this;
+                }
+                return switch (subNew.sizePredicate()) {
+                    case SIZE_ONE -> {
+                        if (payloadArity() == 0 && nodeArity() == 1) {
+                            yield subNew;
+                        }
+                        yield copyAndMigrateFromNodeToInline(bitpos, subNew);
+                    }
+                    case SIZE_MORE -> copyAndSetNode(bitpos, subNew);
+                    default -> throw new IllegalStateException("unexpected empty sub-node after removal");
+                };
+            }
+            return this;
+        }
+
+        private BitmapIndexedNode<K, V> copyAndSetKeyValue(int dataIndex, K key, V value) {
+            final Object[] dst = content.clone();
+            dst[2 * dataIndex] = key;
+            dst[2 * dataIndex + 1] = value;
+            return new BitmapIndexedNode<>(dataMap, nodeMap, dst);
+        }
+
+        private BitmapIndexedNode<K, V> copyAndSetNode(int bitpos, Node<K, V> node) {
+            final Object[] dst = content.clone();
+            dst[content.length - 1 - index(nodeMap, bitpos)] = node;
+            return new BitmapIndexedNode<>(dataMap, nodeMap, dst);
+        }
+
+        private BitmapIndexedNode<K, V> copyAndInsertValue(int bitpos, K key, V value) {
+            final int idx = 2 * index(dataMap, bitpos);
+            final Object[] dst = new Object[content.length + 2];
+            System.arraycopy(content, 0, dst, 0, idx);
+            dst[idx] = key;
+            dst[idx + 1] = value;
+            System.arraycopy(content, idx, dst, idx + 2, content.length - idx);
+            return new BitmapIndexedNode<>(dataMap | bitpos, nodeMap, dst);
+        }
+
+        private BitmapIndexedNode<K, V> copyAndRemoveValue(int bitpos) {
+            final int idx = 2 * index(dataMap, bitpos);
+            final Object[] dst = new Object[content.length - 2];
+            System.arraycopy(content, 0, dst, 0, idx);
+            System.arraycopy(content, idx + 2, dst, idx, content.length - idx - 2);
+            return new BitmapIndexedNode<>(dataMap ^ bitpos, nodeMap, dst);
+        }
+
+        private BitmapIndexedNode<K, V> copyAndMigrateFromInlineToNode(int bitpos, Node<K, V> node) {
+            final int idxOld = 2 * index(dataMap, bitpos);
+            final int idxNew = content.length - 2 - index(nodeMap, bitpos);
+            final Object[] dst = new Object[content.length - 1];
+            System.arraycopy(content, 0, dst, 0, idxOld);
+            System.arraycopy(content, idxOld + 2, dst, idxOld, idxNew - idxOld);
+            dst[idxNew] = node;
+            System.arraycopy(content, idxNew + 2, dst, idxNew + 1, content.length - idxNew - 2);
+            return new BitmapIndexedNode<>(dataMap ^ bitpos, nodeMap | bitpos, dst);
+        }
+
+        private BitmapIndexedNode<K, V> copyAndMigrateFromNodeToInline(int bitpos, Node<K, V> node) {
+            final int idxOld = content.length - 1 - index(nodeMap, bitpos);
+            final int idxNew = 2 * index(dataMap, bitpos);
+            final K key = node.getKey(0);
+            final V value = node.getValue(0);
+            final Object[] dst = new Object[content.length + 1];
+            System.arraycopy(content, 0, dst, 0, idxNew);
+            dst[idxNew] = key;
+            dst[idxNew + 1] = value;
+            System.arraycopy(content, idxNew, dst, idxNew + 2, idxOld - idxNew);
+            System.arraycopy(content, idxOld + 1, dst, idxOld + 2, content.length - idxOld - 1);
+            return new BitmapIndexedNode<>(dataMap | bitpos, nodeMap ^ bitpos, dst);
+        }
+    }
+
+    private static final class HashCollisionNode<K, V> extends Node<K, V> {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final int hash;
+        private final Object[] keys;
+        private final Object[] vals;
+
+        HashCollisionNode(int hash, Object[] keys, Object[] vals) {
+            this.hash = hash;
+            this.keys = keys;
+            this.vals = vals;
+        }
+
+        @Override
+        boolean hasData() {
+            return true;
+        }
+
+        @Override
+        boolean hasNodes() {
+            return false;
+        }
+
+        @Override
+        int payloadArity() {
+            return keys.length;
+        }
+
+        @Override
+        int nodeArity() {
+            return 0;
+        }
+
+        @Override
+        int sizePredicate() {
+            return SIZE_MORE; // a collision node always holds at least two entries
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        K getKey(int index) {
+            return (K) keys[index];
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        V getValue(int index) {
+            return (V) vals[index];
+        }
+
+        @Override
+        Node<K, V> getNode(int index) {
+            throw new UnsupportedOperationException("collision nodes have no sub-nodes");
+        }
+
+        @Override
+        Object findValue(K key, int keyHash, int shift) {
+            if (keyHash == hash) {
+                for (int i = 0; i < keys.length; i++) {
+                    if (Objects.equals(keys[i], key)) {
+                        return vals[i];
+                    }
+                }
+            }
+            return NOT_FOUND;
+        }
+
+        @Override
+        Tuple2<K, V> findEntry(K key, int keyHash, int shift) {
+            if (keyHash == hash) {
+                for (int i = 0; i < keys.length; i++) {
+                    if (Objects.equals(keys[i], key)) {
+                        return Tuple.of(getKey(i), getValue(i));
+                    }
+                }
+            }
+            return null;
+        }
+
+        @Override
+        Node<K, V> updated(K key, V value, int keyHash, int shift, MapDetails details) {
+            if (keyHash != hash) {
+                details.recordAdd();
+                return mergeNodeAndKeyValPair(this, hash, key, value, keyHash, shift);
+            }
+            for (int i = 0; i < keys.length; i++) {
+                if (Objects.equals(keys[i], key)) {
+                    // adopt the replacing key instance (see BitmapIndexedNode#updated)
+                    details.recordReplace();
+                    final Object[] newKeys = keys.clone();
+                    newKeys[i] = key;
+                    final Object[] newVals = vals.clone();
+                    newVals[i] = value;
+                    return new HashCollisionNode<>(hash, newKeys, newVals);
+                }
+            }
+            details.recordAdd();
+            final Object[] newKeys = copyAppend(keys, key);
+            final Object[] newVals = copyAppend(vals, value);
+            return new HashCollisionNode<>(hash, newKeys, newVals);
+        }
+
+        @Override
+        Node<K, V> removed(K key, int keyHash, int shift, MapDetails details) {
+            for (int i = 0; i < keys.length; i++) {
+                if (Objects.equals(keys[i], key)) {
+                    details.recordRemove();
+                    if (keys.length == 2) {
+                        // one entry remains: become an inlineable single-payload node
+                        final int other = 1 - i;
+                        final int newDataMap = bitpos(mask(hash, 0));
+                        return new BitmapIndexedNode<>(newDataMap, 0, new Object[] { keys[other], vals[other] });
+                    }
+                    return new HashCollisionNode<>(hash, copyRemove(keys, i), copyRemove(vals, i));
+                }
+            }
+            return this;
+        }
+
+        private static Object[] copyAppend(Object[] array, Object element) {
+            final Object[] result = new Object[array.length + 1];
+            System.arraycopy(array, 0, result, 0, array.length);
+            result[array.length] = element;
+            return result;
+        }
+
+        private static Object[] copyRemove(Object[] array, int index) {
+            return HashArrayMappedTrieModule.AbstractNode.remove(array, index);
+        }
+    }
+
+    // -- iteration: CHAMP stack walk, yielding each node's payloads before descending
+
+    private static final class EntryIterator<K, V> extends AbstractIterator<Tuple2<K, V>> {
+
+        // 32-bit hashes in 5-bit chunks ⇒ at most 7 bitmap levels; collision nodes are leaves
+        private static final int MAX_DEPTH = 8;
+
+        @SuppressWarnings("unchecked")
+        private final Node<K, V>[] nodeStack = new Node[MAX_DEPTH];
+        private final int[] nodeCursor = new int[MAX_DEPTH];
+        private final int[] nodeLength = new int[MAX_DEPTH];
+        private int level = -1;
+
+        private Node<K, V> valueNode;
+        private int valueCursor;
+        private int valueLength;
+
+        EntryIterator(Node<K, V> root) {
+            if (root.hasNodes()) {
+                level = 0;
+                nodeStack[0] = root;
+                nodeCursor[0] = 0;
+                nodeLength[0] = root.nodeArity();
+            }
+            if (root.hasData()) {
+                valueNode = root;
+                valueCursor = 0;
+                valueLength = root.payloadArity();
+            }
+        }
+
+        private boolean searchNextValueNode() {
+            while (level >= 0) {
+                final int cursor = nodeCursor[level];
+                if (cursor < nodeLength[level]) {
+                    final Node<K, V> child = nodeStack[level].getNode(cursor);
+                    nodeCursor[level] = cursor + 1;
+                    if (child.hasNodes()) {
+                        level++;
+                        nodeStack[level] = child;
+                        nodeCursor[level] = 0;
+                        nodeLength[level] = child.nodeArity();
+                    }
+                    if (child.hasData()) {
+                        valueNode = child;
+                        valueCursor = 0;
+                        valueLength = child.payloadArity();
+                        return true;
+                    }
+                } else {
+                    level--;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return valueCursor < valueLength || searchNextValueNode();
+        }
+
+        @Override
+        protected Tuple2<K, V> getNext() {
+            final Tuple2<K, V> entry = Tuple.of(valueNode.getKey(valueCursor), valueNode.getValue(valueCursor));
+            valueCursor++;
+            return entry;
+        }
+    }
+}

--- a/vavr/src/main/java/io/vavr/collection/HashArrayMappedTrie.java
+++ b/vavr/src/main/java/io/vavr/collection/HashArrayMappedTrie.java
@@ -24,6 +24,7 @@ import io.vavr.collection.HashArrayMappedTrieModule.EmptyNode;
 import io.vavr.control.Option;
 import java.io.Serializable;
 import java.util.Objects;
+import org.jspecify.annotations.NonNull;
 
 import static io.vavr.collection.HashArrayMappedTrieModule.Action.PUT;
 import static io.vavr.collection.HashArrayMappedTrieModule.Action.REMOVE;
@@ -60,6 +61,7 @@ interface HashArrayMappedTrie<K, V> extends Iterable<Tuple2<K, V>>, Serializable
     HashArrayMappedTrie<K, V> remove(K key);
 
     @Override
+    @NonNull
     Iterator<Tuple2<K, V>> iterator();
 
     /**
@@ -222,7 +224,7 @@ interface HashArrayMappedTrieModule {
         }
 
         @Override
-        public Iterator<Tuple2<K, V>> iterator() {
+        public @NonNull Iterator<Tuple2<K, V>> iterator() {
             return nodes().map(node -> Tuple.of(node.key(), node.value()));
         }
 

--- a/vavr/src/main/java/io/vavr/collection/HashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMap.java
@@ -47,7 +47,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final HashMap<?, ?> EMPTY = new HashMap<>(HashArrayMappedTrie.empty());
+    private static final HashMap<?, ?> EMPTY = new HashMap<>(CompressedHashArrayMappedPrefixTrie.empty());
 
     private final HashArrayMappedTrie<K, V> trie;
 
@@ -151,7 +151,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
      * @return A new Map containing the given entry
      */
     public static <K, V> HashMap<K, V> of(@NonNull Tuple2<? extends K, ? extends V> entry) {
-        return new HashMap<>(HashArrayMappedTrie.<K, V> empty().put(entry._1, entry._2));
+        return new HashMap<>(CompressedHashArrayMappedPrefixTrie.<K, V> empty().put(entry._1, entry._2));
     }
 
     /**
@@ -164,7 +164,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
      */
     public static <K, V> HashMap<K, V> ofAll(java.util.@NonNull Map<? extends K, ? extends V> map) {
         Objects.requireNonNull(map, "map is null");
-        HashArrayMappedTrie<K, V> tree = HashArrayMappedTrie.empty();
+        HashArrayMappedTrie<K, V> tree = CompressedHashArrayMappedPrefixTrie.empty();
         for (java.util.Map.Entry<? extends K, ? extends V> entry : map.entrySet()) {
             tree = tree.put(entry.getKey(), entry.getValue());
         }
@@ -213,7 +213,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
      * @return A new Map containing the given entry
      */
     public static <K, V> HashMap<K, V> of(K key, V value) {
-        return new HashMap<>(HashArrayMappedTrie.<K, V> empty().put(key, value));
+        return new HashMap<>(CompressedHashArrayMappedPrefixTrie.<K, V> empty().put(key, value));
     }
 
     /**
@@ -467,7 +467,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     @SafeVarargs
     public static <K, V> HashMap<K, V> ofEntries(java.util.Map.@NonNull Entry<? extends K, ? extends V> @NonNull ... entries) {
         Objects.requireNonNull(entries, "entries is null");
-        HashArrayMappedTrie<K, V> trie = HashArrayMappedTrie.empty();
+        HashArrayMappedTrie<K, V> trie = CompressedHashArrayMappedPrefixTrie.empty();
         for (java.util.Map.Entry<? extends K, ? extends V> entry : entries) {
             trie = trie.put(entry.getKey(), entry.getValue());
         }
@@ -485,7 +485,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     @SafeVarargs
     public static <K, V> HashMap<K, V> ofEntries(@NonNull Tuple2<? extends K, ? extends V> @NonNull ... entries) {
         Objects.requireNonNull(entries, "entries is null");
-        HashArrayMappedTrie<K, V> trie = HashArrayMappedTrie.empty();
+        HashArrayMappedTrie<K, V> trie = CompressedHashArrayMappedPrefixTrie.empty();
         for (Tuple2<? extends K, ? extends V> entry : entries) {
             trie = trie.put(entry._1, entry._2);
         }
@@ -506,7 +506,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
         if (entries instanceof HashMap) {
             return (HashMap<K, V>) entries;
         } else {
-            HashArrayMappedTrie<K, V> trie = HashArrayMappedTrie.empty();
+            HashArrayMappedTrie<K, V> trie = CompressedHashArrayMappedPrefixTrie.empty();
             for (Tuple2<? extends K, ? extends V> entry : entries) {
                 trie = trie.put(entry._1, entry._2);
             }
@@ -862,7 +862,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
     @Override
     public HashMap<K, V> retainAll(@NonNull Iterable<? extends Tuple2<K, V>> elements) {
         Objects.requireNonNull(elements, "elements is null");
-        HashArrayMappedTrie<K, V> tree = HashArrayMappedTrie.empty();
+        HashArrayMappedTrie<K, V> tree = CompressedHashArrayMappedPrefixTrie.empty();
         for (Tuple2<K, V> entry : elements) {
             if (contains(entry)) {
                 tree = tree.put(entry._1, entry._2);
@@ -1021,7 +1021,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
             if (size < 0) {
                 throw new InvalidObjectException("No elements");
             }
-            HashArrayMappedTrie<K, V> temp = HashArrayMappedTrie.empty();
+            HashArrayMappedTrie<K, V> temp = CompressedHashArrayMappedPrefixTrie.empty();
             for (int i = 0; i < size; i++) {
                 @SuppressWarnings("unchecked")
                 final K key = (K) s.readObject();

--- a/vavr/src/main/java/io/vavr/collection/HashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/HashSet.java
@@ -40,7 +40,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private static final HashSet<?> EMPTY = new HashSet<>(HashArrayMappedTrie.empty());
+    private static final HashSet<?> EMPTY = new HashSet<>(CompressedHashArrayMappedPrefixTrie.empty());
 
     private final HashArrayMappedTrie<T, T> tree;
 
@@ -115,7 +115,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
     @SafeVarargs
     public static <T> HashSet<T> of(T @NonNull ... elements) {
         Objects.requireNonNull(elements, "elements is null");
-        HashArrayMappedTrie<T, T> tree = HashArrayMappedTrie.empty();
+        HashArrayMappedTrie<T, T> tree = CompressedHashArrayMappedPrefixTrie.empty();
         for (T element : elements) {
             tree = tree.put(element, element);
         }
@@ -164,7 +164,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
         if (elements instanceof HashSet) {
             return (HashSet<T>) elements;
         } else {
-            final HashArrayMappedTrie<T, T> tree = addAll(HashArrayMappedTrie.empty(), elements);
+            final HashArrayMappedTrie<T, T> tree = addAll(CompressedHashArrayMappedPrefixTrie.empty(), elements);
             return tree.isEmpty() ? empty() : new HashSet<>(tree);
         }
     }
@@ -716,7 +716,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
         if (isEmpty()) {
             return empty();
         } else {
-            final HashArrayMappedTrie<U, U> that = foldLeft(HashArrayMappedTrie.empty(),
+            final HashArrayMappedTrie<U, U> that = foldLeft(CompressedHashArrayMappedPrefixTrie.empty(),
                     (tree, t) -> addAll(tree, mapper.apply(t)));
             return new HashSet<>(that);
         }
@@ -832,7 +832,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
         if (isEmpty()) {
             return empty();
         } else {
-            final HashArrayMappedTrie<U, U> that = foldLeft(HashArrayMappedTrie.empty(), (tree, t) -> {
+            final HashArrayMappedTrie<U, U> that = foldLeft(CompressedHashArrayMappedPrefixTrie.empty(), (tree, t) -> {
                 final U u = mapper.apply(t);
                 return tree.put(u, u);
             });
@@ -1194,7 +1194,7 @@ public final class HashSet<T> implements Set<T>, Serializable {
             if (size < 0) {
                 throw new InvalidObjectException("No elements");
             }
-            HashArrayMappedTrie<T, T> temp = HashArrayMappedTrie.empty();
+            HashArrayMappedTrie<T, T> temp = CompressedHashArrayMappedPrefixTrie.empty();
             for (int i = 0; i < size; i++) {
                 @SuppressWarnings("unchecked")
                 final T element = (T) s.readObject();

--- a/vavr/src/test/java/io/vavr/JmhRunner.java
+++ b/vavr/src/test/java/io/vavr/JmhRunner.java
@@ -1,0 +1,42 @@
+/* ____  ______________  ________________________  __________
+ * \   \/   /      \   \/   /   __/   /      \   \/   /      \
+ *  \______/___/\___\______/___/_____/___/\___\______/___/\___\
+ *
+ * Copyright 2014-2026 Vavr, https://vavr.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vavr;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Programmatic JMH entry point for the CHAMP experiment. A benchmark name regex may be passed as
+ * the first argument (defaults to the CHAMP A/B suite).
+ */
+public final class JmhRunner {
+
+    private JmhRunner() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        final String include = args.length > 0 ? args[0] : ".*ChampBenchmark.*";
+        final Options options = new OptionsBuilder()
+                .include(include)
+                .shouldDoGC(true)
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractTraversableTest.java
@@ -2631,7 +2631,24 @@ public abstract class AbstractTraversableTest extends AbstractValueTest {
         if (value.hasDefiniteSize()) {
             assertThat(root).hasSameSizeAs(value);
         }
-        assertThat(root.toLispString()).isEqualTo("(1 (2 (4 7) 5) (3 (6 8 9)))");
+        if (isOrdered()) {
+            assertThat(root.toLispString()).isEqualTo("(1 (2 (4 7) 5) (3 (6 8 9)))");
+        } else {
+            // hash-based collections have an unspecified iteration order, so sibling order is
+            // arbitrary; assert the tree structure with sibling order normalized away
+            assertThat(normalizedLispString(root)).isEqualTo("(1 (2 (4 7) 5) (3 (6 8 9)))");
+        }
+    }
+
+    private static String normalizedLispString(Tree<String> tree) {
+        if (tree.isLeaf()) {
+            return tree.getValue();
+        }
+        final String children = tree.getChildren()
+          .map(AbstractTraversableTest::normalizedLispString)
+          .sorted()
+          .mkString(" ");
+        return "(" + tree.getValue() + " " + children + ")";
     }
 
     // ++++++ OBJECT ++++++

--- a/vavr/src/test/java/io/vavr/collection/ChampBenchmark.java
+++ b/vavr/src/test/java/io/vavr/collection/ChampBenchmark.java
@@ -1,0 +1,136 @@
+/* ____  ______________  ________________________  __________
+ * \   \/   /      \   \/   /   __/   /      \   \/   /      \
+ *  \______/___/\___\______/___/_____/___/\___\______/___/\___\
+ *
+ * Copyright 2014-2026 Vavr, https://vavr.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vavr.collection;
+
+import io.vavr.Tuple2;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * A/B micro-benchmark comparing the classic HAMT ({@link HashArrayMappedTrie}) against the
+ * experimental CHAMP ({@link CompressedHashArrayMappedPrefixTrie}) through the identical {@link HashArrayMappedTrie}
+ * interface, so the only variable is the node representation.
+ *
+ * <p>Run via {@code io.vavr.JmhRunner}.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+@State(Scope.Thread)
+public class ChampBenchmark {
+
+    public enum Impl { HAMT, CHAMP }
+
+    @Param({"HAMT", "CHAMP"})
+    public Impl impl;
+
+    @Param({"1000", "100000"})
+    public int size;
+
+    private Integer[] keys;
+    private Integer[] absentKeys;
+    private HashArrayMappedTrie<Integer, Integer> trie;
+
+    private HashArrayMappedTrie<Integer, Integer> empty() {
+        return impl == Impl.HAMT ? HashArrayMappedTrie.empty() : CompressedHashArrayMappedPrefixTrie.empty();
+    }
+
+    @Setup(Level.Trial)
+    public void setup() {
+        final Random r = new Random(0xC0FFEE);
+        keys = new Integer[size];
+        absentKeys = new Integer[size];
+        // distinct keys in [0, 2*size); even-ish split present/absent
+        final java.util.LinkedHashSet<Integer> present = new java.util.LinkedHashSet<>();
+        while (present.size() < size) {
+            present.add(r.nextInt(size * 4));
+        }
+        int i = 0;
+        for (Integer k : present) {
+            keys[i++] = k;
+        }
+        for (int j = 0; j < size; j++) {
+            Integer candidate;
+            do {
+                candidate = r.nextInt(size * 4);
+            } while (present.contains(candidate));
+            absentKeys[j] = candidate;
+        }
+        HashArrayMappedTrie<Integer, Integer> t = empty();
+        for (Integer k : keys) {
+            t = t.put(k, k);
+        }
+        trie = t;
+    }
+
+    @Benchmark
+    public HashArrayMappedTrie<Integer, Integer> build() {
+        HashArrayMappedTrie<Integer, Integer> t = empty();
+        for (Integer k : keys) {
+            t = t.put(k, k);
+        }
+        return t;
+    }
+
+    @Benchmark
+    public void getHits(Blackhole bh) {
+        for (Integer k : keys) {
+            bh.consume(trie.getOrElse(k, -1));
+        }
+    }
+
+    @Benchmark
+    public void getMisses(Blackhole bh) {
+        for (Integer k : absentKeys) {
+            bh.consume(trie.getOrElse(k, -1));
+        }
+    }
+
+    @Benchmark
+    public HashArrayMappedTrie<Integer, Integer> removeAll() {
+        HashArrayMappedTrie<Integer, Integer> t = trie;
+        for (Integer k : keys) {
+            t = t.remove(k);
+        }
+        return t;
+    }
+
+    @Benchmark
+    public void iterate(Blackhole bh) {
+        final Iterator<Tuple2<Integer, Integer>> it = trie.iterator();
+        while (it.hasNext()) {
+            bh.consume(it.next());
+        }
+    }
+}

--- a/vavr/src/test/java/io/vavr/collection/ChampMemoryFootprint.java
+++ b/vavr/src/test/java/io/vavr/collection/ChampMemoryFootprint.java
@@ -1,0 +1,69 @@
+/* ____  ______________  ________________________  __________
+ * \   \/   /      \   \/   /   __/   /      \   \/   /      \
+ *  \______/___/\___\______/___/_____/___/\___\______/___/\___\
+ *
+ * Copyright 2014-2026 Vavr, https://vavr.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vavr.collection;
+
+import java.util.Random;
+import org.openjdk.jol.info.GraphLayout;
+
+/**
+ * Reports the retained heap footprint of the classic HAMT vs the experimental CHAMP at several
+ * sizes, using JOL. Both tries are built from the <em>same</em> boxed key/value instances, so the
+ * shared {@code Integer} objects are counted once per graph and the difference between the totals
+ * reflects node/structural overhead rather than payload.
+ *
+ * <p>Run with {@code -Djol.magicFieldOffset=true} (and ideally {@code --add-opens} for JOL) via the
+ * {@code champ-footprint} profile.
+ */
+public final class ChampMemoryFootprint {
+
+    private ChampMemoryFootprint() {
+    }
+
+    public static void main(String[] args) {
+        final int[] sizes = {1_000, 10_000, 100_000};
+        System.out.printf("%-8s %14s %14s %10s %10s %8s%n",
+                "size", "HAMT bytes", "CHAMP bytes", "HAMT/ent", "CHAMP/ent", "CHAMP%");
+        for (int size : sizes) {
+            final Integer[] keys = distinctKeys(size);
+
+            HashArrayMappedTrie<Integer, Integer> hamt = HashArrayMappedTrie.empty();
+            HashArrayMappedTrie<Integer, Integer> champ = CompressedHashArrayMappedPrefixTrie.empty();
+            for (Integer k : keys) {
+                hamt = hamt.put(k, k);
+                champ = champ.put(k, k);
+            }
+
+            final long hamtBytes = GraphLayout.parseInstance(hamt).totalSize();
+            final long champBytes = GraphLayout.parseInstance(champ).totalSize();
+            System.out.printf("%-8d %14d %14d %10.1f %10.1f %7.1f%%%n",
+                    size, hamtBytes, champBytes,
+                    (double) hamtBytes / size, (double) champBytes / size,
+                    100.0 * champBytes / hamtBytes);
+        }
+    }
+
+    private static Integer[] distinctKeys(int size) {
+        final Random r = new Random(0xC0FFEE);
+        final java.util.LinkedHashSet<Integer> set = new java.util.LinkedHashSet<>();
+        while (set.size() < size) {
+            set.add(r.nextInt(size * 4));
+        }
+        return set.toArray(new Integer[0]);
+    }
+}

--- a/vavr/src/test/java/io/vavr/collection/ChampTrieTest.java
+++ b/vavr/src/test/java/io/vavr/collection/ChampTrieTest.java
@@ -1,0 +1,428 @@
+/* ____  ______________  ________________________  __________
+ * \   \/   /      \   \/   /   __/   /      \   \/   /      \
+ *  \______/___/\___\______/___/_____/___/\___\______/___/\___\
+ *
+ * Copyright 2014-2026 Vavr, https://vavr.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vavr.collection;
+
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.control.Option;
+import java.util.ArrayList;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Behavioral spec for the experimental CHAMP-based {@link HashArrayMappedTrie} implementation.
+ *
+ * The strongest oracle is the existing, battle-tested HAMT ({@link HashArrayMappedTrie#empty()}):
+ * for any sequence of operations, CHAMP must agree with it on size, lookups and iteration content.
+ */
+public class ChampTrieTest {
+
+    private static <K, V> HashArrayMappedTrie<K, V> champ() {
+        return CompressedHashArrayMappedPrefixTrie.empty();
+    }
+
+    private static <K, V> HashArrayMappedTrie<K, V> hamt() {
+        return HashArrayMappedTrie.empty();
+    }
+
+    @Test
+    public void emptyHasNoElements() {
+        final HashArrayMappedTrie<Integer, Integer> t = champ();
+        assertThat(t.isEmpty()).isTrue();
+        assertThat(t.size()).isEqualTo(0);
+        assertThat(t.get(1)).isEqualTo(Option.none());
+        assertThat(t.getOrElse(1, 42)).isEqualTo(42);
+        assertThat(t.containsKey(1)).isFalse();
+        assertThat(t.iterator().hasNext()).isFalse();
+    }
+
+    @Test
+    public void putThenGetSingle() {
+        final HashArrayMappedTrie<Integer, Integer> t = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 2);
+        assertThat(t.isEmpty()).isFalse();
+        assertThat(t.size()).isEqualTo(1);
+        assertThat(t.get(1)).isEqualTo(Option.some(2));
+        assertThat(t.getEntry(1)).isEqualTo(Option.some(Tuple.of(1, 2)));
+        assertThat(t.getOrElse(1, 42)).isEqualTo(2);
+        assertThat(t.containsKey(1)).isTrue();
+    }
+
+    @Test
+    public void putOverwritesExistingKey() {
+        final HashArrayMappedTrie<Integer, Integer> t = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 2).put(1, 3);
+        assertThat(t.size()).isEqualTo(1);
+        assertThat(t.get(1)).isEqualTo(Option.some(3));
+    }
+
+    @Test
+    public void putAdoptsTheReplacingKeyInstance() {
+        // Two equal-but-distinct keys; vavr's HashArrayMappedTrie surfaces the *replacing*
+        // key instance after an overwrite, even when the value is equal.
+        final WeakInteger first = new WeakInteger(1);
+        final WeakInteger replacingNewValue = new WeakInteger(1);
+        final WeakInteger replacingEqualValue = new WeakInteger(1);
+
+        HashArrayMappedTrie<WeakInteger, String> t = CompressedHashArrayMappedPrefixTrie.empty();
+        t = t.put(first, "a").put(replacingNewValue, "b");
+        assertThat(t.size()).isEqualTo(1);
+        assertThat(t.getEntry(first).get()._1).isSameAs(replacingNewValue);
+        assertThat(t.getEntry(first).get()._2).isEqualTo("b");
+
+        t = t.put(replacingEqualValue, "b"); // equal value must still adopt the new key instance
+        assertThat(t.getEntry(first).get()._1).isSameAs(replacingEqualValue);
+    }
+
+    @Test
+    public void putIsImmutable() {
+        final HashArrayMappedTrie<Integer, Integer> a = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 1);
+        final HashArrayMappedTrie<Integer, Integer> b = a.put(2, 2);
+        assertThat(a.containsKey(2)).isFalse();
+        assertThat(b.containsKey(2)).isTrue();
+        assertThat(a.size()).isEqualTo(1);
+        assertThat(b.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void supportsNullKeyAndValue() {
+        final HashArrayMappedTrie<Integer, Integer> t = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(null, 7).put(3, null);
+        assertThat(t.get(null)).isEqualTo(Option.some(7));
+        assertThat(t.get(3)).isEqualTo(Option.some(null));
+        assertThat(t.containsKey(3)).isTrue();
+        assertThat(t.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void removeShrinksBackToEmpty() {
+        HashArrayMappedTrie<Integer, Integer> t = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 1).put(2, 2);
+        t = t.remove(1);
+        assertThat(t.size()).isEqualTo(1);
+        assertThat(t.containsKey(1)).isFalse();
+        assertThat(t.get(2)).isEqualTo(Option.some(2));
+        t = t.remove(2);
+        assertThat(t.isEmpty()).isTrue();
+        assertThat(t.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void removeUnknownKeyIsNoOp() {
+        final HashArrayMappedTrie<Integer, Integer> t = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 1);
+        assertThat(t.remove(2).size()).isEqualTo(1);
+        assertThat(CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().remove(99).size()).isEqualTo(0);
+    }
+
+    // -- singleton (one-entry) representation
+
+    @Test
+    public void singleEntryTrieUsesSingletonRepresentation() {
+        final HashArrayMappedTrie<Integer, Integer> t = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 2);
+        assertThat(t.getClass().getSimpleName()).isEqualTo("SingletonTrie");
+        // replacing the value of the only key must stay in the singleton representation
+        assertThat(t.put(1, 99).getClass().getSimpleName()).isEqualTo("SingletonTrie");
+    }
+
+    @Test
+    public void removalCollapseKeepsNullKeySingleton() {
+        HashArrayMappedTrie<Integer, Integer> t = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(null, 7).put(3, 3);
+        t = t.remove(3); // the surviving entry of the collapse has a null key (hash 0)
+        assertThat(t.getClass().getSimpleName()).isEqualTo("SingletonTrie");
+        assertThat(t.get(null)).isEqualTo(Option.some(7));
+        assertThat(t.containsKey(null)).isTrue();
+        assertThat(t.remove(null)).isSameAs(CompressedHashArrayMappedPrefixTrie.empty());
+    }
+
+    @Test
+    public void emptyTrieSerializationPreservesSingletonIdentity() throws Exception {
+        // the trie is only ever serialized directly in-package; HashMap/HashSet go through proxies
+        final java.io.ByteArrayOutputStream bytes = new java.io.ByteArrayOutputStream();
+        try (java.io.ObjectOutputStream out = new java.io.ObjectOutputStream(bytes)) {
+            out.writeObject(CompressedHashArrayMappedPrefixTrie.empty());
+        }
+        try (java.io.ObjectInputStream in = new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(bytes.toByteArray()))) {
+            assertThat(in.readObject()).isSameAs(CompressedHashArrayMappedPrefixTrie.empty());
+        }
+    }
+
+    @Test
+    public void removalToSizeOneCollapsesToSingletonRepresentation() {
+        // shallow: two root-level payloads
+        HashArrayMappedTrie<Integer, Integer> shallow = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 1).put(2, 2);
+        assertThat(shallow.getClass().getSimpleName()).isEqualTo("CompressedHashArrayMappedPrefixTrie");
+        shallow = shallow.remove(2);
+        assertThat(shallow.getClass().getSimpleName()).isEqualTo("SingletonTrie");
+        assertThat(shallow.size()).isEqualTo(1);
+        assertThat(shallow.get(1)).isEqualTo(Option.some(1));
+
+        // deep: keys diverging only at the last bitmap level (shift 30)
+        HashArrayMappedTrie<Integer, Integer> deep = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(0, 0).put(1 << 30, 30);
+        deep = deep.remove(0);
+        assertThat(deep.getClass().getSimpleName()).isEqualTo("SingletonTrie");
+        assertThat(deep.get(1 << 30)).isEqualTo(Option.some(30));
+
+        // collision: two keys with identical 32-bit hashes
+        HashArrayMappedTrie<WeakInteger, Integer> collision = CompressedHashArrayMappedPrefixTrie.<WeakInteger, Integer>empty()
+                .put(new WeakInteger(1), 1)
+                .put(new WeakInteger(11), 11);
+        collision = collision.remove(new WeakInteger(1));
+        assertThat(collision.getClass().getSimpleName()).isEqualTo("SingletonTrie");
+        assertThat(collision.get(new WeakInteger(11))).isEqualTo(Option.some(11));
+    }
+
+    @Test
+    public void removingTheLastEntryReturnsTheEmptySingleton() {
+        final HashArrayMappedTrie<Integer, Integer> single = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 1);
+        assertThat(single.remove(1)).isSameAs(CompressedHashArrayMappedPrefixTrie.empty());
+
+        HashArrayMappedTrie<Integer, Integer> drained = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 1).put(2, 2);
+        drained = drained.remove(1).remove(2);
+        assertThat(drained).isSameAs(CompressedHashArrayMappedPrefixTrie.empty());
+    }
+
+    @Test
+    public void singletonRemoveOfUnknownKeyReturnsSameInstance() {
+        final HashArrayMappedTrie<Integer, Integer> t = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 1);
+        assertThat(t.remove(99)).isSameAs(t);
+        assertThat(t.remove(null)).isSameAs(t);
+    }
+
+    @Test
+    public void singletonSupportsNullKeyAndNullValue() {
+        final HashArrayMappedTrie<Integer, Integer> nullKey = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(null, 7);
+        assertThat(nullKey.get(null)).isEqualTo(Option.some(7));
+        assertThat(nullKey.containsKey(null)).isTrue();
+        assertThat(nullKey.getEntry(null)).isEqualTo(Option.some(Tuple.of((Integer) null, 7)));
+
+        final HashArrayMappedTrie<Integer, Integer> nullValue = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(3, null);
+        assertThat(nullValue.get(3)).isEqualTo(Option.some(null));
+        assertThat(nullValue.getOrElse(3, 42)).isNull(); // present-with-null must NOT fall back to the default
+    }
+
+    @Test
+    public void singletonIteratorsYieldTheSingleEntry() {
+        final HashArrayMappedTrie<Integer, Integer> t = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 2);
+        assertThat(List.ofAll(t.iterator())).isEqualTo(List.of(Tuple.of(1, 2)));
+        assertThat(List.ofAll(t.keysIterator())).isEqualTo(List.of(1));
+        assertThat(List.ofAll(t.valuesIterator())).isEqualTo(List.of(2));
+        final Iterator<Tuple2<Integer, Integer>> it = t.iterator();
+        it.next();
+        assertThat(it.hasNext()).isFalse();
+    }
+
+    @Test
+    public void singletonGrowsOutInAllThreeShapes() {
+        final HashArrayMappedTrie<Integer, Integer> base = CompressedHashArrayMappedPrefixTrie.<Integer, Integer>empty().put(1, 1);
+
+        // distinct root masks
+        final HashArrayMappedTrie<Integer, Integer> distinct = base.put(2, 2);
+        assertThat(distinct.size()).isEqualTo(2);
+        assertThat(distinct.get(1)).isEqualTo(Option.some(1));
+        assertThat(distinct.get(2)).isEqualTo(Option.some(2));
+
+        // shared low bits force a sub-node chain
+        final HashArrayMappedTrie<Integer, Integer> deep = base.put(1 + (1 << 30), 30);
+        assertThat(deep.size()).isEqualTo(2);
+        assertThat(deep.get(1)).isEqualTo(Option.some(1));
+        assertThat(deep.get(1 + (1 << 30))).isEqualTo(Option.some(30));
+
+        // full 32-bit collision straight out of the singleton
+        final HashArrayMappedTrie<WeakInteger, Integer> collision = CompressedHashArrayMappedPrefixTrie.<WeakInteger, Integer>empty()
+                .put(new WeakInteger(1), 1)
+                .put(new WeakInteger(11), 11);
+        assertThat(collision.size()).isEqualTo(2);
+        assertThat(collision.get(new WeakInteger(1))).isEqualTo(Option.some(1));
+        assertThat(collision.get(new WeakInteger(11))).isEqualTo(Option.some(11));
+    }
+
+    @Test
+    public void churnsAcrossEmptyAndSingletonBoundaries() {
+        final Random r = new Random(4242);
+        HashArrayMappedTrie<Integer, Integer> ch = champ();
+        HashArrayMappedTrie<Integer, Integer> or = hamt();
+        for (int op = 0; op < 5000; op++) {
+            final int key = r.nextInt(3); // tiny key space keeps the size oscillating around 0..3
+            if (r.nextBoolean()) {
+                ch = ch.put(key, op);
+                or = or.put(key, op);
+            } else {
+                ch = ch.remove(key);
+                or = or.remove(key);
+            }
+            assertRepresentationInvariant(ch);
+            if (op % 100 == 0) {
+                assertSameContent(ch, or);
+            }
+        }
+        for (int k = 0; k < 3; k++) {
+            ch = ch.remove(k);
+            or = or.remove(k);
+        }
+        assertSameContent(ch, or);
+        ch = ch.put(9, 9);
+        or = or.put(9, 9);
+        assertSameContent(ch, or);
+    }
+
+    @Test
+    public void handlesHashCollisions() {
+        // WeakInteger hashes to value%10, so 1, 11, 21, 31 all collide.
+        HashArrayMappedTrie<WeakInteger, Integer> t = champ();
+        final int[] keys = {1, 11, 21, 31};
+        for (int k : keys) {
+            t = t.put(new WeakInteger(k), k);
+        }
+        assertThat(t.size()).isEqualTo(4);
+        for (int k : keys) {
+            assertThat(t.get(new WeakInteger(k))).isEqualTo(Option.some(k));
+        }
+        t = t.remove(new WeakInteger(21));
+        assertThat(t.size()).isEqualTo(3);
+        assertThat(t.get(new WeakInteger(21))).isEqualTo(Option.none());
+        assertThat(t.get(new WeakInteger(11))).isEqualTo(Option.some(11));
+    }
+
+    @Test
+    public void buildsDeepestTree() {
+        // Keys 1<<i share low bits, forcing maximum depth.
+        HashArrayMappedTrie<Integer, Integer> t = champ();
+        final List<Integer> ints = List.tabulate(Integer.SIZE, i -> 1 << i);
+        t = ints.foldLeft(t, (h, i) -> h.put(i, i));
+        assertThat(t.size()).isEqualTo(Integer.SIZE);
+        assertThat(List.ofAll(t.keysIterator()).sorted()).isEqualTo(ints.sorted());
+        for (int i : ints) {
+            assertThat(t.get(i)).isEqualTo(Option.some(i));
+        }
+    }
+
+    @Test
+    public void iteratorYieldsAllEntries() {
+        HashArrayMappedTrie<Integer, Integer> t = champ();
+        for (int i = 0; i < 1000; i++) {
+            t = t.put(i, i * 2);
+        }
+        final java.util.TreeMap<Integer, Integer> seen = new java.util.TreeMap<>();
+        t.iterator().forEachRemaining(e -> seen.put(e._1, e._2));
+        assertThat(seen.size()).isEqualTo(1000);
+        for (int i = 0; i < 1000; i++) {
+            assertThat(seen.get(i)).isEqualTo(i * 2);
+        }
+        assertThat(List.ofAll(t.keysIterator()).sorted()).isEqualTo(List.range(0, 1000));
+        assertThat(List.ofAll(t.valuesIterator()).sorted())
+                .isEqualTo(List.range(0, 1000).map(i -> i * 2));
+    }
+
+    /**
+     * The workhorse: drive CHAMP and the trusted HAMT oracle through the same random
+     * sequence of puts and removes, asserting they stay observationally identical.
+     */
+    @Test
+    public void differentialAgainstHamtOracle() {
+        final Random r = new Random(42);
+        for (int trial = 0; trial < 50; trial++) {
+            HashArrayMappedTrie<Integer, Integer> ch = champ();
+            HashArrayMappedTrie<Integer, Integer> or = hamt();
+            final int keySpace = 1 + r.nextInt(2000); // sometimes tiny → lots of churn
+            for (int op = 0; op < 4000; op++) {
+                final int key = r.nextInt(keySpace);
+                if (r.nextInt(3) == 0) {
+                    ch = ch.remove(key);
+                    or = or.remove(key);
+                } else {
+                    final int value = r.nextInt();
+                    ch = ch.put(key, value);
+                    or = or.put(key, value);
+                }
+                if (op % 250 == 0) {
+                    assertSameContent(ch, or);
+                }
+            }
+            assertSameContent(ch, or);
+        }
+    }
+
+    @Test
+    public void differentialWithWeakHashes() {
+        final Random r = new Random(7);
+        HashArrayMappedTrie<WeakInteger, Integer> ch = champ();
+        HashArrayMappedTrie<WeakInteger, Integer> or = hamt();
+        for (int op = 0; op < 20000; op++) {
+            final WeakInteger key = new WeakInteger(r.nextInt(500));
+            if (r.nextInt(3) == 0) {
+                ch = ch.remove(key);
+                or = or.remove(key);
+            } else {
+                final int value = r.nextInt();
+                ch = ch.put(key, value);
+                or = or.put(key, value);
+            }
+        }
+        assertSameContent(ch, or);
+    }
+
+    /** Size 0 must be the shared EMPTY, size 1 the SingletonTrie, size >= 2 the general trie. */
+    private static void assertRepresentationInvariant(HashArrayMappedTrie<?, ?> t) {
+        if (t.size() == 0) {
+            assertThat(t).isSameAs(CompressedHashArrayMappedPrefixTrie.empty());
+        } else if (t.size() == 1) {
+            assertThat(t.getClass().getSimpleName()).isEqualTo("SingletonTrie");
+        } else {
+            assertThat(t.getClass().getSimpleName()).isEqualTo("CompressedHashArrayMappedPrefixTrie");
+        }
+    }
+
+    private static <K, V> void assertSameContent(HashArrayMappedTrie<K, V> actual, HashArrayMappedTrie<K, V> oracle) {
+        assertThat(actual.size()).isEqualTo(oracle.size());
+        assertThat(actual.isEmpty()).isEqualTo(oracle.isEmpty());
+        // every oracle entry is present and equal in actual
+        oracle.iterator().forEachRemaining(e -> {
+            assertThat(actual.containsKey(e._1)).as("containsKey %s", e._1).isTrue();
+            assertThat(actual.get(e._1)).as("get %s", e._1).isEqualTo(Option.some(e._2));
+        });
+        // actual carries no extra entries
+        final java.util.List<Tuple2<K, V>> actualEntries = new ArrayList<>();
+        actual.iterator().forEachRemaining(actualEntries::add);
+        assertThat(actualEntries.size()).isEqualTo(oracle.size());
+        actualEntries.forEach(e -> assertThat(oracle.get(e._1)).isEqualTo(Option.some(e._2)));
+    }
+
+    private static final class WeakInteger implements Comparable<WeakInteger> {
+        final int value;
+
+        WeakInteger(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) { return true; }
+            if (o == null || getClass() != o.getClass()) { return false; }
+            return value == ((WeakInteger) o).value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Math.abs(value) % 10;
+        }
+
+        @Override
+        public int compareTo(WeakInteger other) {
+            return Integer.compare(value, other.value);
+        }
+    }
+}


### PR DESCRIPTION
```
Benchmark                 (impl)  (size)  Mode  Cnt         Score        Error  Units
ChampBenchmark.build        HAMT    1000  avgt    5     40412,652 ±   3625,582  ns/op
ChampBenchmark.build        HAMT  100000  avgt    5  12125466,140 ± 895719,885  ns/op
ChampBenchmark.build       CHAMP    1000  avgt    5     38068,962 ±   2847,429  ns/op
ChampBenchmark.build       CHAMP  100000  avgt    5  11766003,370 ± 293445,736  ns/op
ChampBenchmark.getHits      HAMT    1000  avgt    5      9985,895 ±    303,695  ns/op
ChampBenchmark.getHits      HAMT  100000  avgt    5   1430105,896 ±  41572,685  ns/op
ChampBenchmark.getHits     CHAMP    1000  avgt    5      6200,917 ±     95,626  ns/op
ChampBenchmark.getHits     CHAMP  100000  avgt    5   1535244,726 ± 169583,059  ns/op
ChampBenchmark.getMisses    HAMT    1000  avgt    5     13933,988 ±    994,297  ns/op
ChampBenchmark.getMisses    HAMT  100000  avgt    5   1461675,983 ±  41463,538  ns/op
ChampBenchmark.getMisses   CHAMP    1000  avgt    5      4418,984 ±    260,752  ns/op
ChampBenchmark.getMisses   CHAMP  100000  avgt    5   1415779,650 ±  47722,420  ns/op
ChampBenchmark.iterate      HAMT    1000  avgt    5     16934,578 ±    293,880  ns/op
ChampBenchmark.iterate      HAMT  100000  avgt    5   1190281,491 ± 101411,728  ns/op
ChampBenchmark.iterate     CHAMP    1000  avgt    5      3452,472 ±     38,657  ns/op
ChampBenchmark.iterate     CHAMP  100000  avgt    5    418659,706 ±  18000,520  ns/op
ChampBenchmark.removeAll    HAMT    1000  avgt    5     50185,017 ±   2925,834  ns/op
ChampBenchmark.removeAll    HAMT  100000  avgt    5  11681454,369 ± 288621,124  ns/op
ChampBenchmark.removeAll   CHAMP    1000  avgt    5     39168,782 ±    718,661  ns/op
ChampBenchmark.removeAll   CHAMP  100000  avgt    5  11812498,319 ± 675224,685  ns/op
```