### PR TITLE
Remove redundant this qualifiers

### DIFF
--- a/vavr/src/main/java/io/vavr/collection/AbstractMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/AbstractMultimap.java
@@ -450,7 +450,7 @@ abstract class AbstractMultimap<K extends @Nullable Object, V extends @Nullable 
         } else if (that.isEmpty()) {
             return (M) this;
         } else {
-            final Map<K, Traversable<V>> result = that.keySet().foldLeft(this.back, (map, key) -> {
+            final Map<K, Traversable<V>> result = that.keySet().foldLeft(back, (map, key) -> {
                 final Traversable<V2> thatValues = that.get(key).get();
                 final Traversable<V> newValues = map.get(key)
                         .map(thisValues -> collisionResolution.apply(thisValues, thatValues))

--- a/vavr/src/main/java/io/vavr/collection/BitSet.java
+++ b/vavr/src/main/java/io/vavr/collection/BitSet.java
@@ -1233,8 +1233,8 @@ interface BitSetModule {
 
         BitSetIterator(AbstractBitSet<T> bitSet) {
             this.bitSet = bitSet;
-            this.element = bitSet.getWord(0);
-            this.index = 0;
+            element = bitSet.getWord(0);
+            index = 0;
         }
 
         @Override
@@ -1267,7 +1267,7 @@ interface BitSetModule {
         BitSet1(Function1<Integer, T> fromInt, Function1<T, Integer> toInt, long elements) {
             super(fromInt, toInt);
             this.elements = elements;
-            this.len = Long.bitCount(elements);
+            len = Long.bitCount(elements);
         }
 
         @Override
@@ -1334,7 +1334,7 @@ interface BitSetModule {
             super(fromInt, toInt);
             this.elements1 = elements1;
             this.elements2 = elements2;
-            this.len = Long.bitCount(elements1) + Long.bitCount(elements2);
+            len = Long.bitCount(elements1) + Long.bitCount(elements2);
         }
 
         @Override
@@ -1411,7 +1411,7 @@ interface BitSetModule {
         BitSetN(Function1<Integer, T> fromInt, Function1<T, Integer> toInt, long[] elements) {
             super(fromInt, toInt);
             this.elements = elements;
-            this.len = calcLength(elements);
+            len = calcLength(elements);
         }
 
         private static int calcLength(long[] elements) {

--- a/vavr/src/main/java/io/vavr/collection/CharSeq.java
+++ b/vavr/src/main/java/io/vavr/collection/CharSeq.java
@@ -53,7 +53,7 @@ public final class CharSeq implements CharSequence, IndexedSeq<Character>, Seria
     private final String back;
 
     private CharSeq(String javaString) {
-        this.back = javaString;
+        back = javaString;
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/HashArrayMappedTrie.java
+++ b/vavr/src/main/java/io/vavr/collection/HashArrayMappedTrie.java
@@ -481,7 +481,7 @@ interface HashArrayMappedTrieModule {
             this.hash = hash;
             this.key = key;
             this.value = value;
-            this.size = 1 + tail.size();
+            size = 1 + tail.size();
             this.tail = tail;
         }
 
@@ -555,7 +555,7 @@ interface HashArrayMappedTrieModule {
         }
 
         private AbstractNode<K, V> removeElement(K k) {
-            if (Objects.equals(k, this.key)) {
+            if (Objects.equals(k, key)) {
                 return tail;
             }
             LeafNode<K, V> leaf1 = new LeafSingleton<>(hash, key, value);

--- a/vavr/src/main/java/io/vavr/collection/HashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMap.java
@@ -965,7 +965,7 @@ public final class HashMap<K extends @Nullable Object, V extends @Nullable Objec
     }
 
     private Object writeReplace() {
-        return new SerializationProxy<>(this.trie);
+        return new SerializationProxy<>(trie);
     }
 
     private void readObject(ObjectInputStream stream) throws InvalidObjectException {

--- a/vavr/src/main/java/io/vavr/collection/HashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/HashSet.java
@@ -1159,7 +1159,7 @@ public final class HashSet<T extends @Nullable Object> implements Set<T>, Serial
      */
     @Serial
     private Object writeReplace() {
-        return new SerializationProxy<>(this.tree);
+        return new SerializationProxy<>(tree);
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/Iterator.java
+++ b/vavr/src/main/java/io/vavr/collection/Iterator.java
@@ -2446,7 +2446,7 @@ interface IteratorModule {
 
         DistinctIterator(Iterator<? extends T> that, Set<U> set, Function<? super T, ? extends U> keyExtractor) {
             this.that = that;
-            this.known = set;
+            known = set;
             this.keyExtractor = keyExtractor;
         }
 
@@ -2518,9 +2518,9 @@ interface IteratorModule {
             this.that = that;
             this.size = size;
             this.step = step;
-            this.gap = Math.max(step - size, 0);
-            this.preserve = Math.max(size - step, 0);
-            this.buffer = take(that, new Object[size], 0, size);
+            gap = Math.max(step - size, 0);
+            preserve = Math.max(size - step, 0);
+            buffer = take(that, new Object[size], 0, size);
         }
 
         @Override

--- a/vavr/src/main/java/io/vavr/collection/JavaConverters.java
+++ b/vavr/src/main/java/io/vavr/collection/JavaConverters.java
@@ -91,7 +91,7 @@ class JavaConverters {
 
         protected void setDelegate(Supplier<C> newDelegate) {
             ensureMutable();
-            this.delegate = newDelegate.get();
+            delegate = newDelegate.get();
         }
 
         protected void ensureMutable() {
@@ -397,7 +397,7 @@ class JavaConverters {
                 if (index < 0 || index > list.size()) {
                     throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + list.size());
                 }
-                this.nextIndex = index;
+                nextIndex = index;
             }
 
             @Override

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashSet.java
@@ -1174,7 +1174,7 @@ public final class LinkedHashSet<T extends @Nullable Object> implements Set<T>, 
      */
     @Serial
     private Object writeReplace() {
-        return new SerializationProxy<>(this.map);
+        return new SerializationProxy<>(map);
     }
 
     /**

--- a/vavr/src/main/java/io/vavr/collection/List.java
+++ b/vavr/src/main/java/io/vavr/collection/List.java
@@ -1960,7 +1960,7 @@ public interface List<T extends @Nullable Object> extends LinearSeq<T> {
         private Cons(T head, List<T> tail) {
             this.head = head;
             this.tail = tail;
-            this.length = 1 + tail.length();
+            length = 1 + tail.length();
         }
 
         @Override

--- a/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
+++ b/vavr/src/main/java/io/vavr/collection/PriorityQueue.java
@@ -117,8 +117,8 @@ public final class PriorityQueue<T extends @Nullable Object> extends io.vavr.col
         if (isEmpty()) {
             throw new NoSuchElementException("dequeue of empty " + stringPrefix());
         } else {
-            final Tuple2<T, Seq<Node<T>>> dequeue = deleteMin(comparator, this.forest);
-            return Tuple.of(dequeue._1, with(dequeue._2, this.size - 1));
+            final Tuple2<T, Seq<Node<T>>> dequeue = deleteMin(comparator, forest);
+            return Tuple.of(dequeue._1, with(dequeue._2, size - 1));
         }
     }
 
@@ -130,8 +130,8 @@ public final class PriorityQueue<T extends @Nullable Object> extends io.vavr.col
      * @return A new PriorityQueue containing elements from both queues in priority order.
      */
     public PriorityQueue<T> merge(PriorityQueue<T> target) {
-        final Seq<Node<T>> meld = meld(comparator, this.forest, target.forest);
-        return with(meld, this.size + target.size);
+        final Seq<Node<T>> meld = meld(comparator, forest, target.forest);
+        return with(meld, size + target.size);
     }
 
     /**
@@ -939,8 +939,8 @@ final class PriorityQueueBase {
          * *  else                     Node (x2,r2+1,t1 :: c2
          */
         Node<T> link(Comparator<? super T> comparator, Node<T> tree) {
-            return comparator.compare(this.root, tree.root) <= 0
-                   ? of(this.root, this.rank + 1, tree.appendTo(this.children))
+            return comparator.compare(root, tree.root) <= 0
+                   ? of(root, rank + 1, tree.appendTo(children))
                    : of(tree.root, tree.rank + 1, this.appendTo(tree.children));
         }
 

--- a/vavr/src/main/java/io/vavr/collection/RedBlackTree.java
+++ b/vavr/src/main/java/io/vavr/collection/RedBlackTree.java
@@ -367,7 +367,7 @@ interface RedBlackTreeModule {
             this.value = value;
             this.right = right;
             this.empty = empty;
-            this.size = left.size() + right.size() + 1;
+            size = left.size() + right.size() + 1;
         }
 
         @Override

--- a/vavr/src/main/java/io/vavr/collection/Stream.java
+++ b/vavr/src/main/java/io/vavr/collection/Stream.java
@@ -2290,7 +2290,7 @@ interface StreamModule {
         private Supplier<Stream<T>> current;
 
         StreamIterator(Cons<T> stream) {
-            this.current = () -> stream;
+            current = () -> stream;
         }
 
         @Override

--- a/vavr/src/main/java/io/vavr/collection/Tree.java
+++ b/vavr/src/main/java/io/vavr/collection/Tree.java
@@ -905,7 +905,7 @@ public interface Tree<T extends @Nullable Object> extends Traversable<T>, Serial
             Objects.requireNonNull(children, "children is null");
             this.value = value;
             this.children = children;
-            this.size = children.foldLeft(1, (acc, child) -> acc + child.size);
+            size = children.foldLeft(1, (acc, child) -> acc + child.size);
         }
 
         @Override


### PR DESCRIPTION
This PR removes redundant `this` qualifiers identified by a new Checkstyle validation, [`RedundantThisCheck`](https://github.com/checkstyle/checkstyle/pull/20944).

The changes are limited to cases where removing `this` does not change name resolution or program behavior.

This validation is currently being evaluated against real-world projects, so feedback on whether these changes are considered desirable in this project would be particularly useful.

No functional behavior is intended to change.
