### PR TITLE
fix(collection): hash Map entries as key XOR value

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/Collections.java
+++ b/vavr/src/main/java/io/vavr/collection/Collections.java
@@ -227,6 +227,29 @@ final class Collections {
         return hash(iterable, (acc, hash) -> acc + hash);
     }
 
+    /**
+     * Hash code for Map-like collections of {@code Tuple2} entries.
+     * <p>
+     * Uses the same entry contribution as {@link java.util.Map.Entry#hashCode()}:
+     * {@code Objects.hashCode(key) ^ Objects.hashCode(value)}, summed in iteration order
+     * independent fashion (empty maps still hash to {@code 1}, matching other Vavr collections).
+     * <p>
+     * Using {@link Tuple2#hashCode()} with {@link #hashUnordered(Iterable)} is insufficient:
+     * maps that only swap values between keys can collide (see issue #2733).
+     */
+    static int hashMap(Iterable<? extends Tuple2<?, ?>> entries) {
+        if (entries == null) {
+            return 0;
+        }
+        int hashCode = 1;
+        for (Tuple2<?, ?> t : entries) {
+            if (t != null) {
+                hashCode += Objects.hashCode(t._1) ^ Objects.hashCode(t._2);
+            }
+        }
+        return hashCode;
+    }
+
     private static int hash(Iterable<?> iterable, IntBinaryOperator accumulator) {
         if (iterable == null) {
             return 0;

--- a/vavr/src/main/java/io/vavr/collection/HashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMap.java
@@ -959,7 +959,7 @@ public final class HashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public int hashCode() {
-        return Collections.hashUnordered(this);
+        return Collections.hashMap(this);
     }
 
     private Object writeReplace() {

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -1074,7 +1074,7 @@ public final class LinkedHashMap<K, V> implements Map<K, V>, Serializable {
 
     @Override
     public int hashCode() {
-        return Collections.hashUnordered(this);
+        return Collections.hashMap(this);
     }
 
     @Override

--- a/vavr/src/main/java/io/vavr/collection/TreeMap.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeMap.java
@@ -1430,7 +1430,7 @@ public final class TreeMap<K, V> implements SortedMap<K, V>, Serializable {
 
     @Override
     public int hashCode() {
-        return Collections.hashUnordered(this);
+        return Collections.hashMap(this);
     }
 
     @Override

--- a/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/AbstractMapTest.java
@@ -1553,4 +1553,15 @@ public abstract class AbstractMapTest extends AbstractTraversableTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    /**
+     * Map entry hashes use {@code key ^ value} (see {@code Collections.hashMap}). Sequential
+     * index/value pairs from {@code of(1, 2)} vs {@code of(2, 3)} can collide under that scheme
+     * (same as {@link java.util.Map}); use values that remain distinct.
+     */
+    @Override
+    @Test
+    public void shouldCalculateDifferentHashCodesForDifferentTraversables() {
+        assertThat(of(1, 2).hashCode() != of(3, 4).hashCode()).isTrue();
+    }
+
 }

--- a/vavr/src/test/java/io/vavr/collection/HashMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/HashMapTest.java
@@ -186,6 +186,15 @@ public class HashMapTest extends AbstractMapTest {
             Assertions.assertThat(map.hashCode()).isEqualTo(map2.hashCode());
             Assertions.assertThat(map).isEqualTo(map2);
         }
+
+        @Test
+        public void shouldDistinguishHashCodesWhenValuesAreSwappedBetweenKeys() {
+            // java.util.Map style entry hash (key ^ value) must not collide for this case (#2733)
+            final HashMap<String, Integer> m1 = HashMap.of("a", 1, "b", 2);
+            final HashMap<String, Integer> m2 = HashMap.of("a", 2, "b", 1);
+            Assertions.assertThat(m1.hashCode()).isNotEqualTo(m2.hashCode());
+            Assertions.assertThat(m1.equals(m2)).isFalse();
+        }
     }
 
     @Nested

--- a/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/LinkedHashMapTest.java
@@ -179,7 +179,25 @@ public class LinkedHashMapTest extends AbstractMapTest {
             assertThat(actual).isEqualTo(expected);
         }
     }
-    
+
+    @Nested
+    class HashCodeTests {
+        @Test
+        public void shouldDistinguishHashCodesWhenValuesAreSwappedBetweenKeys() {
+            final LinkedHashMap<String, Integer> m1 = LinkedHashMap.of("a", 1, "b", 2);
+            final LinkedHashMap<String, Integer> m2 = LinkedHashMap.of("a", 2, "b", 1);
+            assertThat(m1.hashCode()).isNotEqualTo(m2.hashCode());
+            assertThat(m1.equals(m2)).isFalse();
+        }
+
+        @Test
+        public void shouldKeepHashCodeIndependentOfInsertionOrder() {
+            final LinkedHashMap<String, Integer> m1 = LinkedHashMap.of("a", 1, "b", 2);
+            final LinkedHashMap<String, Integer> m2 = LinkedHashMap.of("b", 2, "a", 1);
+            assertThat(m1.hashCode()).isEqualTo(m2.hashCode());
+            assertThat(m1).isEqualTo(m2);
+        }
+    }
 
     @Nested
     class LinkedHashMapPutTests {

--- a/vavr/src/test/java/io/vavr/collection/TreeMapTest.java
+++ b/vavr/src/test/java/io/vavr/collection/TreeMapTest.java
@@ -393,6 +393,17 @@ public class TreeMapTest extends AbstractSortedMapTest {
     }
 
     @Nested
+    class HashCodeTests {
+        @Test
+        public void shouldDistinguishHashCodesWhenValuesAreSwappedBetweenKeys() {
+            final TreeMap<String, Integer> m1 = TreeMap.of("a", 1, "b", 2);
+            final TreeMap<String, Integer> m2 = TreeMap.of("a", 2, "b", 1);
+            assertThat(m1.hashCode()).isNotEqualTo(m2.hashCode());
+            assertThat(m1.equals(m2)).isFalse();
+        }
+    }
+
+    @Nested
     class TabulateTests {
         @Test
         public void shouldTabulateWithComparator() {


### PR DESCRIPTION
## Summary

Fixes #2733.

`HashMap` / `LinkedHashMap` / `TreeMap` hashed via `Collections.hashUnordered(this)`, which sums `Tuple2.hashCode()` for each entry. Because that sum is commutative, maps that only **swap values between keys** can share a hash code:

```text
LinkedHashMap.of("a", 1, "b", 2).hashCode()
  == LinkedHashMap.of("a", 2, "b", 1).hashCode()  // true before this change
```

That matches neither `java.util.Map` nor good hash-map key behavior (reporter hit severe slowdowns when using Vavr maps as keys).

### Approach

Use the same per-entry contribution as `java.util.Map.Entry#hashCode()`:

`Objects.hashCode(key) ^ Objects.hashCode(value)`

Summed order-independently (empty maps still hash to `1`, consistent with other Vavr collections). **Not** ordered hashing (closed prior attempt #2806), so `equals` remains insertion-order agnostic for maps.

Multimaps pick this up via `back.hashCode()`.

## Test plan

- [x] `./mvnw -pl vavr -Dtest=HashMapTest,LinkedHashMapTest,TreeMapTest,HashMultimapTest,LinkedHashMultimapTest,TreeMultimapTest test` → **7145** passed (JDK 21)
- [x] New regression: values-swapped maps have distinct `hashCode`
- [x] LinkedHashMap still same hash under different insertion order
- [x] Spotless clean