### PR TITLE
add missing jspecify annotations (backport of #3317)

### DIFF
--- a/vavr/src/main/java/io/vavr/control/Option.java
+++ b/vavr/src/main/java/io/vavr/control/Option.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A replacement for {@link java.util.Optional}.
@@ -46,7 +47,7 @@ import org.jspecify.annotations.NonNull;
  *
  * @param <T> the type of the optional value
  */
-public interface Option<T> extends Value<T>, Serializable {
+public interface Option<T extends @Nullable Object> extends Value<T>, Serializable {
 
     /**
      * The serial version UID for serialization.
@@ -56,11 +57,11 @@ public interface Option<T> extends Value<T>, Serializable {
     /**
      * Creates an {@code Option} from the given value.
      *
-     * @param value the value to wrap
-     * @param <T>   the value type
+     * @param value the value to wrap, possibly {@code null}
+     * @param <T>   the (non-null) value type
      * @return {@code Some(value)} if the value is non-null, otherwise {@code None}
      */
-    static <T> Option<@NonNull T> of(T value) {
+    static <T extends @NonNull Object> Option<T> of(@Nullable T value) {
         return (value == null) ? none() : some(value);
     }
 
@@ -187,7 +188,7 @@ public interface Option<T> extends Value<T>, Serializable {
      * @return {@code Some(optional.get())} if the {@code Optional} is present, otherwise {@code None}
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    static <T> Option<T> ofOptional(@NonNull Optional<? extends T> optional) {
+    static <T extends @NonNull Object> Option<T> ofOptional(@NonNull Optional<? extends T> optional) {
         Objects.requireNonNull(optional, "optional is null");
         return optional.<Option<T>>map(Option::of).orElseGet(Option::none);
     }


### PR DESCRIPTION
Backport of #3317 to \`vavr_1.1.0\`.

Cherry-pick of 529282d4655b4c0de8d8768423d0ac969bd8f63c, applied cleanly with no conflicts.

Refines the jspecify nullness contract on \`Option\`:
- \`Option<T>\` -> \`Option<T extends @Nullable Object>\`
- \`of()\`: \`<T> Option<@NonNull T> of(T)\` -> \`<T extends @NonNull Object> Option<T> of(@Nullable T)\`
- \`ofOptional()\`: \`<T>\` -> \`<T extends @NonNull Object>\`

Compatibility: binary compatible (erasure unchanged — the bound erases to \`Object\` either way, and the \`of()\` change moves a type-use annotation only) and source compatible for plain Java callers.

fixes: #3312