### PR TITLE
fix(concurrent): do not poison Future on await timeout/interrupt

### DIFF
--- a/vavr/src/main/java/io/vavr/concurrent/Future.java
+++ b/vavr/src/main/java/io/vavr/concurrent/Future.java
@@ -677,21 +677,23 @@ public interface Future<T> extends Value<T> {
     /**
      * Blocks the current thread until this {@code Future} is completed, or returns immediately if it is already completed.
      *
-     * <p>If the current thread is interrupted while waiting, a failed {@code Future} is returned containing
-     * the corresponding {@link InterruptedException}.</p>
+     * <p>If the current thread is interrupted while waiting, this method returns without completing this
+     * {@code Future}. The interrupt status of the current thread remains set. The underlying computation and
+     * other waiters are unaffected. Callers may use {@link #isCompleted()} to distinguish interruption from
+     * completion.</p>
      *
      * @return this {@code Future} instance
      */
     Future<T> await();
 
     /**
-     * Blocks the current thread until this {@code Future} is completed, or returns immediately if it is already completed.
+     * Blocks the current thread until this {@code Future} is completed or the given timeout elapses,
+     * or returns immediately if it is already completed.
      *
-     * <p>If the current thread is interrupted while waiting, a failed {@code Future} is returned containing
-     * the corresponding {@link InterruptedException}.</p>
-     *
-     * <p>If the specified timeout is reached before completion, a failed {@code Future} is returned containing
-     * a {@link TimeoutException}.</p>
+     * <p>Timeout and interruption are local to the waiting thread: they do not complete or fail this
+     * {@code Future}. Other waiters and the underlying computation are unaffected. After return, use
+     * {@link #isCompleted()} to distinguish timeout or interruption from actual completion
+     * ({@code !future.await(timeout, unit).isCompleted()} means the wait ended without completion).</p>
      *
      * @param timeout the maximum time to wait
      * @param unit    the time unit of the timeout argument

--- a/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
+++ b/vavr/src/main/java/io/vavr/concurrent/FutureImpl.java
@@ -23,12 +23,10 @@ import io.vavr.control.Option;
 import io.vavr.control.Try;
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
@@ -203,9 +201,8 @@ final class FutureImpl<T> implements Future<T> {
      * If timeout = 0 then {@code LockSupport.park()} is called (start, timeout and unit are not used),
      * otherwise {@code LockSupport.park(timeout, unit}} is called.
      * <p>
-     * If a timeout > -1 is specified and the deadline is not met, this Future fails with a {@link TimeoutException}.
-     * <p>
-     * If this Thread was interrupted, this Future fails with a {@link InterruptedException}.
+     * Timeout and interruption are local to the waiting thread: they stop waiting without completing
+     * this Future. The underlying computation and other waiters are unaffected.
      *
      * @param start   the start time in nanos, based on {@linkplain System#nanoTime()}
      * @param timeout a timeout in the given {@code unit} of time
@@ -226,8 +223,11 @@ final class FutureImpl<T> implements Future<T> {
                  * LockSupport.park() / parkNanos() may return when the Thread is permitted to be scheduled again.
                  * If so, the Future's tryComplete() method wasn't called yet. In that case the block() method is
                  * called again. The remaining timeout is recalculated accordingly.
+                 * <p>
+                 * On timeout or interruption of the waiting thread, returns {@code true} to stop blocking without
+                 * completing this Future (those conditions are local to the waiter).
                  *
-                 * @return true, if this Future is completed, false otherwise
+                 * @return true if blocking is no longer needed (completed, timed out, or interrupted), false otherwise
                  */
                 @Override
                 public boolean block() {
@@ -246,13 +246,15 @@ final class FutureImpl<T> implements Future<T> {
                             final long remainder = duration - delta;
                             LockSupport.parkNanos(remainder); // returns immediately if remainder <= 0
                             if (System.nanoTime() - start > duration) {
-                                tryComplete(Try.failure(new TimeoutException("timeout after " + timeout + " " + unit.name().toLowerCase())));
+                                // Timeout is local to this waiter; do not poison the shared Future.
+                                return true;
                             }
                         } else {
                             LockSupport.park();
                         }
                         if (waitingThread.isInterrupted()) {
-                            tryComplete(Try.failure(new ExecutionException(new InterruptedException())));
+                            // Interrupt is local to this waiter; do not poison the shared Future.
+                            return true;
                         }
                     } catch (Throwable x) {
                         tryComplete(Try.failure(x));

--- a/vavr/src/test/java/io/vavr/concurrent/FutureTest.java
+++ b/vavr/src/test/java/io/vavr/concurrent/FutureTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -537,9 +536,41 @@ public class FutureTest extends AbstractValueTest {
             });
             final Future<Void> returnedFuture = future.await(timeout, TimeUnit.MILLISECONDS);
             assertThat(returnedFuture).isSameAs(future);
-            assertThat(future.isFailure()).isTrue();
-            assertThat(future.getCause().get()).isInstanceOf(TimeoutException.class);
-            assertThat(future.getCause().get().getMessage()).isEqualTo("timeout after 100 milliseconds");
+            // timeout is local to the waiter; the Future stays incomplete for other consumers
+            assertThat(future.isCompleted()).isFalse();
+        }
+
+        @Test
+        public void shouldNotPoisonFutureWhenShortTimeoutExpires() {
+            final Future<Integer> future = Future.of(() -> {
+                Thread.sleep(500);
+                return 42;
+            });
+            future.await(50, TimeUnit.MILLISECONDS);
+            assertThat(future.isCompleted()).isFalse();
+            // a longer wait (or the computation finishing) can still observe success
+            future.await(2, TimeUnit.SECONDS);
+            assertThat(future.isSuccess()).isTrue();
+            assertThat(future.get()).isEqualTo(42);
+        }
+
+        @Test
+        public void shouldNotPoisonFutureWhenWaitingThreadIsInterrupted() throws InterruptedException {
+            final Future<Integer> future = Future.of(() -> {
+                Thread.sleep(500);
+                return 7;
+            });
+            final Thread waiter = new Thread(() -> future.await());
+            waiter.start();
+            // give the waiter time to park, then interrupt it
+            Thread.sleep(50);
+            waiter.interrupt();
+            waiter.join(1000);
+            assertThat(waiter.isAlive()).isFalse();
+            assertThat(future.isCompleted()).isFalse();
+            future.await(2, TimeUnit.SECONDS);
+            assertThat(future.isSuccess()).isTrue();
+            assertThat(future.get()).isEqualTo(7);
         }
 
         @Test


### PR DESCRIPTION
## Summary

`Future.await` / `await(timeout, unit)` previously called `tryComplete` when a **waiting** thread timed out or was interrupted. That permanently failed the shared `Future` for **all** consumers, discarding a successful computation result.

Timeout and interrupt mean “this waiter stops waiting,” not “the Future failed.” `_await` now exits the `ManagedBlocker` without completing the Future. Callers can use `!future.await(...).isCompleted()` to detect wait exit without completion.

This is a **semver-major** behavior change (already targeted at 2.0.0 / issue milestone). Javadoc for `await` / `await(timeout, unit)` is updated accordingly.

Fixes #3273

## Changes

- `FutureImpl._await`: on timeout or waiter interrupt, `return true` from `block()` instead of `tryComplete(TimeoutException|InterruptedException)`
- Javadoc: document local timeout/interrupt semantics
- Tests: timeout leaves Future incomplete; short timeout does not poison a later success; waiter interrupt does not poison a later success; existing computation-`InterruptedException` → cancelled behavior unchanged

## Test plan

- [x] `./mvnw -pl vavr -Dtest=io.vavr.concurrent.FutureTest test` (JDK 21)
- [x] spotless:check

## Notes

I understand and stand behind this change (AI-assisted drafting of the PR text/tests aligned with the issue’s proposed fix).