### PR TITLE
Fix NullAway 0.14 override-bound errors

### DIFF
--- a/vavr/generator/Generator.scala
+++ b/vavr/generator/Generator.scala
@@ -1800,6 +1800,7 @@ def generateMainClasses(): Unit = {
         val genericsTryReturnType = s"<${genericsFunction}${im.getType("io.vavr.control.Try")}<R>>"
         val curried = if (i == 0) "v" else (1 to i).gen(j => s"t$j")(using " -> ")
         val compositionType = if(checked) "CheckedFunction1" else im.getType("java.util.function.Function")
+        val compositionTypeVariableBound = if (!checked && i == 1) "" else s" $nullableBound"
 
         // imports
 
@@ -2202,7 +2203,7 @@ def generateMainClasses(): Unit = {
                * @return a function composed of this and after
                * @throws NullPointerException if after is null
                */
-              default <V $nullableBound> $className<${genericsFunction}V> andThen($compositionType<? super R, ? extends V> after) {
+              default <V$compositionTypeVariableBound> $className<${genericsFunction}V> andThen($compositionType<? super R, ? extends V> after) {
                   $Objects.requireNonNull(after, "after is null");
                   return ($params) -> after.apply(apply($params));
               }
@@ -2217,7 +2218,7 @@ def generateMainClasses(): Unit = {
                  * @return a function composed of before and this
                  * @throws NullPointerException if before is null
                  */
-                default <V $nullableBound> ${name}1<V, R> compose($compositionType<? super V, ? extends T1> before) {
+                default <V$compositionTypeVariableBound> ${name}1<V, R> compose($compositionType<? super V, ? extends T1> before) {
                     $Objects.requireNonNull(before, "before is null");
                     return v -> apply(before.apply(v));
                 }

--- a/vavr/src-gen/main/java/io/vavr/Function1.java
+++ b/vavr/src-gen/main/java/io/vavr/Function1.java
@@ -262,7 +262,7 @@ public interface Function1<T1 extends @Nullable Object, R extends @Nullable Obje
      * @return a function composed of this and after
      * @throws NullPointerException if after is null
      */
-    default <V extends @Nullable Object> Function1<T1, V> andThen(Function<? super R, ? extends V> after) {
+    default <V> Function1<T1, V> andThen(Function<? super R, ? extends V> after) {
         Objects.requireNonNull(after, "after is null");
         return (t1) -> after.apply(apply(t1));
     }
@@ -276,7 +276,7 @@ public interface Function1<T1 extends @Nullable Object, R extends @Nullable Obje
      * @return a function composed of before and this
      * @throws NullPointerException if before is null
      */
-    default <V extends @Nullable Object> Function1<V, R> compose(Function<? super V, ? extends T1> before) {
+    default <V> Function1<V, R> compose(Function<? super V, ? extends T1> before) {
         Objects.requireNonNull(before, "before is null");
         return v -> apply(before.apply(v));
     }

--- a/vavr/src/main/java/io/vavr/collection/AbstractMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/AbstractMultimap.java
@@ -442,7 +442,7 @@ abstract class AbstractMultimap<K extends @Nullable Object, V extends @Nullable 
 
     @SuppressWarnings("unchecked")
     @Override
-    public <K2 extends K, V2 extends V> M merge(Multimap<K2, V2> that, BiFunction<Traversable<V>, Traversable<V2>, Traversable<V>> collisionResolution) {
+    public <K2 extends @Nullable K, V2 extends @Nullable V> M merge(Multimap<K2, V2> that, BiFunction<Traversable<V>, Traversable<V2>, Traversable<V>> collisionResolution) {
         Objects.requireNonNull(that, "that is null");
         Objects.requireNonNull(collisionResolution, "collisionResolution is null");
         if (isEmpty()) {

--- a/vavr/src/main/java/io/vavr/collection/HashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/HashMap.java
@@ -746,7 +746,7 @@ public final class HashMap<K extends @Nullable Object, V extends @Nullable Objec
     }
 
     @Override
-    public <U extends V> HashMap<K, V> merge(Map<? extends K, U> that,
+    public <U extends @Nullable V> HashMap<K, V> merge(Map<? extends K, U> that,
                                              BiFunction<? super V, ? super U, ? extends V> collisionResolution) {
         return Maps.merge(this, this::createFromEntries, that, collisionResolution);
     }
@@ -772,7 +772,7 @@ public final class HashMap<K extends @Nullable Object, V extends @Nullable Objec
     }
 
     @Override
-    public <U extends V> HashMap<K, V> put(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge) {
+    public <U extends @Nullable V> HashMap<K, V> put(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge) {
         return Maps.put(this, key, value, merge);
     }
 
@@ -787,7 +787,7 @@ public final class HashMap<K extends @Nullable Object, V extends @Nullable Objec
     }
 
     @Override
-    public <U extends V> HashMap<K, V> put(Tuple2<? extends K, U> entry,
+    public <U extends @Nullable V> HashMap<K, V> put(Tuple2<? extends K, U> entry,
                                            BiFunction<? super V, ? super U, ? extends V> merge) {
         return Maps.put(this, entry, merge);
     }

--- a/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
+++ b/vavr/src/main/java/io/vavr/collection/LinkedHashMap.java
@@ -829,7 +829,7 @@ public final class LinkedHashMap<K extends @Nullable Object, V extends @Nullable
     }
 
     @Override
-    public <U extends V> LinkedHashMap<K, V> merge(Map<? extends K, U> that,
+    public <U extends @Nullable V> LinkedHashMap<K, V> merge(Map<? extends K, U> that,
                                                    BiFunction<? super V, ? super U, ? extends V> collisionResolution) {
         return Maps.merge(this, this::createFromEntries, that, collisionResolution);
     }
@@ -855,7 +855,7 @@ public final class LinkedHashMap<K extends @Nullable Object, V extends @Nullable
     }
 
     @Override
-    public <U extends V> LinkedHashMap<K, V> put(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge) {
+    public <U extends @Nullable V> LinkedHashMap<K, V> put(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge) {
         return Maps.put(this, key, value, merge);
     }
 
@@ -889,7 +889,7 @@ public final class LinkedHashMap<K extends @Nullable Object, V extends @Nullable
     }
 
     @Override
-    public <U extends V> LinkedHashMap<K, V> put(Tuple2<? extends K, U> entry,
+    public <U extends @Nullable V> LinkedHashMap<K, V> put(Tuple2<? extends K, U> entry,
                                                  BiFunction<? super V, ? super U, ? extends V> merge) {
         return Maps.put(this, entry, merge);
     }

--- a/vavr/src/main/java/io/vavr/collection/SortedMap.java
+++ b/vavr/src/main/java/io/vavr/collection/SortedMap.java
@@ -208,7 +208,7 @@ public interface SortedMap<K extends @Nullable Object, V extends @Nullable Objec
     SortedMap<K, V> merge(Map<? extends K, ? extends V> that);
 
     @Override
-    <U extends V> SortedMap<K, V> merge(Map<? extends K, U> that, BiFunction<? super V, ? super U, ? extends V> collisionResolution);
+    <U extends @Nullable V> SortedMap<K, V> merge(Map<? extends K, U> that, BiFunction<? super V, ? super U, ? extends V> collisionResolution);
 
     @Override
     SortedMap<K, V> orElse(Iterable<? extends Tuple2<K, V>> other);
@@ -229,10 +229,10 @@ public interface SortedMap<K extends @Nullable Object, V extends @Nullable Objec
     SortedMap<K, V> put(Tuple2<? extends K, ? extends V> entry);
 
     @Override
-    <U extends V> SortedMap<K, V> put(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge);
+    <U extends @Nullable V> SortedMap<K, V> put(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge);
 
     @Override
-    <U extends V> SortedMap<K, V> put(Tuple2<? extends K, U> entry, BiFunction<? super V, ? super U, ? extends V> merge);
+    <U extends @Nullable V> SortedMap<K, V> put(Tuple2<? extends K, U> entry, BiFunction<? super V, ? super U, ? extends V> merge);
 
     @Override
     SortedMap<K, V> remove(K key);

--- a/vavr/src/main/java/io/vavr/collection/SortedMultimap.java
+++ b/vavr/src/main/java/io/vavr/collection/SortedMultimap.java
@@ -79,7 +79,7 @@ public interface SortedMultimap<K extends @Nullable Object, V extends @Nullable 
     SortedMultimap<K, V> merge(Multimap<? extends K, ? extends V> that);
 
     @Override
-    <K2 extends K, V2 extends V> SortedMultimap<K, V> merge(Multimap<K2, V2> that, BiFunction<Traversable<V>, Traversable<V2>, Traversable<V>> collisionResolution);
+    <K2 extends @Nullable K, V2 extends @Nullable V> SortedMultimap<K, V> merge(Multimap<K2, V2> that, BiFunction<Traversable<V>, Traversable<V2>, Traversable<V>> collisionResolution);
 
     @Override
     SortedMultimap<K, V> put(K key, V value);

--- a/vavr/src/main/java/io/vavr/collection/TreeMap.java
+++ b/vavr/src/main/java/io/vavr/collection/TreeMap.java
@@ -1212,7 +1212,7 @@ public final class TreeMap<K extends @Nullable Object, V extends @Nullable Objec
     }
 
     @Override
-    public <U extends V> TreeMap<K, V> merge(Map<? extends K, U> that,
+    public <U extends @Nullable V> TreeMap<K, V> merge(Map<? extends K, U> that,
                                              BiFunction<? super V, ? super U, ? extends V> collisionResolution) {
         return Maps.merge(this, this::createFromEntries, that, collisionResolution);
     }
@@ -1254,7 +1254,7 @@ public final class TreeMap<K extends @Nullable Object, V extends @Nullable Objec
     }
 
     @Override
-    public <U extends V> TreeMap<K, V> put(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge) {
+    public <U extends @Nullable V> TreeMap<K, V> put(K key, U value, BiFunction<? super V, ? super U, ? extends V> merge) {
         return Maps.put(this, key, value, merge);
     }
 
@@ -1269,7 +1269,7 @@ public final class TreeMap<K extends @Nullable Object, V extends @Nullable Objec
     }
 
     @Override
-    public <U extends V> TreeMap<K, V> put(Tuple2<? extends K, U> entry,
+    public <U extends @Nullable V> TreeMap<K, V> put(Tuple2<? extends K, U> entry,
                                            BiFunction<? super V, ? super U, ? extends V> merge) {
         return Maps.put(this, entry, merge);
     }


### PR DESCRIPTION
## Summary

Companion fix for #3338, targeting its exact Dependabot branch.

NullAway 0.14 checks generic upper bounds on overridden methods more strictly. This change:

- makes regular `Function1.andThen` and `Function1.compose` retain the non-null implicit bound required by `java.util.function.Function`, while preserving nullable bounds for checked and higher-arity Vavr functions;
- repeats the nullable parent bounds on the affected map and multimap overrides; and
- updates the function generator as well as its tracked generated output.

There is no runtime behavior change. The annotations make the existing override contracts explicit.

## Verification

- `JAVA_HOME=<JDK 21> ./mvnw -B -Pnullaway compile` — passed, including Spotless.
- `JAVA_HOME=<JDK 21> ./mvnw -B clean test` — passed: 23,325 tests, 0 failures, 0 errors, 43 skipped.
- `JAVA_HOME=<JDK 21> ./mvnw -B -pl vavr generate-sources` — passed; `Function1.java` was byte-for-byte stable on regeneration.
- `git diff --check` and complete diff review — passed.
- JAIPilot Remote (JDK 21): `./mvnw -B -Pnullaway compile` — passed in 44.7s, including Spotless.

The documented `javadoc:javadoc` goal currently fails, with and without `-pl vavr`, because Maven Javadoc refuses to aggregate the repository's named and unnamed modules. The remote medium-profile full test attempt also exceeded its 4 GiB heap and tripped one wall-clock performance assertion; the complete suite passed locally as recorded above.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, `jaipilot-review-diff`, and `jaipilot-remote-java`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
