### PR TITLE
improve LinkedHashMap/LinkedHashSet#remove() performance via tombstoned order slots

### DIFF
--- a/vavr/pom.xml
+++ b/vavr/pom.xml
@@ -49,6 +49,20 @@
             <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- JMH micro-benchmarks (test scope only), run via io.vavr.JmhRunner -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -86,4 +100,54 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Enables JMH annotation processing for test sources so @Benchmark classes generate
+             their runners. Gated behind a profile to keep the normal build intact. -->
+        <profile>
+            <id>jmh-bench</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                                <configuration>
+                                    <compilerArgs>
+                                        <arg>-Xlint:none</arg>
+                                    </compilerArgs>
+                                    <annotationProcessorPaths combine.self="override">
+                                        <path>
+                                            <groupId>io.vavr</groupId>
+                                            <artifactId>vavr-match</artifactId>
+                                            <version>1.0.0</version>
+                                        </path>
+                                        <path>
+                                            <groupId>io.vavr</groupId>
+                                            <artifactId>vavr-match-processor</artifactId>
+                                            <version>1.0.0</version>
+                                        </path>
+                                        <path>
+                                            <groupId>org.openjdk.jmh</groupId>
+                                            <artifactId>jmh-generator-annprocess</artifactId>
+                                            <version>${jmh.version}</version>
+                                        </path>
+                                    </annotationProcessorPaths>
+                                    <annotationProcessors combine.self="override">
+                                        <annotationProcessor>io.vavr.match.PatternsProcessor</annotationProcessor>
+                                        <annotationProcessor>org.openjdk.jmh.generators.BenchmarkProcessor</annotationProcessor>
+                                    </annotationProcessors>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -21,6 +21,11 @@ package io.vavr.collection;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.control.Option;
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -47,14 +52,30 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final LinkedHashMap<?, ?> EMPTY = new LinkedHashMap<>(Vector.empty(), HashMap.empty());
+    private static final Object TOMBSTONE = new Object();
+
+    private static final LinkedHashMap<?, ?> EMPTY = new LinkedHashMap<>(Vector.empty(), HashMap.empty(), 0, 0);
 
     private final Vector<K> list;
-    private final HashMap<K, V> map;
 
-    private LinkedHashMap(Vector<K> list, HashMap<K, V> map) {
+    private final HashMap<K, Slot<V>> map;
+
+    private final int offset;
+
+    private final int tombstones;
+
+    private LinkedHashMap(Vector<K> list, HashMap<K, Slot<V>> map, int offset, int tombstones) {
         this.list = list;
         this.map = map;
+        this.offset = offset;
+        this.tombstones = tombstones;
+    }
+
+    private record Slot<V>(V value, int index) implements Serializable {}
+
+    @SuppressWarnings("unchecked")
+    private static <K> K tombstone() {
+        return (K) TOMBSTONE;
     }
 
     /**
@@ -646,12 +667,14 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public Option<V> get(K key) {
-        return map.get(key);
+        final Slot<V> slot = map.getOrElse(key, null);
+        return slot == null ? Option.none() : Option.some(slot.value());
     }
 
     @Override
     public V getOrElse(K key, V defaultValue) {
-        return map.getOrElse(key, defaultValue);
+        final Slot<V> slot = map.getOrElse(key, null);
+        return slot == null ? defaultValue : slot.value();
     }
 
     @Override
@@ -666,7 +689,8 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public Tuple2<K, V> head() {
-        return map.getEntry(list.head()).get();
+        final Tuple2<K, Slot<V>> entry = map.getEntry(list.head()).get();
+        return Tuple.of(entry._1, entry._2.value());
     }
 
     @Override
@@ -674,7 +698,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         if (isEmpty()) {
             throw new UnsupportedOperationException("init of empty LinkedHashMap");
         } else {
-            return wrap(list.init(), map.remove(list.last()));
+            return remove(list.last());
         }
     }
 
@@ -715,17 +739,20 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public @NonNull Iterator<Tuple2<K, V>> iterator() {
-        return list.iterator().map(key -> map.getEntry(key).get());
+        return list.iterator().filter(key -> key != TOMBSTONE).map(key -> {
+            final Tuple2<K, Slot<V>> entry = map.getEntry(key).get();
+            return Tuple.of(entry._1, entry._2.value());
+        });
     }
 
     @Override
     public Iterator<K> keysIterator() {
-        return list.iterator();
+        return list.iterator().filter(key -> key != TOMBSTONE).map(key -> map.getEntry(key).get()._1);
     }
 
     @Override
     public Iterator<V> valuesIterator() {
-        return list.iterator().map(key -> map.get(key).get());
+        return list.iterator().filter(key -> key != TOMBSTONE).map(key -> map.get(key).get().value());
     }
 
     @SuppressWarnings("unchecked")
@@ -736,7 +763,8 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public Tuple2<K, V> last() {
-        return map.getEntry(list.last()).get();
+        final Tuple2<K, Slot<V>> entry = map.getEntry(list.last()).get();
+        return Tuple.of(entry._1, entry._2.value());
     }
 
     @Override
@@ -815,10 +843,12 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     @Override
     public LinkedHashMap<K, V> put(K key, V value) {
-        final boolean containsKey = map.containsKey(key);
-        final HashMap<K, V> newMap = map.put(key, value);
-        final Vector<K> newList = containsKey ? list : list.append(key);
-        return wrap(newList, newMap);
+        final Slot<V> existing = map.getOrElse(key, null);
+        if (existing != null) {
+            return new LinkedHashMap<>(list, map.put(key, new Slot<>(value, existing.index())), offset, tombstones);
+        } else {
+            return new LinkedHashMap<>(list.append(key), map.put(key, new Slot<>(value, offset + list.size())), offset, tombstones);
+        }
     }
 
     @Override
@@ -834,13 +864,17 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public LinkedHashMap<K, V> remove(K key) {
-        if (containsKey(key)) {
-            final Vector<K> newList = list.removeFirst(k -> Objects.equals(k, key));
-            final HashMap<K, V> newMap = map.remove(key);
-            return wrap(newList, newMap);
-        } else {
+        final Slot<V> existing = map.getOrElse(key, null);
+        if (existing == null) {
             return this;
         }
+        final HashMap<K, Slot<V>> newMap = map.remove(key);
+        if (newMap.isEmpty()) {
+            return empty();
+        }
+        final K tombstone = tombstone();
+        final Vector<K> newList = list.update(existing.index() - offset, tombstone);
+        return normalized(newList, newMap, offset, tombstones + 1);
     }
 
     @Override
@@ -854,9 +888,8 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public LinkedHashMap<K, V> removeAll(@NonNull Iterable<? extends K> keys) {
         Objects.requireNonNull(keys, "keys is null");
         final HashSet<K> toRemove = HashSet.ofAll(keys);
-        final Vector<K> newList = list.filter(k -> !toRemove.contains(k));
-        final HashMap<K, V> newMap = map.filter(t -> !toRemove.contains(t._1));
-        return newList.size() == size() ? this : wrap(newList, newMap);
+        final HashMap<K, Slot<V>> newMap = map.filter(t -> !toRemove.contains(t._1));
+        return newMap.size() == map.size() ? this : reindex(list, newMap);
     }
 
     @Override
@@ -882,7 +915,8 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         if (!Objects.equals(currentElement, newElement) && contains(currentElement)) {
 
             Vector<K> newList = list;
-            HashMap<K, V> newMap = map;
+            HashMap<K, Slot<V>> newMap = map;
+            int newTombstones = tombstones;
 
             final K currentKey = currentElement._1;
             final K newKey = newElement._1;
@@ -890,13 +924,18 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
             // If current key and new key are equal, the key keeps its position,
             // otherwise we need to remove an already present newKey from the order manually.
             if (!Objects.equals(currentKey, newKey) && newMap.containsKey(newKey)) {
-                newList = newList.remove(newKey);
+                final Slot<V> obsolete = newMap.get(newKey).get();
+                final K tombstone = tombstone();
+                newList = newList.update(obsolete.index() - offset, tombstone);
+                newMap = newMap.remove(newKey);
+                newTombstones++;
             }
 
-            newList = newList.replace(currentKey, newKey);
-            newMap = newMap.remove(currentKey).put(newElement);
+            final Slot<V> currentSlot = newMap.get(currentKey).get();
+            newList = newList.update(currentSlot.index() - offset, newKey);
+            newMap = newMap.remove(currentKey).put(newKey, new Slot<>(newElement._2, currentSlot.index()));
 
-            return wrap(newList, newMap);
+            return normalized(newList, newMap, offset, newTombstones);
 
         } else {
             return this;
@@ -972,7 +1011,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         if (isEmpty()) {
             throw new UnsupportedOperationException("tail of empty LinkedHashMap");
         } else {
-            return wrap(list.tail(), map.remove(list.head()));
+            return remove(list.head());
         }
     }
 
@@ -1021,10 +1060,6 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         return Collections.hashUnordered(this);
     }
 
-    private Object readResolve() {
-        return isEmpty() ? EMPTY : this;
-    }
-
     @Override
     public String stringPrefix() {
         return "LinkedHashMap";
@@ -1045,7 +1080,15 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      * @return A new Map containing the given map with given key order
      */
     private static <K, V> LinkedHashMap<K, V> wrap(@NonNull Vector<K> list, HashMap<K, V> map) {
-        return list.isEmpty() ? empty() : new LinkedHashMap<>(list, map);
+        if (list.isEmpty()) {
+            return empty();
+        }
+        HashMap<K, Slot<V>> indexed = HashMap.empty();
+        int index = 0;
+        for (K key : list) {
+            indexed = indexed.put(key, new Slot<>(map.get(key).get(), index++));
+        }
+        return new LinkedHashMap<>(list, indexed, 0, 0);
     }
 
     /**
@@ -1058,20 +1101,107 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      * @return A new Map containing the given map with given key order
      */
     private static <K, V> LinkedHashMap<K, V> wrapNonUnique(@NonNull Vector<K> list, HashMap<K, V> map) {
-        if (list.isEmpty()) {
-            return empty();
-        }
         if (list.size() == map.size()) {
-            return new LinkedHashMap<>(list, map);
+            return wrap(list, map);
         }
         // Keep the last occurrence of every key, matching the value precedence in `map`.
-        return new LinkedHashMap<>(list.reverse().distinct().reverse().toVector(), map);
+        return wrap(list.reverse().distinct().reverse().toVector(), map);
+    }
+
+    private static <K, V> LinkedHashMap<K, V> normalized(Vector<K> list, HashMap<K, Slot<V>> map, int offset, int tombstones) {
+        while (list.head() == TOMBSTONE) {
+            list = list.tail();
+            offset++;
+            tombstones--;
+        }
+        while (list.last() == TOMBSTONE) {
+            list = list.init();
+            tombstones--;
+        }
+        if (tombstones > map.size()) {
+            return reindex(list, map);
+        }
+        return new LinkedHashMap<>(list, map, offset, tombstones);
+    }
+
+    private static <K, V> LinkedHashMap<K, V> reindex(Vector<K> list, HashMap<K, Slot<V>> survivors) {
+        if (survivors.isEmpty()) {
+            return empty();
+        }
+        final ArrayList<K> liveKeys = new ArrayList<>(survivors.size());
+        for (K key : list) {
+            if (key != TOMBSTONE && survivors.containsKey(key)) {
+                liveKeys.add(key);
+            }
+        }
+        HashMap<K, Slot<V>> indexed = HashMap.empty();
+        int index = 0;
+        for (K key : liveKeys) {
+            indexed = indexed.put(key, new Slot<>(survivors.get(key).get().value(), index++));
+        }
+        return new LinkedHashMap<>(Vector.ofAll(liveKeys), indexed, 0, 0);
     }
 
     // We need this method to narrow the argument of `ofEntries`.
     // If this method is static with type args <K, V>, the jdk fails to infer types at the call site.
     private LinkedHashMap<K, V> createFromEntries(Iterable<Tuple2<K, V>> tuples) {
         return LinkedHashMap.ofEntries(tuples);
+    }
+
+    // -- Serialization
+
+    @Serial
+    private Object writeReplace() {
+        return new SerializationProxy<>(this);
+    }
+
+    @Serial
+    private void readObject(ObjectInputStream stream) throws InvalidObjectException {
+        throw new InvalidObjectException("Proxy required");
+    }
+
+    private static final class SerializationProxy<K, V> implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private transient LinkedHashMap<K, V> map;
+
+        SerializationProxy(LinkedHashMap<K, V> map) {
+            this.map = map;
+        }
+
+        @Serial
+        private void writeObject(ObjectOutputStream s) throws IOException {
+            s.defaultWriteObject();
+            s.writeInt(map.size());
+            for (Tuple2<K, V> e : map) {
+                s.writeObject(e._1);
+                s.writeObject(e._2);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        @Serial
+        private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
+            s.defaultReadObject();
+            final int size = s.readInt();
+            if (size < 0) {
+                throw new InvalidObjectException("No elements");
+            }
+            LinkedHashMap<K, V> temp = LinkedHashMap.empty();
+            for (int i = 0; i < size; i++) {
+                final K key = (K) s.readObject();
+                final V value = (V) s.readObject();
+                temp = temp.put(key, value);
+            }
+            map = temp;
+        }
+
+        @Serial
+        private Object readResolve() {
+            return map;
+        }
     }
 
 }

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -58,20 +58,20 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     private final Vector<K> list;
 
-    private final HashMap<K, Slot<V>> map;
+    private final HashMap<K, Slot<K, V>> map;
 
     private final int offset;
 
     private final int tombstones;
 
-    private LinkedHashMap(Vector<K> list, HashMap<K, Slot<V>> map, int offset, int tombstones) {
+    private LinkedHashMap(Vector<K> list, HashMap<K, Slot<K, V>> map, int offset, int tombstones) {
         this.list = list;
         this.map = map;
         this.offset = offset;
         this.tombstones = tombstones;
     }
 
-    private record Slot<V>(V value, int index) implements Serializable {}
+    private record Slot<K, V>(Tuple2<K, V> entry, int index) implements Serializable {}
 
     @SuppressWarnings("unchecked")
     private static <K> K tombstone() {
@@ -667,14 +667,14 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public Option<V> get(K key) {
-        final Slot<V> slot = map.getOrElse(key, null);
-        return slot == null ? Option.none() : Option.some(slot.value());
+        final Slot<K, V> slot = map.getOrElse(key, null);
+        return slot == null ? Option.none() : Option.some(slot.entry()._2);
     }
 
     @Override
     public V getOrElse(K key, V defaultValue) {
-        final Slot<V> slot = map.getOrElse(key, null);
-        return slot == null ? defaultValue : slot.value();
+        final Slot<K, V> slot = map.getOrElse(key, null);
+        return slot == null ? defaultValue : slot.entry()._2;
     }
 
     @Override
@@ -689,8 +689,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public Tuple2<K, V> head() {
-        final Tuple2<K, Slot<V>> entry = map.getEntry(list.head()).get();
-        return Tuple.of(entry._1, entry._2.value());
+        return map.get(list.head()).get().entry();
     }
 
     @Override
@@ -739,20 +738,39 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public @NonNull Iterator<Tuple2<K, V>> iterator() {
-        return list.iterator().filter(key -> key != TOMBSTONE).map(key -> {
-            final Tuple2<K, Slot<V>> entry = map.getEntry(key).get();
-            return Tuple.of(entry._1, entry._2.value());
-        });
+        final Iterator<K> slots = list.iterator();
+        return new AbstractIterator<Tuple2<K, V>>() {
+            private K nextKey;
+            private boolean nextKeyDefined;
+
+            @Override
+            public boolean hasNext() {
+                while (!nextKeyDefined && slots.hasNext()) {
+                    final K key = slots.next();
+                    if (key != TOMBSTONE) {
+                        nextKey = key;
+                        nextKeyDefined = true;
+                    }
+                }
+                return nextKeyDefined;
+            }
+
+            @Override
+            protected Tuple2<K, V> getNext() {
+                nextKeyDefined = false;
+                return map.get(nextKey).get().entry();
+            }
+        };
     }
 
     @Override
     public Iterator<K> keysIterator() {
-        return list.iterator().filter(key -> key != TOMBSTONE).map(key -> map.getEntry(key).get()._1);
+        return iterator().map(entry -> entry._1);
     }
 
     @Override
     public Iterator<V> valuesIterator() {
-        return list.iterator().filter(key -> key != TOMBSTONE).map(key -> map.get(key).get().value());
+        return iterator().map(entry -> entry._2);
     }
 
     @SuppressWarnings("unchecked")
@@ -763,8 +781,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public Tuple2<K, V> last() {
-        final Tuple2<K, Slot<V>> entry = map.getEntry(list.last()).get();
-        return Tuple.of(entry._1, entry._2.value());
+        return map.get(list.last()).get().entry();
     }
 
     @Override
@@ -843,11 +860,11 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
      */
     @Override
     public LinkedHashMap<K, V> put(K key, V value) {
-        final Slot<V> existing = map.getOrElse(key, null);
+        final Slot<K, V> existing = map.getOrElse(key, null);
         if (existing != null) {
-            return new LinkedHashMap<>(list, map.put(key, new Slot<>(value, existing.index())), offset, tombstones);
+            return new LinkedHashMap<>(list, map.put(key, new Slot<>(Tuple.of(key, value), existing.index())), offset, tombstones);
         } else {
-            return new LinkedHashMap<>(list.append(key), map.put(key, new Slot<>(value, offset + list.size())), offset, tombstones);
+            return new LinkedHashMap<>(list.append(key), map.put(key, new Slot<>(Tuple.of(key, value), offset + list.size())), offset, tombstones);
         }
     }
 
@@ -864,11 +881,11 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public LinkedHashMap<K, V> remove(K key) {
-        final Slot<V> existing = map.getOrElse(key, null);
+        final Slot<K, V> existing = map.getOrElse(key, null);
         if (existing == null) {
             return this;
         }
-        final HashMap<K, Slot<V>> newMap = map.remove(key);
+        final HashMap<K, Slot<K, V>> newMap = map.remove(key);
         if (newMap.isEmpty()) {
             return empty();
         }
@@ -888,7 +905,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
     public LinkedHashMap<K, V> removeAll(@NonNull Iterable<? extends K> keys) {
         Objects.requireNonNull(keys, "keys is null");
         final HashSet<K> toRemove = HashSet.ofAll(keys);
-        final HashMap<K, Slot<V>> newMap = map.filter(t -> !toRemove.contains(t._1));
+        final HashMap<K, Slot<K, V>> newMap = map.filter(t -> !toRemove.contains(t._1));
         return newMap.size() == map.size() ? this : reindex(list, newMap);
     }
 
@@ -915,7 +932,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         if (!Objects.equals(currentElement, newElement) && contains(currentElement)) {
 
             Vector<K> newList = list;
-            HashMap<K, Slot<V>> newMap = map;
+            HashMap<K, Slot<K, V>> newMap = map;
             int newTombstones = tombstones;
 
             final K currentKey = currentElement._1;
@@ -924,16 +941,16 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
             // If current key and new key are equal, the key keeps its position,
             // otherwise we need to remove an already present newKey from the order manually.
             if (!Objects.equals(currentKey, newKey) && newMap.containsKey(newKey)) {
-                final Slot<V> obsolete = newMap.get(newKey).get();
+                final Slot<K, V> obsolete = newMap.get(newKey).get();
                 final K tombstone = tombstone();
                 newList = newList.update(obsolete.index() - offset, tombstone);
                 newMap = newMap.remove(newKey);
                 newTombstones++;
             }
 
-            final Slot<V> currentSlot = newMap.get(currentKey).get();
+            final Slot<K, V> currentSlot = newMap.get(currentKey).get();
             newList = newList.update(currentSlot.index() - offset, newKey);
-            newMap = newMap.remove(currentKey).put(newKey, new Slot<>(newElement._2, currentSlot.index()));
+            newMap = newMap.remove(currentKey).put(newKey, new Slot<>(newElement, currentSlot.index()));
 
             return normalized(newList, newMap, offset, newTombstones);
 
@@ -1083,10 +1100,10 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         if (list.isEmpty()) {
             return empty();
         }
-        HashMap<K, Slot<V>> indexed = HashMap.empty();
+        HashMap<K, Slot<K, V>> indexed = HashMap.empty();
         int index = 0;
         for (K key : list) {
-            indexed = indexed.put(key, new Slot<>(map.get(key).get(), index++));
+            indexed = indexed.put(key, new Slot<>(Tuple.of(key, map.get(key).get()), index++));
         }
         return new LinkedHashMap<>(list, indexed, 0, 0);
     }
@@ -1108,7 +1125,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         return wrap(list.reverse().distinct().reverse().toVector(), map);
     }
 
-    private static <K, V> LinkedHashMap<K, V> normalized(Vector<K> list, HashMap<K, Slot<V>> map, int offset, int tombstones) {
+    private static <K, V> LinkedHashMap<K, V> normalized(Vector<K> list, HashMap<K, Slot<K, V>> map, int offset, int tombstones) {
         while (list.head() == TOMBSTONE) {
             list = list.tail();
             offset++;
@@ -1124,7 +1141,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
         return new LinkedHashMap<>(list, map, offset, tombstones);
     }
 
-    private static <K, V> LinkedHashMap<K, V> reindex(Vector<K> list, HashMap<K, Slot<V>> survivors) {
+    private static <K, V> LinkedHashMap<K, V> reindex(Vector<K> list, HashMap<K, Slot<K, V>> survivors) {
         if (survivors.isEmpty()) {
             return empty();
         }
@@ -1134,10 +1151,10 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
                 liveKeys.add(key);
             }
         }
-        HashMap<K, Slot<V>> indexed = HashMap.empty();
+        HashMap<K, Slot<K, V>> indexed = HashMap.empty();
         int index = 0;
         for (K key : liveKeys) {
-            indexed = indexed.put(key, new Slot<>(survivors.get(key).get().value(), index++));
+            indexed = indexed.put(key, new Slot<>(survivors.get(key).get().entry(), index++));
         }
         return new LinkedHashMap<>(Vector.ofAll(liveKeys), indexed, 0, 0);
     }

--- a/vavr/src/test/java/io/vavr/JmhRunner.java
+++ b/vavr/src/test/java/io/vavr/JmhRunner.java
@@ -1,0 +1,42 @@
+/* ____  ______________  ________________________  __________
+ * \   \/   /      \   \/   /   __/   /      \   \/   /      \
+ *  \______/___/\___\______/___/_____/___/\___\______/___/\___\
+ *
+ * Copyright 2014-2026 Vavr, https://vavr.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vavr;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Programmatic JMH entry point. A benchmark name regex may be passed as the first argument
+ * (defaults to all benchmarks).
+ */
+public final class JmhRunner {
+
+    private JmhRunner() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        final String include = args.length > 0 ? args[0] : ".*Benchmark.*";
+        final Options options = new OptionsBuilder()
+                .include(include)
+                .shouldDoGC(true)
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/vavr/src/test/java/io/vavr/collection/LinkedHashMapBenchmark.java
+++ b/vavr/src/test/java/io/vavr/collection/LinkedHashMapBenchmark.java
@@ -1,0 +1,148 @@
+/* ____  ______________  ________________________  __________
+ * \   \/   /      \   \/   /   __/   /      \   \/   /      \
+ *  \______/___/\___\______/___/_____/___/\___\______/___/\___\
+ *
+ * Copyright 2014-2026 Vavr, https://vavr.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vavr.collection;
+
+import io.vavr.Tuple2;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmarks {@link LinkedHashMap} through its public API only, so the identical suite can be run
+ * against different internal representations (e.g. before/after the tombstoned-order-slots change).
+ *
+ * <p>{@code removeDrain*}/{@code removeSingle} cover the improved operations; {@code put*},
+ * {@code getHits} and {@code iterate} guard the operations that must not regress.
+ *
+ * <p>Run via {@code io.vavr.JmhRunner}.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+@State(Scope.Thread)
+public class LinkedHashMapBenchmark {
+
+    @Param({ "1000", "100000" })
+    public int size;
+
+    private Integer[] keys;
+    private Integer[] shuffledKeys;
+    private LinkedHashMap<Integer, Integer> map;
+    private int cursor;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        final Random random = new Random(0xC0FFEE);
+        final java.util.LinkedHashSet<Integer> distinct = new java.util.LinkedHashSet<>();
+        while (distinct.size() < size) {
+            distinct.add(random.nextInt(size * 4));
+        }
+        keys = distinct.toArray(new Integer[0]);
+        shuffledKeys = keys.clone();
+        final java.util.List<Integer> shuffled = java.util.Arrays.asList(shuffledKeys);
+        java.util.Collections.shuffle(shuffled, random);
+        LinkedHashMap<Integer, Integer> m = LinkedHashMap.empty();
+        for (Integer key : keys) {
+            m = m.put(key, key);
+        }
+        map = m;
+    }
+
+    // -- improved by the tombstone change
+
+    @Benchmark
+    public LinkedHashMap<Integer, Integer> removeSingle() {
+        return map.remove(shuffledKeys[cursor++ % size]);
+    }
+
+    @Benchmark
+    public LinkedHashMap<Integer, Integer> removeDrainReverseOrder() {
+        LinkedHashMap<Integer, Integer> m = map;
+        for (int i = size - 1; i >= 0; i--) {
+            m = m.remove(keys[i]);
+        }
+        return m;
+    }
+
+    @Benchmark
+    public LinkedHashMap<Integer, Integer> removeDrainRandomOrder() {
+        LinkedHashMap<Integer, Integer> m = map;
+        for (Integer key : shuffledKeys) {
+            m = m.remove(key);
+        }
+        return m;
+    }
+
+    @Benchmark
+    public LinkedHashMap<Integer, Integer> putRemoveChurn() {
+        LinkedHashMap<Integer, Integer> m = map;
+        for (int i = 0; i < size; i++) {
+            m = (i & 1) == 0 ? m.remove(shuffledKeys[i]) : m.put(shuffledKeys[i - 1], i);
+        }
+        return m;
+    }
+
+    // -- must not regress
+
+    @Benchmark
+    public LinkedHashMap<Integer, Integer> putFreshKeys() {
+        LinkedHashMap<Integer, Integer> m = LinkedHashMap.empty();
+        for (Integer key : keys) {
+            m = m.put(key, key);
+        }
+        return m;
+    }
+
+    @Benchmark
+    public LinkedHashMap<Integer, Integer> putOverwrite() {
+        LinkedHashMap<Integer, Integer> m = map;
+        for (Integer key : shuffledKeys) {
+            m = m.put(key, 42);
+        }
+        return m;
+    }
+
+    @Benchmark
+    public void getHits(Blackhole bh) {
+        for (Integer key : shuffledKeys) {
+            bh.consume(map.getOrElse(key, -1));
+        }
+    }
+
+    @Benchmark
+    public void iterate(Blackhole bh) {
+        for (Tuple2<Integer, Integer> entry : map) {
+            bh.consume(entry);
+        }
+    }
+}

--- a/vavr/src/test/java/io/vavr/collection/LinkedHashMapRemoveTest.java
+++ b/vavr/src/test/java/io/vavr/collection/LinkedHashMapRemoveTest.java
@@ -1,0 +1,161 @@
+/* ____  ______________  ________________________  __________
+ * \   \/   /      \   \/   /   __/   /      \   \/   /      \
+ *  \______/___/\___\______/___/_____/___/\___\______/___/\___\
+ *
+ * Copyright 2014-2026 Vavr, https://vavr.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vavr.collection;
+
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LinkedHashMapRemoveTest {
+
+    // -- performance: remove(key) must not scan the insertion-order structure
+
+    @Test
+    public void shouldRemoveInReverseOrderInSubQuadraticTime() {
+        final int n = 50_000;
+        LinkedHashMap<Integer, Integer> map = LinkedHashMap.empty();
+        for (int i = 0; i < n; i++) {
+            map = map.put(i, i);
+        }
+        final long start = System.nanoTime();
+        LinkedHashMap<Integer, Integer> result = map;
+        for (int i = n - 1; i >= 0; i--) {
+            result = result.remove(i);
+        }
+        final long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        assertThat(result.isEmpty()).isTrue();
+        // O(n) per remove takes seconds here; O(log n) takes tens of milliseconds.
+        // The bound is deliberately loose to stay robust on slow CI machines.
+        assertThat(elapsedMs).isLessThan(2_000);
+    }
+
+    // -- semantics: random interleaving must match java.util.LinkedHashMap
+
+    @Test
+    public void shouldMatchJavaLinkedHashMapUnderRandomPutRemoveInterleaving() {
+        for (long seed = 0; seed < 5; seed++) {
+            final Random random = new Random(seed);
+            LinkedHashMap<Integer, Integer> actual = LinkedHashMap.empty();
+            final java.util.LinkedHashMap<Integer, Integer> expected = new java.util.LinkedHashMap<>();
+            for (int op = 0; op < 5_000; op++) {
+                final int key = random.nextInt(200);
+                if (random.nextInt(3) == 0) {
+                    actual = actual.remove(key);
+                    expected.remove(key);
+                } else {
+                    actual = actual.put(key, op);
+                    expected.put(key, op);
+                }
+            }
+            assertThat(actual.size()).isEqualTo(expected.size());
+            final java.util.Iterator<java.util.Map.Entry<Integer, Integer>> expectedIterator = expected.entrySet().iterator();
+            for (Tuple2<Integer, Integer> entry : actual) {
+                final java.util.Map.Entry<Integer, Integer> expectedEntry = expectedIterator.next();
+                assertThat(entry._1).isEqualTo(expectedEntry.getKey());
+                assertThat(entry._2).isEqualTo(expectedEntry.getValue());
+            }
+            assertThat(expectedIterator.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    public void shouldKeepHeadAndLastConsistentWhileRemovingFromBothEnds() {
+        final int n = 1_001;
+        LinkedHashMap<Integer, Integer> map = LinkedHashMap.empty();
+        for (int i = 0; i < n; i++) {
+            map = map.put(i, i);
+        }
+        int lo = 0, hi = n - 1;
+        while (lo < hi) {
+            assertThat(map.head()).isEqualTo(Tuple.of(lo, lo));
+            assertThat(map.last()).isEqualTo(Tuple.of(hi, hi));
+            map = map.remove(lo++).remove(hi--);
+        }
+        assertThat(map.size()).isEqualTo(1);
+        assertThat(map.head()).isEqualTo(map.last());
+    }
+
+    @Test
+    public void shouldPreserveOrderAfterRemovingEveryOtherKey() {
+        final int n = 1_000;
+        LinkedHashMap<Integer, Integer> map = LinkedHashMap.empty();
+        for (int i = 0; i < n; i++) {
+            map = map.put(i, i);
+        }
+        for (int i = 0; i < n; i += 2) {
+            map = map.remove(i);
+        }
+        assertThat(map.keysIterator().toJavaList())
+                .isEqualTo(Iterator.range(0, n).filter(i -> i % 2 == 1).toJavaList());
+        assertThat(map.head()).isEqualTo(Tuple.of(1, 1));
+        assertThat(map.last()).isEqualTo(Tuple.of(n - 1, n - 1));
+    }
+
+    @Test
+    public void shouldPreserveInsertionPointWhenRemovedKeyIsReinserted() {
+        LinkedHashMap<String, Integer> map = LinkedHashMap.of("a", 1, "b", 2, "c", 3)
+                .remove("b")
+                .put("b", 4);
+        assertThat(map.keysIterator().toJavaList()).containsExactly("a", "c", "b");
+    }
+
+    @Test
+    public void shouldSupportTailAndInitAfterInteriorRemovals() {
+        LinkedHashMap<Integer, Integer> map = LinkedHashMap.empty();
+        for (int i = 0; i < 100; i++) {
+            map = map.put(i, i);
+        }
+        for (int i = 10; i < 90; i += 3) {
+            map = map.remove(i);
+        }
+        final java.util.List<Integer> keys = map.keysIterator().toJavaList();
+        assertThat(map.tail().keysIterator().toJavaList()).isEqualTo(keys.subList(1, keys.size()));
+        assertThat(map.init().keysIterator().toJavaList()).isEqualTo(keys.subList(0, keys.size() - 1));
+    }
+
+    // -- serialization must survive interior removals and preserve order
+
+    @Test
+    public void shouldSerializeAndDeserializePreservingOrderAfterRemovals() throws Exception {
+        LinkedHashMap<Integer, Integer> map = LinkedHashMap.empty();
+        for (int i = 0; i < 100; i++) {
+            map = map.put(i, i);
+        }
+        for (int i = 0; i < 100; i += 4) {
+            map = map.remove(i);
+        }
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(map);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            @SuppressWarnings("unchecked")
+            final LinkedHashMap<Integer, Integer> deserialized = (LinkedHashMap<Integer, Integer>) in.readObject();
+            assertThat(deserialized.keysIterator().toJavaList()).isEqualTo(map.keysIterator().toJavaList());
+            assertThat(deserialized).isEqualTo(map);
+        }
+    }
+}


### PR DESCRIPTION
LinkedHashMap is a pair: a `Vector<K>` holding insertion order, and a `HashMap` holding the values. Every operation except one was already fast, but `remove(key)` had to find the key's position in the `Vector`, and nothing stored that position. 

So it scanned: `list.removeFirst(k -> Objects.equals(k, key))` - O(n) per removal and O(n²) for a drain loop. On a 100k-entry map, removing all entries in reverse order took 22 seconds. See: https://github.com/vavr-io/vavr/issues/2727

To avoid this problem, we make the map remember each key's position, and on removal, mark the slot dead instead of physically removing it.

before:
```
Benchmark                                       (size)  Mode  Cnt            Score            Error  Units
LinkedHashMapBenchmark.getHits                    1000  avgt    5        12122,841 ±        720,900  ns/op
LinkedHashMapBenchmark.getHits                  100000  avgt    5      1665281,693 ±     194276,853  ns/op
LinkedHashMapBenchmark.iterate                    1000  avgt    5        22747,322 ±       1656,566  ns/op
LinkedHashMapBenchmark.iterate                  100000  avgt    5      2655442,560 ±     175813,386  ns/op
LinkedHashMapBenchmark.putFreshKeys               1000  avgt    5        71662,702 ±       8621,086  ns/op
LinkedHashMapBenchmark.putFreshKeys             100000  avgt    5     22359018,170 ±    4552127,544  ns/op
LinkedHashMapBenchmark.putOverwrite               1000  avgt    5        69575,610 ±       2644,258  ns/op
LinkedHashMapBenchmark.putOverwrite             100000  avgt    5     23205094,132 ±   12548802,726  ns/op
LinkedHashMapBenchmark.putRemoveChurn             1000  avgt    5      1499005,168 ±      92914,573  ns/op
LinkedHashMapBenchmark.putRemoveChurn           100000  avgt    5  15692546083,400 ±   77736390,875  ns/op
LinkedHashMapBenchmark.removeDrainRandomOrder     1000  avgt    5      1328422,630 ±      26150,167  ns/op
LinkedHashMapBenchmark.removeDrainRandomOrder   100000  avgt    5  16564981591,600 ±  307264948,374  ns/op
LinkedHashMapBenchmark.removeDrainReverseOrder    1000  avgt    5      1627700,616 ±      40068,127  ns/op
LinkedHashMapBenchmark.removeDrainReverseOrder  100000  avgt    5  22290225533,400 ± 1442487964,584  ns/op
LinkedHashMapBenchmark.removeSingle               1000  avgt    5         2459,630 ±        123,794  ns/op
LinkedHashMapBenchmark.removeSingle             100000  avgt    5       380551,261 ±      10499,212  ns/op
```

after:
```
Benchmark                                       (size)  Mode  Cnt         Score         Error  Units
LinkedHashMapBenchmark.getHits                    1000  avgt    5     11292,041 ±    3698,062  ns/op
LinkedHashMapBenchmark.getHits                  100000  avgt    5   1995491,392 ±   65484,133  ns/op
LinkedHashMapBenchmark.iterate                    1000  avgt    5     17491,519 ±     770,808  ns/op
LinkedHashMapBenchmark.iterate                  100000  avgt    5   2472150,205 ±   67611,291  ns/op
LinkedHashMapBenchmark.putFreshKeys               1000  avgt    5     75953,402 ±    3918,280  ns/op
LinkedHashMapBenchmark.putFreshKeys             100000  avgt    5  22735590,334 ±  907735,771  ns/op
LinkedHashMapBenchmark.putOverwrite               1000  avgt    5     75791,153 ±    1146,297  ns/op
LinkedHashMapBenchmark.putOverwrite             100000  avgt    5  22080343,673 ± 1276300,078  ns/op
LinkedHashMapBenchmark.putRemoveChurn             1000  avgt    5    110305,129 ±    7886,724  ns/op
LinkedHashMapBenchmark.putRemoveChurn           100000  avgt    5  26683762,526 ± 5180982,274  ns/op
LinkedHashMapBenchmark.removeDrainRandomOrder     1000  avgt    5    169193,644 ±    4011,004  ns/op
LinkedHashMapBenchmark.removeDrainRandomOrder   100000  avgt    5  50162851,693 ± 1184953,686  ns/op
LinkedHashMapBenchmark.removeDrainReverseOrder    1000  avgt    5     95186,873 ±    2184,413  ns/op
LinkedHashMapBenchmark.removeDrainReverseOrder  100000  avgt    5  22455997,732 ±  768012,555  ns/op
LinkedHashMapBenchmark.removeSingle               1000  avgt    5        91,780 ±       2,084  ns/op
LinkedHashMapBenchmark.removeSingle             100000  avgt    5       202,479 ±       6,312  ns/op
```